### PR TITLE
Fix type identification for TFORM like '1D'

### DIFF
--- a/Table/src/lib/FitsReaderHelper.cpp
+++ b/Table/src/lib/FitsReaderHelper.cpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+ /**
  * @file src/lib/FitsReaderHelper.cpp
  * @date April 17, 2014
  * @author Nikolaos Apostolakos
@@ -62,49 +62,70 @@ std::type_index asciiFormatToType(const std::string& format) {
 }
 
 std::type_index binaryFormatToType(const std::string& format, const std::vector<size_t>& shape) {
-  if (format[0] == 'L') {
-    return typeid(bool);
-  } else if (format[0] == 'B') {
-    return typeid(int32_t);
-  } else if (format[0] == 'I') {
-    return typeid(int32_t);
-  } else if (format[0] == 'J') {
-    return typeid(int32_t);
-  } else if (format[0] == 'K') {
-    return typeid(int64_t);
-  } else if (format.back() == 'A') {
-    return typeid(std::string);
-  } else if (format[0] == 'E') {
-    return typeid(float);
-  } else if (format[0] == 'D') {
-    return typeid(double);
-  } else if (shape.empty()) {
-    if (format.back() == 'B') {
-      return typeid(std::vector<int32_t>);
-    } else if (format.back() == 'I') {
-      return typeid(std::vector<int32_t>);
-    } else if (format.back() == 'J') {
-      return typeid(std::vector<int32_t>);
-    } else if (format.back() == 'K') {
-      return typeid(std::vector<int64_t>);
-    } else if (format.back() == 'E') {
-      return typeid(std::vector<float>);
-    } else if (format.back() == 'D') {
-      return typeid(std::vector<double>);
-    }
-  } else {
-    if (format.back() == 'B') {
+  // Get the size out of the format string
+  char ft = format.front();
+  int size = 1;
+  if (std::isdigit(format.front())) {
+    size = std::stoi(format.substr(0, format.size() - 1));
+    ft = format.back();
+  }
+
+  // If shape is set, it is an NdArray
+  if (!shape.empty()) {
+    if (ft == 'B') {
       return typeid(NdArray<int32_t>);
-    } else if (format.back() == 'I') {
+    } else if (ft == 'I') {
       return typeid(NdArray<int32_t>);
-    } else if (format.back() == 'J') {
+    } else if (ft == 'J') {
       return typeid(NdArray<int32_t>);
-    } else if (format.back() == 'K') {
+    } else if (ft == 'K') {
       return typeid(NdArray<int64_t>);
-    } else if (format.back() == 'E') {
+    } else if (ft == 'E') {
       return typeid(NdArray<float>);
-    } else if (format.back() == 'D') {
+    } else if (ft == 'D') {
       return typeid(NdArray<double>);
+    }
+  }
+  // If the dimensionality is 1, it is a scalar
+  else if (size == 1) {
+    if (ft == 'L') {
+      return typeid(bool);
+    }
+    else if (ft == 'B') {
+      return typeid(int32_t);
+    }
+    else if (ft == 'I') {
+      return typeid(int32_t);
+    }
+    else if (ft == 'J') {
+      return typeid(int32_t);
+    }
+    else if (ft == 'K') {
+      return typeid(int64_t);
+    }
+    else if (ft == 'E') {
+      return typeid(float);
+    }
+    else if (ft == 'D') {
+      return typeid(double);
+    }
+  }
+  // Last, vectors
+  else {
+    if (ft == 'B') {
+      return typeid(std::vector<int32_t>);
+    } else if (ft == 'I') {
+      return typeid(std::vector<int32_t>);
+    } else if (ft == 'J') {
+      return typeid(std::vector<int32_t>);
+    } else if (ft == 'K') {
+      return typeid(std::vector<int64_t>);
+    } else if (ft == 'E') {
+      return typeid(std::vector<float>);
+    } else if (ft == 'D') {
+      return typeid(std::vector<double>);
+    } else if (ft == 'A') {
+      return typeid(std::string);
     }
   }
   throw Elements::Exception() << "FITS binary table format " << format << " is not "

--- a/Table/tests/src/FitsReaderHelper_test.cpp
+++ b/Table/tests/src/FitsReaderHelper_test.cpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+ /**
  * @file tests/src/FitsReaderHelper_test.cpp
  * @date April 17, 2014
  * @author Nikolaos Apostolakos
@@ -36,46 +36,46 @@ struct FitsReaderHelper_Fixture {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (AsciiReaderHelper_test)
+BOOST_AUTO_TEST_SUITE (FitsReaderHelper_test)
 
 //-----------------------------------------------------------------------------
 // Test the autoDetectColumnNames method
 //-----------------------------------------------------------------------------
- 
+
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnNames, FitsReaderHelper_Fixture) {
-  
+
   // Given
   std::vector<std::string> names {"First","Second","","Fourth"};
   std::vector<std::string> types {"J","J","J","J"};
   CCfits::Table* table_hdu = fits->addTable("CheckNames", 0, names, types);
-  
+
   // When
   std::vector<std::string> result = Euclid::Table::autoDetectColumnNames(*table_hdu);
-  
+
   // Then
   BOOST_CHECK_EQUAL(result.size(), 4);
   BOOST_CHECK_EQUAL(result[0], "First");
   BOOST_CHECK_EQUAL(result[1], "Second");
   BOOST_CHECK_EQUAL(result[2], "Col3");
   BOOST_CHECK_EQUAL(result[3], "Fourth");
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the autoDetectColumnTypes method for ASCII table
 //-----------------------------------------------------------------------------
- 
+
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnTypesAscii, FitsReaderHelper_Fixture) {
-  
+
   // Given
   std::vector<std::string> names {"String","Integer","Float1","Float2","Float3"};
   std::vector<std::string> types {"A10","I6","F4.3","E6.5","D8.7"};
   std::vector<std::string> units {"","","","",""};
   CCfits::Table* table_hdu = fits->addTable("ASCII", 0, names, types, units, CCfits::HduType::AsciiTbl);
-  
+
   // When
   std::vector<std::type_index> result = Euclid::Table::autoDetectColumnTypes(*table_hdu);
-  
+
   // Then
   BOOST_CHECK_EQUAL(result.size(), 5);
   BOOST_CHECK(result[0] == typeid(std::string));
@@ -83,26 +83,26 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnTypesAscii, FitsReaderHelper_Fixture) {
   BOOST_CHECK(result[2] == typeid(double));
   BOOST_CHECK(result[3] == typeid(double));
   BOOST_CHECK(result[4] == typeid(double));
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the autoDetectColumnTypes method for binary table
 //-----------------------------------------------------------------------------
- 
+
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnTypesBinary, FitsReaderHelper_Fixture) {
-  
+
   // Given
   std::vector<std::string> names {"Bool","Byte","Short","Int","Long","String","Float","Double",
-          "ByteVector","ShortVector","IntVector","LongVector","FloatVector","DoubleVector"};
-  std::vector<std::string> types {"L","B","I","J","K","10A","E","D","2B","3I","4J","5K","6E","7D"};
+          "ByteVector","ShortVector","IntVector","LongVector","FloatVector","DoubleVector", "Scalar"};
+  std::vector<std::string> types {"L","B","I","J","K","10A","E","D","2B","3I","4J","5K","6E","7D", "1D"};
   CCfits::Table* table_hdu = fits->addTable("Binary", 0, names, types);
-  
+
   // When
   std::vector<std::type_index> result = Euclid::Table::autoDetectColumnTypes(*table_hdu);
-  
+
   // Then
-  BOOST_CHECK_EQUAL(result.size(), 14);
+  BOOST_CHECK_EQUAL(result.size(), 15);
   BOOST_CHECK(result[0] == typeid(bool));
   BOOST_CHECK(result[1] == typeid(int32_t));
   BOOST_CHECK(result[2] == typeid(int32_t));
@@ -117,94 +117,95 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnTypesBinary, FitsReaderHelper_Fixture) {
   BOOST_CHECK(result[11] == typeid(std::vector<int64_t>));
   BOOST_CHECK(result[12] == typeid(std::vector<float>));
   BOOST_CHECK(result[13] == typeid(std::vector<double>));
-  
+  BOOST_CHECK(result[14] == typeid(double));
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the autoDetectColumnTypes method for binary table throws for unsupported types
 //-----------------------------------------------------------------------------
- 
+
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnTypesBinaryUnsupportedTypes, FitsReaderHelper_Fixture) {
-  
+
   // Given
   std::vector<std::string> names {"Bit"};
   std::vector<std::string> types {"X"};
   CCfits::Table* table_hdu = fits->addTable("Bit", 0, names, types);
-  
+
   // Then
   BOOST_CHECK_THROW(Euclid::Table::autoDetectColumnTypes(*table_hdu), Elements::Exception);
-  
+
   // Given
   names = {"FloatComplex"};
   types = {"C"};
   table_hdu = fits->addTable("FloatComplex", 0, names, types);
-  
+
   // Then
   BOOST_CHECK_THROW(Euclid::Table::autoDetectColumnTypes(*table_hdu), Elements::Exception);
-  
+
   // Given
   names = {"DoubleComplex"};
   types = {"M"};
   table_hdu = fits->addTable("DoubleComplex", 0, names, types);
-  
+
   // Then
   BOOST_CHECK_THROW(Euclid::Table::autoDetectColumnTypes(*table_hdu), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the autoDetectColumnUnits method
 //-----------------------------------------------------------------------------
- 
+
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnUnits, FitsReaderHelper_Fixture) {
-  
+
   // Given
   std::vector<std::string> names {"First","Second","","Fourth"};
   std::vector<std::string> types {"J","J","J","J"};
   std::vector<std::string> units {"m","mag","pc",""};
   CCfits::Table* table_hdu = fits->addTable("CheckNames", 0, names, types, units);
-  
+
   // When
   std::vector<std::string> result = Euclid::Table::autoDetectColumnUnits(*table_hdu);
-  
+
   // Then
   BOOST_CHECK_EQUAL(result.size(), 4);
   BOOST_CHECK_EQUAL(result[0], "m");
   BOOST_CHECK_EQUAL(result[1], "mag");
   BOOST_CHECK_EQUAL(result[2], "pc");
   BOOST_CHECK_EQUAL(result[3], "");
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the autoDetectColumnUnits method when TUNITn keywords are missing
 //-----------------------------------------------------------------------------
- 
+
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnUnitsMissingKeywords, FitsReaderHelper_Fixture) {
-  
+
   // Given
   std::vector<std::string> names {"First","Second","","Fourth"};
   std::vector<std::string> types {"J","J","J","J"};
   CCfits::Table* table_hdu = fits->addTable("CheckNames", 0, names, types);
-  
+
   // When
   std::vector<std::string> result = Euclid::Table::autoDetectColumnUnits(*table_hdu);
-  
+
   // Then
   BOOST_CHECK_EQUAL(result.size(), 4);
   BOOST_CHECK_EQUAL(result[0], "");
   BOOST_CHECK_EQUAL(result[1], "");
   BOOST_CHECK_EQUAL(result[2], "");
   BOOST_CHECK_EQUAL(result[3], "");
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the autoDetectColumnDescriptions method
 //-----------------------------------------------------------------------------
- 
+
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnDescriptions, FitsReaderHelper_Fixture) {
-  
+
   // Given
   std::vector<std::string> names {"First","Second","","Fourth"};
   std::vector<std::string> types {"J","J","J","J"};
@@ -213,25 +214,25 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnDescriptions, FitsReaderHelper_Fixture) 
   table_hdu->addKey("TDESC1", "Desc1", "");
   table_hdu->addKey("TDESC2", "", "");
   table_hdu->addKey("TDESC4", "Desc4", "");
-  
+
   // When
   std::vector<std::string> result = Euclid::Table::autoDetectColumnDescriptions(*table_hdu);
-  
+
   // Then
   BOOST_CHECK_EQUAL(result.size(), 4);
   BOOST_CHECK_EQUAL(result[0], "Desc1");
   BOOST_CHECK_EQUAL(result[1], "");
   BOOST_CHECK_EQUAL(result[2], "");
   BOOST_CHECK_EQUAL(result[3], "Desc4");
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the translateColumn method
 //-----------------------------------------------------------------------------
- 
+
 BOOST_FIXTURE_TEST_CASE(translateColumn, FitsReaderHelper_Fixture) {
-  
+
   // Given
   std::vector<std::string> names {"Bool","Int","Long","String","Float","Double","IntVector","DoubleVector"};
   std::vector<std::string> types {"L","J","K","10A","E","D","2J","2D"};
@@ -252,8 +253,8 @@ BOOST_FIXTURE_TEST_CASE(translateColumn, FitsReaderHelper_Fixture) {
   table_hdu->column(7).writeArrays(int_vectors, 1);
   std::vector<std::valarray<double>> double_vectors {{1.1,1.2}, {2.1,2.2}};
   table_hdu->column(8).writeArrays(double_vectors, 1);
-  
-  
+
+
   // When
   auto bool_result = Euclid::Table::translateColumn(table_hdu->column(1), typeid(bool));
   auto int_result = Euclid::Table::translateColumn(table_hdu->column(2), typeid(int32_t));
@@ -263,7 +264,7 @@ BOOST_FIXTURE_TEST_CASE(translateColumn, FitsReaderHelper_Fixture) {
   auto double_result = Euclid::Table::translateColumn(table_hdu->column(6), typeid(double));
   auto int_vector_result = Euclid::Table::translateColumn(table_hdu->column(7), typeid(std::vector<int32_t>));
   auto double_vector_result = Euclid::Table::translateColumn(table_hdu->column(8), typeid(std::vector<double>));
-  
+
   // Then
   BOOST_CHECK_EQUAL(bool_result.size(), 2);
   BOOST_CHECK_EQUAL(boost::get<bool>(bool_result[0]), true);
@@ -297,7 +298,7 @@ BOOST_FIXTURE_TEST_CASE(translateColumn, FitsReaderHelper_Fixture) {
   BOOST_CHECK_EQUAL(boost::get<std::vector<double>>(double_vector_result[1]).size(), 2);
   BOOST_CHECK_EQUAL(boost::get<std::vector<double>>(double_vector_result[1])[0], 2.1);
   BOOST_CHECK_EQUAL(boost::get<std::vector<double>>(double_vector_result[1])[1], 2.2);
-  
+
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
CCFits will read columns whose identifier starts with 1 as scalars