### PR TITLE
Add numerical differentiation

### DIFF
--- a/MathUtils/CMakeLists.txt
+++ b/MathUtils/CMakeLists.txt
@@ -6,7 +6,10 @@ find_package(GMock)
 
 #===== Libraries ===============================================================
 
-elements_add_library(MathUtils src/lib/function/*.cpp src/lib/interpolation/*.cpp src/lib/numericalIntegration/*.cpp src/lib/PDF/*.cpp
+elements_add_library(MathUtils
+                      src/lib/function/*.cpp src/lib/interpolation/*.cpp
+                      src/lib/numericalIntegration/*.cpp src/lib/numericalDifferentiation/*.cpp
+                      src/lib/PDF/*.cpp
                      LINK_LIBRARIES XYDataset
                      PUBLIC_HEADERS MathUtils)
 
@@ -30,13 +33,16 @@ elements_add_unit_test(function_all_tests tests/src/function/*_test.cpp
 elements_add_unit_test(interpolation_all_tests tests/src/interpolation/*_test.cpp
                        LINK_LIBRARIES MathUtils XYDataset TYPE Boost)
 
+elements_add_unit_test(central_difference_tests tests/src/numericalDifferentiation/FiniteDifference_test.cpp
+                       LINK_LIBRARIES MathUtils TYPE Boost)
+
 elements_add_unit_test(SimpsonsRule_test tests/src/numericalIntegration/SimpsonsRule_test.cpp
                        LINK_LIBRARIES MathUtils TYPE Boost)
-                       
-elements_add_unit_test(Cumulative_test tests/src/PDF/Cumulative_test.cpp 
+
+elements_add_unit_test(Cumulative_test tests/src/PDF/Cumulative_test.cpp
                      LINK_LIBRARIES MathUtils XYDataset TYPE Boost)
 
-elements_add_unit_test(PdfModeExtraction_test tests/src/PDF/PdfModeExtraction_test.cpp 
+elements_add_unit_test(PdfModeExtraction_test tests/src/PDF/PdfModeExtraction_test.cpp
                      LINK_LIBRARIES MathUtils XYDataset TYPE Boost)
 
 #===== Tests using GMock =======================================================
@@ -48,7 +54,7 @@ elements_add_unit_test(function_tools_test tests/src/function/function_tools_tes
 elements_add_unit_test(FunctionAdapter_test tests/src/function/FunctionAdapter_test_mock.cpp
                          LINK_LIBRARIES GMock MathUtils TYPE Boost
                          INCLUDE_DIRS GMock)
-                         
+
 elements_add_unit_test(AdaptativeIntegration_test tests/src/numericalIntegration/AdaptativeIntegration_test.cpp
                          LINK_LIBRARIES GMock MathUtils TYPE Boost
                          INCLUDE_DIRS GMock)

--- a/MathUtils/MathUtils/numericalDifferentiation/FiniteDifference.h
+++ b/MathUtils/MathUtils/numericalDifferentiation/FiniteDifference.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file MathUtils/numericalDifferentiation/CentralDifference.h
+ * @date January 09, 2020
+ * @author Alejandro Alvarez Ayllon
+ */
+
+#ifndef MATHUTILS_MATHUTILS_NUMERICALDIFFERENTIATION_FINITEDIFFERENCE_H_
+#define MATHUTILS_MATHUTILS_NUMERICALDIFFERENTIATION_FINITEDIFFERENCE_H_
+
+#include "MathUtils/function/Function.h"
+
+namespace Euclid {
+namespace MathUtils {
+
+/**
+ * Derivative using finite differences:
+ *  \f$ f'(x) = \frac{f(x+h) - f(x)}{h} \f$
+ * @note
+ *  h is computed automatically following the same approach as boost numeric differentiation:
+ *  \f$ h =(x + \sqrt{\epsilon} * 2)  - x \f$
+ *  This guarantees that xh is representable using floating point (since (x + h) - x is *not* necessarily equal to h)
+ *  If h happens to be 0, std::nextafter is called
+ * @param f
+ *  The Function to derive
+ * @param x
+ *  The point where to do the derivation
+ * @return
+ *  An approximation of f'(x)
+ */
+double derivative(const Function& f, const double x);
+
+/**
+ * Second derivative using finite differences:
+ *  \f$ f''(x) = \frac{f(x+h) - 2f(x) + f(x - h)}{h^2} \f$
+ * @note
+ *  h is computed automatically as follows:
+ *  \f$ h =(x + \sqrt[4]{\epsilon} * 2) - x \f$
+ *  This guarantees that xh is representable using floating point (since (x + h) - x is *not* necessarily equal to h)
+ *  If h happens to be 0, std::nextafter is called
+ * @param f
+ *  The Function to derive
+ * @param x
+ *  The point where to do the derivation
+ * @return
+ *  An approximation of f''(x)
+ */
+double derivative2nd(const Function& f, const double x);
+
+} // end namespace MathUtils
+} // end namespace Euclid
+
+#endif // MATHUTILS_MATHUTILS_NUMERICALDIFFERENTIATION_FINITEDIFFERENCE_H_

--- a/MathUtils/doc/MathUtils.dox
+++ b/MathUtils/doc/MathUtils.dox
@@ -144,10 +144,31 @@ integrate() method:
 \endcode
 
 The integrate() method will take advantage of the functions which are
-implementing the Integrable interface during its calculation. Note that the
-current version of the MathUtils module does not provide a default numerical
-integration method, so if a function is not implementing the Integrable
-interface, an exception will be thrown.
+implementing the Integrable interface during its calculation.
+
+For functions that do not implement the Integrable interface, an optional third
+argument can be used to specify the numerical integration method to use, which can be
+any class implementing the NumericalIntegrationScheme interface. Note that the
+current version of the MathUtils module does not provide a default.
+
+\code{.cpp}
+  std::unique_ptr<NumericalIntegrationScheme> numerical_scheme(new AdaptativeIntegration<SimpsonsRule>(0.1, 3));
+  cout << "Integral of f() in [3,6] = " << integrate(piece, 3, 6, numerical_scheme) << '\n';
+\endcode
+
+\subsubsection numericaldifferences Numerical differentiation
+
+For Function%s that do not provide the Differentiable API, the MathUtils module provides
+an implementation of numerical differentiation via finite differences.
+
+\code{.cpp}
+    auto ex_f = FunctionAdapter([](double x){return std::pow(M_E, x); });
+
+    auto dy = derivative(ex_f, x);
+    auto ddy = derivative2nd(ex_f, x);
+    BOOST_CHECK_CLOSE(dy, ex_f(x), close_tolerance);
+    BOOST_CHECK_CLOSE(ddy, ex_f(x), close_tolerance);
+\endcode
 
 \subsubsection multiplication Multiplication
 
@@ -186,7 +207,7 @@ The currently supported types of interpolation are linear and cubic spline:
   auto linear = interpolate(x, y, InterpolationType::LINEAR);
   // Cubic spline interpolation
   auto spline = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
-  
+
   cout << "linear\tspline\n";
   for (double i=0; i<=4; i+=0.1) {
     cout << (*linear)(i) << '\t' << (*spline)(i) << '\n';
@@ -291,7 +312,7 @@ example:
   multiplySpecificSpecificMap.insert(
       {pair<type_index,type_index>(typeid(Constant),typeid(Polynomial)), multConstPol}
   );
-  
+
   // The result of multiplying a Constant with a Polynomial is now a Polynomial
   auto m = multiply(Constant{5}, Polynomial{{0,1}});
   cout << typeid(*m).name() << '\n';
@@ -316,7 +337,7 @@ unique_ptr<Function> multConst(const Function& f1, const Function& f2) {
   multiplySpecificSpecificMap.insert(
       {pair<type_index,type_index>(typeid(Constant),typeid(Constant)), multConst}
   );
-  
+
   // The result of multiplying Constants is now a Constant
   m = multiply(Constant{5}, Constant{10});
   cout << typeid(*m).name() << '\n';

--- a/MathUtils/src/lib/numericalDifferentiation/FiniteDifference.cpp
+++ b/MathUtils/src/lib/numericalDifferentiation/FiniteDifference.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file MathUtils/src/lib/numericalDifferentiation/CentralDifference.cpp
+ * @date January 09, 2020
+ * @author Alejandro Alvarez Ayllon
+ */
+
+#include "MathUtils/numericalDifferentiation/FiniteDifference.h"
+#include <cmath>
+#include <limits>
+
+namespace Euclid {
+namespace MathUtils {
+
+static double guess_h(double initial_h, double x) {
+  volatile double xh = x + initial_h;
+  volatile double h = xh - x;
+  if (h == 0) {
+    h = std::nextafter(x, std::numeric_limits<double>::max()) - x;
+  }
+  return h;
+}
+
+double derivative(const Function& f, const double x) {
+  double h = std::sqrt(std::numeric_limits<double>::epsilon()) * 2;
+  h = guess_h(h, x);
+
+  double yh = f(x + h);
+  double y0 = f(x);
+  return (yh - y0) / h;
+}
+
+double derivative2nd(const Function& f, const double x) {
+  double h = std::sqrt(std::sqrt(std::numeric_limits<double>::epsilon())) * 2;
+  h = guess_h(h, x);
+
+  double ymh = f(x - h);
+  double y = f(x);
+  double yph = f(x + h);
+
+  return (yph - 2 * y + ymh) / (h * h);
+}
+
+} // end namespace MathUtils
+} // end namespace Euclid

--- a/MathUtils/tests/src/numericalDifferentiation/FiniteDifference_test.cpp
+++ b/MathUtils/tests/src/numericalDifferentiation/FiniteDifference_test.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+* @file tests/src/numericalDifferentiation/CentralDifference_test.cpp
+* @date January 9, 2020
+* @author Alejandro Alvarez Ayllon
+*/
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+#include <cmath>
+#include "MathUtils/numericalDifferentiation/FiniteDifference.h"
+#include "MathUtils/function/FunctionAdapter.h"
+
+using namespace Euclid::MathUtils;
+
+struct FiniteDifference_Fixture {
+  double close_tolerance {1E-4};
+  double small_tolerance {1E-20};
+
+  std::vector<double> xs;
+
+  FiniteDifference_Fixture() {
+    for (double xValue = -10.; xValue <= 10.; xValue += 1) {
+      xs.push_back(xValue);
+    }
+  }
+};
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (FiniteDifference_test)
+
+//-----------------------------------------------------------------------------
+// Constant function: First and second derivatives are 0
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(Constant, FiniteDifference_Fixture) {
+  auto constant_f = FunctionAdapter([](double) {
+    return 5;
+  });
+
+  for (auto x : xs) {
+    auto dy = derivative(constant_f, x);
+    auto ddy = derivative2nd(constant_f, x);
+    BOOST_CHECK_SMALL(dy, small_tolerance);
+    BOOST_CHECK_SMALL(ddy, small_tolerance);
+  }
+}
+
+//-----------------------------------------------------------------------------
+// Linear function: first derivative is the slope, second is 0
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(Linear, FiniteDifference_Fixture) {
+  const float slope = 5;
+  auto linear_f = FunctionAdapter([slope](double x) {
+    return slope * x + 4;
+  });
+
+  for (auto x : xs) {
+    auto dy = derivative(linear_f, x);
+    auto ddy = derivative2nd(linear_f, x);
+    BOOST_CHECK_CLOSE(dy, slope, close_tolerance);
+    BOOST_CHECK_SMALL(ddy, small_tolerance);
+  }
+}
+
+//-----------------------------------------------------------------------------
+// Quadratic function: first derivative is 2ax + b, second is 2a
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(Quadratic, FiniteDifference_Fixture) {
+  const float a = 3, b = 5, c = 42;
+  auto quadratic_f = FunctionAdapter([a, b, c](double x) {
+    double y = a * x * x + b * x + c;
+    return y;
+  });
+
+  for (auto x : xs) {
+    auto dy = derivative(quadratic_f, x);
+    auto ddy = derivative2nd(quadratic_f, x);
+    BOOST_CHECK_CLOSE(dy, 2 * a * x + b, close_tolerance);
+    BOOST_CHECK_CLOSE(ddy, 2 * a, close_tolerance);
+  }
+}
+
+//-----------------------------------------------------------------------------
+// Sin function: first derivative is cos(x), second is -sin(x)
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(Sin, FiniteDifference_Fixture) {
+  auto sin_f = FunctionAdapter([](double x){return std::sin(x); });
+
+  for (auto x : xs) {
+    auto dy = derivative(sin_f, x);
+    auto ddy = derivative2nd(sin_f, x);
+    BOOST_CHECK_CLOSE(dy, cos(x), close_tolerance);
+    BOOST_CHECK_CLOSE(ddy, -sin(x), close_tolerance);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE_END ()

--- a/MathUtils/tests/src/numericalDifferentiation/FiniteDifference_test.cpp
+++ b/MathUtils/tests/src/numericalDifferentiation/FiniteDifference_test.cpp
@@ -117,5 +117,20 @@ BOOST_FIXTURE_TEST_CASE(Sin, FiniteDifference_Fixture) {
 }
 
 //-----------------------------------------------------------------------------
+// e^x function: first and second derivative are e^x
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(ex, FiniteDifference_Fixture) {
+  auto ex_f = FunctionAdapter([](double x){return std::pow(M_E, x); });
+
+  for (auto x : xs) {
+    auto dy = derivative(ex_f, x);
+    auto ddy = derivative2nd(ex_f, x);
+    BOOST_CHECK_CLOSE(dy, ex_f(x), close_tolerance);
+    BOOST_CHECK_CLOSE(ddy, ex_f(x), close_tolerance);
+  }
+}
+
+//-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_SUITE_END ()


### PR DESCRIPTION
Normally boost provides this, but in some platforms the available boost version doesn't.

I need them because of some tests I added for the cubic interpolation, like testing the continuity at the knots.