### PR TITLE
Feature: GridContainerToTable

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,3 @@
 set noparent
-filter=-whitespace,-build/header_guard,-build/namespaces,-build/c++11
+filter=-whitespace,-build/header_guard,-build/namespaces,-build/c++11,-runtime/references
 linelength=120

--- a/GridContainer/CMakeLists.txt
+++ b/GridContainer/CMakeLists.txt
@@ -1,13 +1,13 @@
 elements_subdir(GridContainer)
 
-elements_depends_on_subdirs(ElementsKernel XYDataset)
+elements_depends_on_subdirs(ElementsKernel Table XYDataset)
 find_package(Boost REQUIRED COMPONENTS system serialization filesystem)
 find_package(CCfits)
 
 #===== Libraries ===============================================================
 
 elements_add_library(GridContainer src/lib/*.cpp
-                     LINK_LIBRARIES Boost ElementsKernel CCfits XYDataset
+                     LINK_LIBRARIES Boost ElementsKernel CCfits Table XYDataset
                      INCLUDE_DIRS CCfits
                      PUBLIC_HEADERS GridContainer)
 
@@ -26,6 +26,9 @@ elements_add_unit_test(GridConstructionHelper_test tests/src/GridConstructionHel
                        LINK_LIBRARIES GridContainer TYPE Boost)
 
 elements_add_unit_test(GridIndexHelper_test tests/src/GridIndexHelper_test.cpp
+                       LINK_LIBRARIES GridContainer TYPE Boost)
+
+elements_add_unit_test(GridContainerToTable_test tests/src/GridContainerToTable_test.cpp
                        LINK_LIBRARIES GridContainer TYPE Boost)
 
 elements_add_unit_test(GridCellManagerTraits_test tests/src/GridCellManagerTraits_test.cpp

--- a/GridContainer/GridContainer/GridContainerToTable.h
+++ b/GridContainer/GridContainer/GridContainerToTable.h
@@ -34,8 +34,8 @@ namespace GridContainer {
  *  Type to be mapped
  */
 template<typename T>
-struct Knot2FitsTrait {
-  typedef T fits_t;
+struct GridAxisToTable {
+  typedef T table_cell_t;
 
   static T serialize(T v) {
     return v;
@@ -46,10 +46,10 @@ struct Knot2FitsTrait {
  * Specialization for mapping a qualified name into a string
  */
 template<>
-struct Knot2FitsTrait<Euclid::XYDataset::QualifiedName> {
-  typedef std::string fits_t;
+struct GridAxisToTable<Euclid::XYDataset::QualifiedName> {
+  typedef std::string table_cell_t;
 
-  static fits_t serialize(const Euclid::XYDataset::QualifiedName& qn) {
+  static table_cell_t serialize(const Euclid::XYDataset::QualifiedName& qn) {
     return qn.qualifiedName();
   }
 };
@@ -60,8 +60,8 @@ struct Knot2FitsTrait<Euclid::XYDataset::QualifiedName> {
  *  Type to be mapped
  */
 template<typename T, typename Enable=void>
-struct Cell2FitsTrait {
-  static_assert(!std::is_same<T, T>::value, "Specialization of Cell2FitsTrait required");
+struct GridCellToTable {
+  static_assert(!std::is_same<T, T>::value, "Specialization of GridCellToTable required");
 
   /**
    * Get the column descriptions of the values of the cell. The element passed will be one
@@ -87,7 +87,7 @@ struct Cell2FitsTrait {
  * Specialization for scalar types
  */
 template<typename T>
-struct Cell2FitsTrait<T, typename std::enable_if<std::is_arithmetic<T>::value>::type> {
+struct GridCellToTable<T, typename std::enable_if<std::is_arithmetic<T>::value>::type> {
 
   static void addColumnDescriptions(const T&, std::vector<Table::ColumnDescription>& columns) {
     columns.emplace_back("value", typeid(T));

--- a/GridContainer/GridContainer/GridContainerToTable.h
+++ b/GridContainer/GridContainer/GridContainerToTable.h
@@ -22,6 +22,7 @@
 #include <vector>
 #include "GridContainer/GridContainer.h"
 #include "Table/Table.h"
+#include "XYDataset/QualifiedName.h"
 
 namespace Euclid {
 namespace GridContainer {
@@ -38,6 +39,18 @@ struct Knot2FitsTrait {
 
   static T serialize(T v) {
     return v;
+  }
+};
+
+/**
+ * Specialization for mapping a qualified name into a string
+ */
+template<>
+struct Knot2FitsTrait<Euclid::XYDataset::QualifiedName> {
+  typedef std::string fits_t;
+
+  static fits_t serialize(const Euclid::XYDataset::QualifiedName& qn) {
+    return qn.qualifiedName();
   }
 };
 
@@ -68,6 +81,21 @@ struct Cell2FitsTrait {
    *    Destination row. New cells must be *appended* on the same order as the column descriptions.
    */
   static void addCells(const T& c, std::vector<Table::Row::cell_type>& row);
+};
+
+/**
+ * Specialization for scalar types
+ */
+template<typename T>
+struct Cell2FitsTrait<T, typename std::enable_if<std::is_arithmetic<T>::value>::type> {
+
+  static void addColumnDescriptions(const T&, std::vector<Table::ColumnDescription>& columns) {
+    columns.emplace_back("value", typeid(T));
+  }
+
+  static void addCells(const T& c, std::vector<Table::Row::cell_type>& row) {
+    row.emplace_back(c);
+  }
 };
 
 /**

--- a/GridContainer/GridContainer/GridContainerToTable.h
+++ b/GridContainer/GridContainer/GridContainerToTable.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef GRIDCONTAINER_GRIDCONTAINERTOTABLE_H
+#define GRIDCONTAINER_GRIDCONTAINERTOTABLE_H
+
+#include "GridContainer/GridContainer.h"
+#include "Table/Table.h"
+
+namespace Euclid {
+namespace GridContainer {
+
+/**
+ * Trait used to map internal C++ types to types known by Alexandria's Table implementation.
+ * This is the generic case: identity mapping
+ * @tparam T
+ *  Type to be mapped
+ */
+template<typename T>
+struct Knot2FitsTrait {
+  typedef T fits_t;
+
+  static T serialize(T v) {
+    return v;
+  }
+};
+
+/**
+ * Trait used to map the grid cell type into an Alexandria's table set of cells.
+ * @tparam T
+ *  Type to be mapped
+ */
+template<typename T, typename Enable=void>
+struct Cell2FitsTrait {
+  static_assert(!std::is_same<T, T>::value, "Specialization of Cell2FitsTrait required");
+
+  /**
+   * Get the column descriptions of the values of the cell. The element passed will be one
+   * reference cell from the grid (i.e. the first one)
+   * @param c
+   *    A cell instance
+   * @param columns
+   *    The column description(s) for the cell type. New columns must be *appended*
+   */
+  static void addColumnDescriptions(const T& c, std::vector<Table::ColumnDescription>& columns);
+
+  /**
+   * Add the cell values into the row
+   * @param c
+   *    A cell instance to be serialized
+   * @param row
+   *    Destination row. New cells must be *appended* on the same order as the column descriptions.
+   */
+  static void addCells(const T& c, std::vector<Table::Row::cell_type>& row);
+};
+
+/**
+ * Transform a GridContainer into a Table, with an entry for each
+ * cell. The content will be unfolded, so the knot values will be repeated.
+ */
+template<typename GridCellManager, typename ...AxesTypes>
+Table::Table gridContainerToTable(const GridContainer<GridCellManager, AxesTypes...>& grid);
+
+} // end of namespace GridContainer
+} // end of namespace Euclid
+
+#include "GridContainer/_impl/GridContainerToTable.icpp"
+
+#endif // GRIDCONTAINER_GRIDCONTAINERTOTABLE_H

--- a/GridContainer/GridContainer/GridContainerToTable.h
+++ b/GridContainer/GridContainer/GridContainerToTable.h
@@ -19,6 +19,7 @@
 #ifndef GRIDCONTAINER_GRIDCONTAINERTOTABLE_H
 #define GRIDCONTAINER_GRIDCONTAINERTOTABLE_H
 
+#include <vector>
 #include "GridContainer/GridContainer.h"
 #include "Table/Table.h"
 

--- a/GridContainer/GridContainer/_impl/GridContainerToTable.icpp
+++ b/GridContainer/GridContainer/_impl/GridContainerToTable.icpp
@@ -64,7 +64,7 @@ struct GridToFitsHelper {
    * Generate recursively the column description for each *knot* on the grid. The order on the tuples
    * is reversed, so the 0th tuple element is inserted on the last position.
    * @param grid
-   *    The photometry grid
+   *    An instance of a grid
    * @param description
    *    A vector where to emplace the description
    */
@@ -84,7 +84,7 @@ struct GridToFitsHelper {
    * @tparam Args
    *    Used to keep track of the types of the knots of the previous axes
    * @param grid
-   *    Photometry grid
+   *    An instance of a grid
    * @param column_info
    *    As populated by getColumnDescriptions
    * @param rows

--- a/GridContainer/GridContainer/_impl/GridContainerToTable.icpp
+++ b/GridContainer/GridContainer/_impl/GridContainerToTable.icpp
@@ -19,38 +19,9 @@
 #include <type_traits>
 #include <vector>
 #include <boost/algorithm/string.hpp>
-#include "XYDataset/QualifiedName.h"
 
 namespace Euclid {
 namespace GridContainer {
-
-/**
- * Specialization for mapping a qualified name into a string
- */
-template<>
-struct Knot2FitsTrait<Euclid::XYDataset::QualifiedName> {
-  typedef std::string fits_t;
-
-  static fits_t serialize(const Euclid::XYDataset::QualifiedName& qn) {
-    return qn.qualifiedName();
-  }
-};
-
-/**
- * Specialization for scalars
- * @tparam T
- */
-template<typename T>
-struct Cell2FitsTrait<T, typename std::enable_if<std::is_arithmetic<T>::value>::type> {
-
-  static void addColumnDescriptions(const T&, std::vector<Table::ColumnDescription>& columns) {
-    columns.emplace_back("value", typeid(T));
-  }
-
-  static void addCells(const T& c, std::vector<Table::Row::cell_type>& row) {
-    row.emplace_back(c);
-  }
-};
 
 /**
  * Template class to help on the recursive traversal of the grid

--- a/GridContainer/GridContainer/_impl/GridContainerToTable.icpp
+++ b/GridContainer/GridContainer/_impl/GridContainerToTable.icpp
@@ -99,7 +99,7 @@ struct GridToFitsHelper<0, GridCellManager, Axes...> {
                                     std::vector<Table::ColumnDescription>&) {}
 
   /**
-   * Insert into the row vector the cell value (photometry) plus the axes values that brought us here
+   * Insert into the row vector the cell value plus the axes values that brought us here
    */
   template<typename ...Args>
   static void

--- a/GridContainer/GridContainer/_impl/GridContainerToTable.icpp
+++ b/GridContainer/GridContainer/_impl/GridContainerToTable.icpp
@@ -45,7 +45,7 @@ struct GridToFitsHelper {
     using knot_t = typename std::remove_reference<decltype(axis)>::type::data_type;
     auto name = axis.name();
     boost::replace_all(name, " ", "_");
-    description.emplace_back(name, typeid(typename Knot2FitsTrait<knot_t>::fits_t));
+    description.emplace_back(name, typeid(typename GridAxisToTable<knot_t>::table_cell_t));
 
     GridToFitsHelper<I - 1, GridCellManager, Axes...>::addColumnDescriptions(grid, description);
   }
@@ -107,10 +107,10 @@ struct GridToFitsHelper<0, GridCellManager, Axes...> {
          std::vector<Table::Row>& rows, std::pair<size_t, Args> ...axes) {
     using GridType = GridContainer<GridCellManager, Axes...>;
 
-    std::vector<Table::Row::cell_type> row_content{Knot2FitsTrait<Args>::serialize(axes.second)...};
+    std::vector<Table::Row::cell_type> row_content{GridAxisToTable<Args>::serialize(axes.second)...};
     std::reverse(row_content.begin(), row_content.end());
 
-    Cell2FitsTrait<typename GridType::cell_type> cell_traits;
+    GridCellToTable<typename GridType::cell_type> cell_traits;
     cell_traits.addCells(grid.at(axes.first...), row_content);
 
     rows.emplace_back(row_content, column_info);
@@ -129,7 +129,7 @@ Table::Table gridContainerToTable(const GridContainer<GridCellManager, AxesTypes
   std::vector<Table::ColumnDescription> columns;
   Helper::addColumnDescriptions(grid.getAxesTuple(), columns);
 
-  Cell2FitsTrait<typename GridType::cell_type> cell_trais;
+  GridCellToTable<typename GridType::cell_type> cell_trais;
   cell_trais.addColumnDescriptions(*grid.begin(), columns);
 
   auto column_info = std::make_shared<Table::ColumnInfo>(std::move(columns));

--- a/GridContainer/GridContainer/_impl/GridContainerToTable.icpp
+++ b/GridContainer/GridContainer/_impl/GridContainerToTable.icpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <type_traits>
+#include <vector>
+#include <boost/algorithm/string.hpp>
+#include "XYDataset/QualifiedName.h"
+
+namespace Euclid {
+namespace GridContainer {
+
+/**
+ * Specialization for mapping a qualified name into a string
+ */
+template<>
+struct Knot2FitsTrait<Euclid::XYDataset::QualifiedName> {
+  typedef std::string fits_t;
+
+  static fits_t serialize(const Euclid::XYDataset::QualifiedName& qn) {
+    return qn.qualifiedName();
+  }
+};
+
+/**
+ * Specialization for scalars
+ * @tparam T
+ */
+template<typename T>
+struct Cell2FitsTrait<T, typename std::enable_if<std::is_arithmetic<T>::value>::type> {
+
+  static void addColumnDescriptions(const T&, std::vector<Table::ColumnDescription>& columns) {
+    columns.emplace_back("value", typeid(T));
+  }
+
+  static void addCells(const T& c, std::vector<Table::Row::cell_type>& row) {
+    row.emplace_back(c);
+  }
+};
+
+/**
+ * Template class to help on the recursive traversal of the grid
+ * @tparam I
+ *  Handle the axis stored on the (I-1)th position on the GridContainer::AxesTuple
+ */
+template<size_t I, typename GridCellManager, typename ...Axes>
+struct GridToFitsHelper {
+
+  /**
+   * Generate recursively the column description for each *knot* on the grid. The order on the tuples
+   * is reversed, so the 0th tuple element is inserted on the last position.
+   * @param grid
+   *    The photometry grid
+   * @param description
+   *    A vector where to emplace the description
+   */
+  static void addColumnDescriptions(const GridContainer<GridCellManager, Axes...>& grid,
+                                    std::vector<Table::ColumnDescription>& description) {
+    auto& axis = grid.template getAxis<I - 1>();
+    using knot_t = typename std::remove_reference<decltype(axis)>::type::data_type;
+    auto name = axis.name();
+    boost::replace_all(name, " ", "_");
+    description.emplace_back(name, typeid(typename Knot2FitsTrait<knot_t>::fits_t));
+
+    GridToFitsHelper<I - 1, GridCellManager, Axes...>::addColumnDescriptions(grid, description);
+  }
+
+  /**
+   * Iterate over the elements of the (I-1)th axis, and for each one call recursively unfold on the next axis.
+   * @tparam Args
+   *    Used to keep track of the types of the knots of the previous axes
+   * @param grid
+   *    Photometry grid
+   * @param column_info
+   *    As populated by getColumnDescriptions
+   * @param rows
+   *    Grid cells will be inserted on this vector
+   * @param axes
+   *    Used to keep track of the values of the knots of the previous axis
+   */
+  template<typename ...Args>
+  static void
+  unfold(const GridContainer<GridCellManager, Axes...>& grid, const std::shared_ptr<Table::ColumnInfo>& column_info,
+         std::vector<Table::Row>& rows, std::pair<size_t, Args>... axes) {
+    auto& axis = grid.template getAxis<I - 1>();
+    for (size_t i = 0; i < axis.size(); ++i) {
+      GridToFitsHelper<I - 1, GridCellManager, Axes...>::unfold(grid, column_info, rows, std::make_pair(i, axis[i]),
+                                                              axes...);
+    }
+  }
+
+  /**
+   * Same as before, but without the book-keeping data, since this is the entry point
+   */
+  static void
+  unfold(const GridContainer<GridCellManager, Axes...>& grid, const std::shared_ptr<Table::ColumnInfo>& column_info,
+         std::vector<Table::Row>& rows) {
+    auto& axis = grid.template getAxis<I - 1>();
+    for (size_t i = 0; i < axis.size(); ++i) {
+      GridToFitsHelper<I - 1, GridCellManager, Axes...>::unfold(grid, column_info, rows, std::make_pair(i, axis[i]));
+    }
+  }
+};
+
+/**
+ * Base class for the recursive traversal of the grid
+ */
+template<typename GridCellManager, typename ...Axes>
+struct GridToFitsHelper<0, GridCellManager, Axes...> {
+  /**
+   * There are no more axis, so do nothing for the columns
+   */
+  static void addColumnDescriptions(const GridContainer<GridCellManager, Axes...>&,
+                                    std::vector<Table::ColumnDescription>&) {}
+
+  /**
+   * Insert into the row vector the cell value (photometry) plus the axes values that brought us here
+   */
+  template<typename ...Args>
+  static void
+  unfold(const GridContainer<GridCellManager, Axes...>& grid, const std::shared_ptr<Table::ColumnInfo>& column_info,
+         std::vector<Table::Row>& rows, std::pair<size_t, Args> ...axes) {
+    using GridType = GridContainer<GridCellManager, Axes...>;
+
+    std::vector<Table::Row::cell_type> row_content{Knot2FitsTrait<Args>::serialize(axes.second)...};
+    std::reverse(row_content.begin(), row_content.end());
+
+    Cell2FitsTrait<typename GridType::cell_type> cell_traits;
+    cell_traits.addCells(grid.at(axes.first...), row_content);
+
+    rows.emplace_back(row_content, column_info);
+  }
+};
+
+/**
+ * Transform a GridContainer into a Table, with an entry for each
+ * cell. The content will be unfolded, so the knot values will be repeated.
+ */
+template<typename GridCellManager, typename ...AxesTypes>
+Table::Table gridContainerToTable(const GridContainer<GridCellManager, AxesTypes...>& grid) {
+  using GridType = GridContainer<GridCellManager, AxesTypes...>;
+  using Helper = GridToFitsHelper<std::tuple_size<typename GridType::AxesTuple>::value, GridCellManager, AxesTypes...>;
+
+  std::vector<Table::ColumnDescription> columns;
+  Helper::addColumnDescriptions(grid.getAxesTuple(), columns);
+
+  Cell2FitsTrait<typename GridType::cell_type> cell_trais;
+  cell_trais.addColumnDescriptions(*grid.begin(), columns);
+
+  auto column_info = std::make_shared<Table::ColumnInfo>(std::move(columns));
+
+  std::vector<Table::Row> rows;
+  rows.reserve(grid.size());
+
+  Helper::unfold(grid, column_info, rows);
+
+  return Table::Table{std::move(rows)};
+}
+
+} // end of namespace GridContainer
+} // end of namespace Euclid

--- a/GridContainer/doc/GridContainer.dox
+++ b/GridContainer/doc/GridContainer.dox
@@ -66,7 +66,7 @@ the following code:
 In the code above one can make the following observations:
 
 - To support axes with knots of different types, the GridAxis class gets this
-  type as a template parameter. In the example above the type chosen is `int` 
+  type as a template parameter. In the example above the type chosen is `int`
   (`GridAxis<int>`). To use knots of `string` type, the definitions should be
   `GridAxis<string>`. Note that user defined types are also supported.
 
@@ -88,13 +88,13 @@ brackets (`[]`) operator, as demonstrated in the following example:
 \code{.cpp}
   // Getting the axis name
   cout << "Axis name : " << wavelength_axis.name() << "\n";
-  
+
   // Getting the number of knots
   cout << "Number of knots : " << wavelength_axis.size() << "\n";
-  
+
   // Accessing a knot value directly using its (zero based) index
   cout << "Second knot value : " << wavelength_axis[1] << "\n";
-  
+
   // Accessing the knots using the iterator
   cout << "All knot values : ( ";
   for (auto& knot_value : wavelength_axis) {
@@ -119,7 +119,7 @@ the array of grid cell values. Instead, it delegates this task to a
 **GridCellManager**, the type of which is provided as a template parameter to
 the GridContainer class (with signatures such as `GridContainer<GridCellManager,
 ...>`, where the additional template parameters are related to the grid axes,
-see \ref grid below). 
+see \ref grid below).
 
 Existing container classes can be used as the **GridCellManager** of a
 GridContainer, with the simplest example being the std::vector. For example, a
@@ -583,6 +583,65 @@ GridCellManagerTraits must have the enable_boost_serializable flag set to true.
 By default the GridContainer module enables serialization only for vectors of
 types which are boost serializable.
 
+\subsection grid2table Generating a Table
+
+A GridContainer can be unfolded into an Alexandria Table, which can, in turn, be serialized
+either into plain text or FITS files. However, keep in mind that this is operation has a single
+direction: there is no functionality provided to load a GridContainer from a Table. However, it can be
+useful for debugging purposes to serialize a GridContainer into a format easy to read from other tools
+or languages (i.e. astropy's Table)
+
+To be able to export a Table, you need to include first GridContainer/GridContainerToTable.h
+
+\code{cpp}
+#include "GridContainer/GridContainerToTable.h"
+\endcode
+
+When you want to transform a Grid, you need to make sure the axes and cell types can be translated to
+the types supported by Row::cell_type, and given a name.
+This is done via the specialization of two set of traits: GridAxisToTable and GridCellToTable.
+
+By default, Alexandria provides two specializations of GridAxisToTable:
+
+- From Euclid::XYDataset::QualifiedName to std::string
+- A default identity mapping for every other type, which will generally work for most POD types, strings,
+  and vectors of POD.
+
+Note that only one column can be generated for each axis, using the name assigned to the axis.
+
+For GridCellToTable, a default specialization for any kind of scalar - integer and floating point - is provided.
+By default, the associated column name will be `value`.
+
+For composed cell values, as it would be SourceCatalog::Photometry, you will need to provide a custom specialization.
+For instance:
+
+\code{cpp}
+/**
+ * Specialization for mapping a Photometry object into a set of cells.
+ * Two columns will be generated: one with the flux, and another with the error
+ */
+template<>
+struct Euclid::GridContainer::GridCellToTable<Euclid::SourceCatalog::Photometry> {
+  static void addColumnDescriptions(const Photometry& p, std::vector<ColumnDescription>& columns) {
+    auto& photo_ref = p;
+    for (auto piter = photo_ref.begin(); piter != photo_ref.end(); ++piter) {
+      columns.emplace_back(piter.filterName(), typeid(double));
+      columns.emplace_back(piter.filterName() + "_error", typeid(double));
+    }
+  }
+
+  static void addCells(const Photometry& photometry, std::vector<Row::cell_type>& row) {
+    for (auto& p : photometry) {
+      row.emplace_back(p.flux);
+      row.emplace_back(p.error);
+    }
+  }
+};
+\endcode
+
+Note that addColumnDescriptions uses the first value on the grid as a model for every other cell.
+This code assumes that all instances look alike.
+
 \section apispecialization Specializing the GridContainer API
 
 From the examples above can be seen that the API of the GridContainer module is
@@ -641,32 +700,32 @@ make easier the comparison.
   GridAxis<int> int_axis {"Integers", {1, 2, 3, 4, 5}};
   GridAxis<double> double_axis {"Doubles", {0.1, 0.2}};
   GridAxis<string> string_axis {"Strings", {"one", "two", "three"}};
-  
+
   // Create a grid with integer data
   MyGridContainer<int> grid {int_axis, double_axis, string_axis};
-  
+
   // Print all the nodes of the string axis
   cout << "String axis knots:";
   for (auto& knot : grid.getAxis<STRING_AXIS>()) {
     cout << " " << knot;
   }
   cout << "\n";
-  
+
   // Get an iterator and fix two axes
   auto iter = grid.begin();
   iter.fixAxisByValue<STRING_AXIS>("two").fixAxisByIndex<INT_AXIS>(3);
-  
+
   // Print some info about each cell
   do {
     cout << "Double axis coord: " << iter.axisIndex<DOUBLE_AXIS>() << "\n";
     cout << "Double axis knot value: " << iter.axisValue<DOUBLE_AXIS>() << "\n";
   } while (++iter != grid.end());
-  
+
   // Write the grid in a string stream and then read it back
   stringstream stream {};
   gridBinaryExport(stream, grid);
   auto stream_grid = myBinaryImport<int>(stream);
-  
+
   // Create a grid to keep strings
   MyGridContainer<string> string_grid = {grid.getAxesTuple()};
 \endcode
@@ -697,9 +756,9 @@ The GridCellManagerTraits must implement the following interfaces:
 
 - function GridCellManagerTraits::begin()<br/> Returns an iterator pointing to
   the first cell managed by the GridCellManager.
- 
+
 - function GridCellManagerTraits::end()<br/> Returns an iterator pointing right
-  after the last cell managed by the GridCellManager. 
+  after the last cell managed by the GridCellManager.
 
 - constant GridCellManagerTraits::enable_boost_serialize<br/> Indicates if the
   GridCellManager is boost serializable (as explained in the \ref serialization
@@ -891,20 +950,20 @@ MyGridContainer<T> myBinaryImport(istream& in) {
 // ///////////////////////////////////////////////////
 
 int main() {
-  
+
   // /////////////////////////////////////////
   // Creating GridAxis objects
   // /////////////////////////////////////////
   cout << "\nCreating GridAxis objects\n";
-  
+
   vector<int> knot_values {3000, 3500, 4000, 4500, 5000};
   GridAxis<int> wavelength_axis {"Wavelength", move(knot_values)};
-  
+
   // /////////////////////////////////////////
   // Using GridAxis objects
   // /////////////////////////////////////////
   cout << "\nUsing GridAxis objects\n";
-  
+
   // Getting the axis name
   cout << "Axis name : " << wavelength_axis.name() << "\n";
   // Getting the number of knots
@@ -917,61 +976,61 @@ int main() {
     cout << knot_value << " ";
   }
   cout << ")\n";
-  
+
   // /////////////////////////////////////////
   // Using custom GridCellManager
   // /////////////////////////////////////////
   cout << "\nUsing custom GridCellManager\n";
-  
+
   GridContainer<MemoryManager<double>, int> custom_dm_grid { wavelength_axis };
-  
+
   // /////////////////////////////////////////
   // Creating GridContainer objects
   // /////////////////////////////////////////
   cout << "\nCreating GridContainer objects\n";
-  
+
   // Create the axes descriptions
   GridAxis<int> int_axis {"Integers", {1, 2, 3, 4, 5}};
   GridAxis<double> double_axis {"Doubles", {0.1, 0.2}};
   GridAxis<string> string_axis {"Strings", {"one", "two", "three"}};
-  
+
   // Create a grid with integer data
   GridContainer<vector<int>, int, double, string> grid {int_axis, double_axis, string_axis};
 
   // Create grid with same parameter space
   GridContainer<vector<bool>, int, double, string> bool_grid {grid.getAxesTuple()};
-  
+
   // /////////////////////////////////////////
   // Retrieving GridContainer information
   // /////////////////////////////////////////
   cout << "\nRetrieving GridContainer information\n";
-  
+
   // Get the grid dimensionality
   cout << "Dimensionality: " << grid.axisNumber() << "\n";
-  
+
   // Get the total number of cells of the grid
   cout << "Total number of cells: " << grid.size() << "\n";
-  
+
   // Retrieve information about the third axis
   auto& third_axis = grid.getAxis<2>();
-  
+
   // Print the axis information
   cout << "Third axis name: " << third_axis.name() << "\n";
   cout << "Third axis knots: ";
   for (auto& knot : third_axis) {
     cout << knot << " ";
   }
-  
+
   // /////////////////////////////////////////
   // Direct cell access
   // /////////////////////////////////////////
   cout << "\nDirect cell access\n";
-  
+
   // Set the value of a specific cell
   grid(2, 0, 1) = 50;
   // Read the value of a specific cell
   cout << "GridContainer cell (2, 0, 1):" << grid(2, 0, 1) << "\n";
-  
+
   // Calling at() with in bounds coordinates
   size_t coord = 1;
   try {
@@ -982,7 +1041,7 @@ int main() {
   } catch (Elements::Exception e) {
     cout << e.what() << "\n";
   }
-  
+
   // Calling at() with out of bounds coordinates
   coord = 20;
   try {
@@ -998,7 +1057,7 @@ int main() {
   // GridContainer iterator
   // /////////////////////////////////////////
   cout << "\nGridContainer iterator\n";
-  
+
   // Set all the grid values
   int counter {0};
   for (auto& cell : grid) {
@@ -1010,7 +1069,7 @@ int main() {
     cout << cell << " ";
   }
   cout << '\n';
-  
+
   // Print detailed information for each cell
   for (auto iter=grid.begin(); iter!=grid.end(); ++iter) {
     cout << "Cell (" << iter.axisValue<0>() << ", " << iter.axisValue<1>()
@@ -1021,22 +1080,22 @@ int main() {
   // GridContainer slicing
   // /////////////////////////////////////////
   cout << "\nGridContainer slicing\n";
-  
+
   // Get an iterator and fix the third axis
   cout << "One axis fixed\n";
   auto iter = grid.begin();
   iter.fixAxisByValue<2>("two");
-  
+
   // Print detailed information for each cell
   do {
     cout << "Cell (" << iter.axisValue<0>() << ", " << iter.axisValue<1>()
          << ", " << iter.axisValue<2>() << "): " << *iter << "\n";
   } while (++iter != grid.end());
-  
+
   cout << "Three axes fixed\n";
   iter = grid.begin();
   iter.fixAxisByValue<2>("two").fixAxisByIndex<0>(2).fixAxisByValue<1>(.1);
-  
+
   // Print detailed information for each cell
   do {
     cout << "Cell (" << iter.axisValue<0>() << ", " << iter.axisValue<1>()
@@ -1047,7 +1106,7 @@ int main() {
   // Default GridContainer Serialization
   // /////////////////////////////////////////
   cout << "\nDefault GridContainer Serialization\n";
-  
+
   stringstream stream {};
   gridBinaryExport(stream, grid);
   auto stream_grid = gridBinaryImport<vector<int>, int, double, string>(stream);
@@ -1056,7 +1115,7 @@ int main() {
   // Using specialized GridContainer types
   // /////////////////////////////////////////
   cout << "\nUsing specialized GridContainer types\n";
-  
+
   // Create a grid with integer data
   MyGridContainer<int> spec_grid {int_axis, double_axis, string_axis};
   // Print all the nodes of the string axis
@@ -1078,7 +1137,7 @@ int main() {
   auto stream_spec_grid = myBinaryImport<int>(stream);
   // Create a grid to keep strings
   MyGridContainer<string> string_grid = {stream_spec_grid.getAxesTuple()};
-  
+
 }
 \endcode
 

--- a/GridContainer/tests/src/GridContainerToTable_test.cpp
+++ b/GridContainer/tests/src/GridContainerToTable_test.cpp
@@ -62,7 +62,7 @@ struct CellWithAttributes {
 
 namespace Euclid { namespace GridContainer {
 template<>
-struct Cell2FitsTrait<CellWithAttributes> {
+struct GridCellToTable<CellWithAttributes> {
   static void addColumnDescriptions(const CellWithAttributes&, std::vector<Euclid::Table::ColumnDescription>& columns) {
     columns.emplace_back("MyFlux", typeid(double));
     columns.emplace_back("MyError", typeid(double));

--- a/GridContainer/tests/src/GridContainerToTable_test.cpp
+++ b/GridContainer/tests/src/GridContainerToTable_test.cpp
@@ -60,8 +60,9 @@ struct CellWithAttributes {
   std::string description;
 };
 
+namespace Euclid { namespace GridContainer {
 template<>
-struct Euclid::GridContainer::Cell2FitsTrait<CellWithAttributes> {
+struct Cell2FitsTrait<CellWithAttributes> {
   static void addColumnDescriptions(const CellWithAttributes&, std::vector<Euclid::Table::ColumnDescription>& columns) {
     columns.emplace_back("MyFlux", typeid(double));
     columns.emplace_back("MyError", typeid(double));
@@ -74,6 +75,7 @@ struct Euclid::GridContainer::Cell2FitsTrait<CellWithAttributes> {
     row.emplace_back(c.description);
   }
 };
+}}
 
 struct ComposedGridContainer_Fixture {
   typedef GridContainer<std::vector<CellWithAttributes>, int, int, std::string, float> GridContainerType;

--- a/GridContainer/tests/src/GridContainerToTable_test.cpp
+++ b/GridContainer/tests/src/GridContainerToTable_test.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <cmath>
+#include "GridContainer/GridContainerToTable.h"
+
+using namespace Euclid::GridContainer;
+
+struct SimpleGridContainer_Fixture {
+  typedef GridContainer<std::vector<double>, int, int, std::string, float> GridContainerType;
+  typedef GridAxis<int> IntAxis;
+  typedef GridAxis<std::string> StrAxis;
+  typedef GridAxis<float> FloatAxis;
+  IntAxis axis1{"Axis 1", {1, 2, 3, 4, 5}};
+  IntAxis axis2{"Axis 2", {1, 2, 3}};
+  StrAxis axis3{"Axis 3", {"a", "b", "c", "d", "e", "f"}};
+  FloatAxis axis4{"Axis 4", {1, 2}};
+  std::tuple<IntAxis, IntAxis, StrAxis, FloatAxis> axes_tuple{axis1, axis2, axis3, axis4};
+
+  GridContainerType grid{axis1, axis2, axis3, axis4};
+
+  double Fx(int ax1, int ax2, const std::string& ax3, float ax4) {
+    return ax1 * 1000 + ax2 * 100 + (ax3[0] - 'a') * 10 + ax4;
+  }
+
+  SimpleGridContainer_Fixture() {
+    for (size_t a1 = 0; a1 < axis1.size(); ++a1) {
+      for (size_t a2 = 0; a2 < axis2.size(); ++a2) {
+        for (size_t a3 = 0; a3 < axis3.size(); ++a3) {
+          for (size_t a4 = 0; a4 < axis4.size(); ++a4) {
+            grid.at(a1, a2, a3, a4) = Fx(axis1[a1], axis2[a2], axis3[a3], axis4[a4]);
+          }
+        }
+      }
+    }
+  }
+};
+
+struct CellWithAttributes {
+  double flux, error;
+  std::string description;
+};
+
+namespace Euclid {
+namespace GridContainer {
+template<>
+struct Cell2FitsTrait<CellWithAttributes> {
+  static void addColumnDescriptions(const CellWithAttributes&, std::vector<Euclid::Table::ColumnDescription>& columns) {
+    columns.emplace_back("MyFlux", typeid(double));
+    columns.emplace_back("MyError", typeid(double));
+    columns.emplace_back("MyDescription", typeid(std::string));
+  }
+
+  static void addCells(const CellWithAttributes& c, std::vector<Euclid::Table::Row::cell_type>& row) {
+    row.emplace_back(c.flux);
+    row.emplace_back(c.error);
+    row.emplace_back(c.description);
+  }
+};
+}
+}
+
+struct ComposedGridContainer_Fixture {
+  typedef GridContainer<std::vector<CellWithAttributes>, int, int, std::string, float> GridContainerType;
+  typedef GridAxis<int> IntAxis;
+  typedef GridAxis<std::string> StrAxis;
+  typedef GridAxis<float> FloatAxis;
+  IntAxis axis1{"Axis 1", {1, 2, 3, 4, 5}};
+  IntAxis axis2{"Axis 2", {1, 2, 3}};
+  StrAxis axis3{"Axis 3", {"a", "b", "c", "d", "e", "f"}};
+  FloatAxis axis4{"Axis 4", {1, 2}};
+  std::tuple<IntAxis, IntAxis, StrAxis, FloatAxis> axes_tuple{axis1, axis2, axis3, axis4};
+
+  GridContainerType grid{axis1, axis2, axis3, axis4};
+
+  double Fx(int ax1, int ax2, const std::string& ax3, float ax4) {
+    return ax1 * 1000 + ax2 * 100 + (ax3[0] - 'a') * 10 + ax4;
+  }
+
+  ComposedGridContainer_Fixture() {
+    for (size_t a1 = 0; a1 < axis1.size(); ++a1) {
+      for (size_t a2 = 0; a2 < axis2.size(); ++a2) {
+        for (size_t a3 = 0; a3 < axis3.size(); ++a3) {
+          for (size_t a4 = 0; a4 < axis4.size(); ++a4) {
+            CellWithAttributes c;
+            c.flux = Fx(axis1[a1], axis2[a2], axis3[a3], axis4[a4]);
+            c.error = std::sqrt(c.flux);
+            c.description = std::string(a4 + 1, 'x');
+            grid.at(a1, a2, a3, a4) = c;
+          }
+        }
+      }
+    }
+  }
+};
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE (GridToTable_test)
+
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(SimpleToTable, SimpleGridContainer_Fixture) {
+  auto table = gridContainerToTable(grid);
+
+  BOOST_CHECK_EQUAL(grid.size(), table.size());
+
+  auto column_info = table.getColumnInfo();
+
+  auto axis1_col = column_info->getDescription("Axis_1");
+  BOOST_CHECK(std::type_index(typeid(int)) == axis1_col.type);
+
+  auto axis2_col = column_info->getDescription("Axis_2");
+  BOOST_CHECK(std::type_index(typeid(int)) == axis2_col.type);
+
+  auto axis3_col = column_info->getDescription("Axis_3");
+  BOOST_CHECK(std::type_index(typeid(std::string)) == axis3_col.type);
+
+  auto axis4_col = column_info->getDescription("Axis_4");
+  BOOST_CHECK(std::type_index(typeid(float)) == axis4_col.type);
+
+  auto cell_col = column_info->getDescription("value");
+  BOOST_CHECK(std::type_index(typeid(double)) == cell_col.type);
+
+  // The order is not so important as to keep the proper values together!
+  for (auto& row: table) {
+    auto ax1 = boost::get<int>(row["Axis_1"]);
+    auto ax2 = boost::get<int>(row["Axis_2"]);
+    auto ax3 = boost::get<std::string>(row["Axis_3"]);
+    auto ax4 = boost::get<float>(row["Axis_4"]);
+    double v = Fx(ax1, ax2, ax3, ax4);
+    BOOST_CHECK_CLOSE(boost::get<double>(row["value"]), v, 1e-7);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(ComposedToTable, ComposedGridContainer_Fixture) {
+  auto table = gridContainerToTable(grid);
+
+  BOOST_CHECK_EQUAL(grid.size(), table.size());
+
+  auto column_info = table.getColumnInfo();
+
+  auto axis1_col = column_info->getDescription("Axis_1");
+  BOOST_CHECK(std::type_index(typeid(int)) == axis1_col.type);
+
+  auto axis2_col = column_info->getDescription("Axis_2");
+  BOOST_CHECK(std::type_index(typeid(int)) == axis2_col.type);
+
+  auto axis3_col = column_info->getDescription("Axis_3");
+  BOOST_CHECK(std::type_index(typeid(std::string)) == axis3_col.type);
+
+  auto axis4_col = column_info->getDescription("Axis_4");
+  BOOST_CHECK(std::type_index(typeid(float)) == axis4_col.type);
+
+  auto flux_col = column_info->getDescription("MyFlux");
+  BOOST_CHECK(std::type_index(typeid(double)) == flux_col.type);
+
+  auto fluxerr_col = column_info->getDescription("MyError");
+  BOOST_CHECK(std::type_index(typeid(double)) == fluxerr_col.type);
+
+  auto descr_col = column_info->getDescription("MyDescription");
+  BOOST_CHECK(std::type_index(typeid(std::string)) == descr_col.type);
+
+  // The order is not so important as to keep the proper values together!
+  for (auto& row: table) {
+    auto ax1 = boost::get<int>(row["Axis_1"]);
+    auto ax2 = boost::get<int>(row["Axis_2"]);
+    auto ax3 = boost::get<std::string>(row["Axis_3"]);
+    auto ax4 = boost::get<float>(row["Axis_4"]);
+    double v = Fx(ax1, ax2, ax3, ax4);
+    BOOST_CHECK_CLOSE(boost::get<double>(row["MyFlux"]), v, 1e-7);
+    BOOST_CHECK_CLOSE(boost::get<double>(row["MyError"]), std::sqrt(v), 1e-7);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//-----------------------------------------------------------------------------

--- a/GridContainer/tests/src/GridContainerToTable_test.cpp
+++ b/GridContainer/tests/src/GridContainerToTable_test.cpp
@@ -16,6 +16,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <string>
+#include <tuple>
+#include <vector>
 #include <boost/test/unit_test.hpp>
 #include <cmath>
 #include "GridContainer/GridContainerToTable.h"
@@ -57,10 +60,8 @@ struct CellWithAttributes {
   std::string description;
 };
 
-namespace Euclid {
-namespace GridContainer {
 template<>
-struct Cell2FitsTrait<CellWithAttributes> {
+struct Euclid::GridContainer::Cell2FitsTrait<CellWithAttributes> {
   static void addColumnDescriptions(const CellWithAttributes&, std::vector<Euclid::Table::ColumnDescription>& columns) {
     columns.emplace_back("MyFlux", typeid(double));
     columns.emplace_back("MyError", typeid(double));
@@ -73,8 +74,6 @@ struct Cell2FitsTrait<CellWithAttributes> {
     row.emplace_back(c.description);
   }
 };
-}
-}
 
 struct ComposedGridContainer_Fixture {
   typedef GridContainer<std::vector<CellWithAttributes>, int, int, std::string, float> GridContainerType;

--- a/Table/Table/ColumnInfo.h
+++ b/Table/Table/ColumnInfo.h
@@ -1,21 +1,21 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
+
  /**
  * @file Table/ColumnInfo.h
  * @date April 7, 2014
@@ -103,7 +103,7 @@ public:
    * @return the number of columns
    */
   std::size_t size() const;
-  
+
   /**
    * @brief
    * Returns the description of the column with the given index or throws an
@@ -115,6 +115,18 @@ public:
    *    if the index is out of bounds
    */
   const ColumnDescription& getDescription(std::size_t index) const;
+
+  /**
+   * @brief
+   * Returns the description of the column with the given name or throws an
+   * exception if column does not exist
+   *
+   * @param name The name to search for
+   * @return The description of the column
+   * @throws Elements::Exception
+   *    if the index is out of bounds
+   */
+  const ColumnDescription& getDescription(const std::string& name) const;
 
   /**
    * @brief

--- a/Table/src/lib/ColumnInfo.cpp
+++ b/Table/src/lib/ColumnInfo.cpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+ /**
  * @file src/lib/ColumnInfo.cpp
  * @date April 7, 2014
  * @author Nikolaos Apostolakos
@@ -66,6 +66,14 @@ const ColumnDescription& ColumnInfo::getDescription(std::size_t index) const {
   return m_info_list[index];
 }
 
+const ColumnDescription& ColumnInfo::getDescription(const std::string& name) const {
+  auto iter = std::find_if(m_info_list.begin(), m_info_list.end(),
+                           [&name](const info_type& info) { return info.name == name; });
+  if (iter == m_info_list.end()) {
+    throw Elements::Exception() << "Column " << name << " does not exist";
+  }
+  return *iter;
+}
 
 std::unique_ptr<size_t> ColumnInfo::find(const std::string& name) const {
   auto begin = m_info_list.begin();
@@ -73,7 +81,7 @@ std::unique_ptr<size_t> ColumnInfo::find(const std::string& name) const {
   auto iter = std::find_if(begin, end, [&name](const info_type& info){return info.name == name;});
   if (iter != end) {
     size_t index {static_cast<size_t>(std::distance(begin, iter))};
-    return std::unique_ptr<size_t> {new size_t {index}}; 
+    return std::unique_ptr<size_t> {new size_t {index}};
   }
   return std::unique_ptr<size_t> {};
 }


### PR DESCRIPTION
This feature allows unfolding a grid container into a Table, which can be written to a FITS file, for instance.

This is related to [#20930](https://redmine.isdc.unige.ch/issues/20930)

The idea behind is to get access to model grids (i.e. the not-scaled photometry computed by Phosphoros), which I think is a reasonable use case, also for debugging.