### PR TITLE
Piecewise function: use unique_ptr

### DIFF
--- a/MathUtils/MathUtils/function/Piecewise.h
+++ b/MathUtils/MathUtils/function/Piecewise.h
@@ -1,21 +1,21 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
+
  /**
  * @file MathUtils/function/Piecewise.h
  * @date February 20, 2014
@@ -64,6 +64,8 @@ public:
    */
   Piecewise(std::vector<double> knots, std::vector<std::shared_ptr<Function>> functions);
 
+  Piecewise(std::vector<double> knots, std::vector<std::unique_ptr<Function>>&& functions);
+
   /// Default destructor
   virtual ~Piecewise() = default;
 
@@ -71,7 +73,7 @@ public:
   const std::vector<double>& getKnots() const;
 
   /// Returns the functions in the ranges between the knots
-  const std::vector<std::shared_ptr<Function>>& getFunctions() const;
+  const std::vector<std::unique_ptr<Function>>& getFunctions() const;
 
   /// Returns the value of the piecewise function for the given value, by using
   /// the correct sub-function. Values outside of the knots evaluate to zero.
@@ -95,7 +97,7 @@ private:
   /// A vector where the knots are kept
   std::vector<double> m_knots;
   /// A vector where the sub-functions are kept
-  std::vector<std::shared_ptr<Function>> m_functions;
+  std::vector<std::unique_ptr<Function>> m_functions;
 
 };
 

--- a/MathUtils/src/lib/function/multiplication.cpp
+++ b/MathUtils/src/lib/function/multiplication.cpp
@@ -1,21 +1,21 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
+
  /**
  * @file src/lib/function/multiplication.cpp
  * @date February 19, 2014
@@ -52,7 +52,7 @@ std::unique_ptr<Function> multiplyPolynomials(const Function& f1, const Function
 std::unique_ptr<Function> multiplyPiecewiseWithGeneric(const Function& f1, const Function& f2) {
   const Piecewise& piecewise = dynamic_cast<const Piecewise&>(f1);
   std::vector<std::shared_ptr<Function>> functions {};
-  for (auto original : piecewise.getFunctions()) {
+  for (auto& original : piecewise.getFunctions()) {
     functions.push_back(std::shared_ptr<Function>{Euclid::MathUtils::multiply(*original, f2).release()});
   }
   return std::unique_ptr<Function>(new Piecewise {piecewise.getKnots(), functions});
@@ -100,8 +100,8 @@ std::unique_ptr<Function> multiplyPiecewises(const Function& f1, const Function&
   }
 
   std::vector<std::shared_ptr<Function>> functions {};
-  auto p1func = p1.getFunctions();
-  auto p2func = p2.getFunctions();
+  auto& p1func = p1.getFunctions();
+  auto& p2func = p2.getFunctions();
   int i1 {};
   int i2 {};
   for (double knot : knots) {

--- a/MathUtils/src/lib/interpolation/interpolation.cpp
+++ b/MathUtils/src/lib/interpolation/interpolation.cpp
@@ -52,10 +52,14 @@ std::unique_ptr<Function> interpolate(const std::vector<double>& x, const std::v
 
   // We remove any duplicate lines and we check that we have only increasing
   // X values and no step functions
-  std::vector<double> final_x {};
-  std::vector<double> final_y {};
-  final_x.push_back(x[0]);
-  final_y.push_back(y[0]);
+  std::vector<double> final_x;
+  std::vector<double> final_y;
+
+  final_x.reserve(x.size());
+  final_y.reserve(x.size());
+
+  final_x.emplace_back(x[0]);
+  final_y.emplace_back(y[0]);
   for (std::size_t i = 1; i < x.size(); ++i) {
     if (x[i] == x[i-1]) {
       if (y[i] == y[i-1]) {
@@ -72,8 +76,8 @@ std::unique_ptr<Function> interpolate(const std::vector<double>& x, const std::v
       throw InterpolationException() << "Only increasing X values are supported "
               << "but found " << x[i] << " after " << x[i-1];
     }
-  final_x.push_back(x[i]);
-  final_y.push_back(y[i]);
+    final_x.emplace_back(x[i]);
+    final_y.emplace_back(y[i]);
   }
 
   switch (type) {
@@ -87,11 +91,13 @@ std::unique_ptr<Function> interpolate(const std::vector<double>& x, const std::v
 
 std::unique_ptr<Function> interpolate(const Euclid::XYDataset::XYDataset& dataset, InterpolationType type,
                                       bool extrapolate) {
-  std::vector<double> x {};
-  std::vector<double> y {};
+  std::vector<double> x;
+  std::vector<double> y;
+  x.reserve(dataset.size());
+  y.reserve(dataset.size());
   for (auto& pair : dataset) {
-    x.push_back(pair.first);
-    y.push_back(pair.second);
+    x.emplace_back(pair.first);
+    y.emplace_back(pair.second);
   }
   return interpolate(x, y, type, extrapolate);
 }

--- a/MathUtils/src/lib/interpolation/spline.cpp
+++ b/MathUtils/src/lib/interpolation/spline.cpp
@@ -79,9 +79,10 @@ std::unique_ptr<Function> splineInterpolation(const std::vector<double>& x, cons
     // d[i] keeps the same value
   }
 
-  std::vector<std::shared_ptr<Function>> functions {};
+  std::vector<std::shared_ptr<Function>> functions;
+  functions.reserve(n);
   for (int i=0; i<n; i++) {
-    functions.push_back(std::shared_ptr<Function>(new Polynomial{{a[i],b[i],c[i],d[i]}}));
+    functions.emplace_back(std::shared_ptr<Function>(new Polynomial{{a[i],b[i],c[i],d[i]}}));
   }
 
   if (extrapolate) {

--- a/MathUtils/src/lib/interpolation/spline.cpp
+++ b/MathUtils/src/lib/interpolation/spline.cpp
@@ -79,10 +79,10 @@ std::unique_ptr<Function> splineInterpolation(const std::vector<double>& x, cons
     // d[i] keeps the same value
   }
 
-  std::vector<std::shared_ptr<Function>> functions;
+  std::vector<std::unique_ptr<Function>> functions;
   functions.reserve(n);
   for (int i=0; i<n; i++) {
-    functions.emplace_back(std::shared_ptr<Function>(new Polynomial{{a[i],b[i],c[i],d[i]}}));
+    functions.emplace_back(std::unique_ptr<Function>(new Polynomial{{a[i],b[i],c[i],d[i]}}));
   }
 
   if (extrapolate) {

--- a/MathUtils/tests/src/function/Piecewise_test.cpp
+++ b/MathUtils/tests/src/function/Piecewise_test.cpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+ /**
  * @file tests/src/function/Piecewise_test.cpp
  * @date February 20, 2014
  * @author Nikolaos Apostolakos
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_SUITE (Piecewise_test)
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Constructor, Piecewise_Fixture) {
-  
+
   // Given
   std::vector<double> knots {-1.,-0.5,0.25,10.};
   std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
@@ -52,16 +52,13 @@ BOOST_FIXTURE_TEST_CASE(Constructor, Piecewise_Fixture) {
     functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(knot)));
   }
   functions.pop_back();
-  
+
   // When
   Euclid::MathUtils::Piecewise piecewise{knots, functions};
   auto resKnots = piecewise.getKnots();
-  auto resFuncs = piecewise.getFunctions();
-  
+
   // Then
   BOOST_CHECK_EQUAL_COLLECTIONS(resKnots.begin(), resKnots.end(), knots.begin(), knots.end());
-  BOOST_CHECK_EQUAL_COLLECTIONS(resFuncs.begin(), resFuncs.end(), functions.begin(), functions.end());
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -69,7 +66,7 @@ BOOST_FIXTURE_TEST_CASE(Constructor, Piecewise_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(ConstructorUnorderedKnots, Piecewise_Fixture) {
-  
+
   // Given
   std::vector<double> knots {-1.,0.5,0.25,10.};
   std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
@@ -77,10 +74,10 @@ BOOST_FIXTURE_TEST_CASE(ConstructorUnorderedKnots, Piecewise_Fixture) {
     functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(knot)));
   }
   functions.pop_back();
-  
+
   // Then
   BOOST_CHECK_THROW(Euclid::MathUtils::Piecewise(knots, functions), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -88,17 +85,17 @@ BOOST_FIXTURE_TEST_CASE(ConstructorUnorderedKnots, Piecewise_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(ConstructorWrongSizes, Piecewise_Fixture) {
-  
+
   // Given
   std::vector<double> knots {-1.,-0.5,0.25,10.};
   std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
   for (double knot : knots) {
     functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(knot)));
   }
-  
+
   // Then
   BOOST_CHECK_THROW(Euclid::MathUtils::Piecewise(knots, functions), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -106,7 +103,7 @@ BOOST_FIXTURE_TEST_CASE(ConstructorWrongSizes, Piecewise_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Clone, Piecewise_Fixture) {
-  
+
   // Given
   std::vector<double> knots {-1.,-0.5,0.25,10.};
   std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
@@ -115,19 +112,16 @@ BOOST_FIXTURE_TEST_CASE(Clone, Piecewise_Fixture) {
   }
   functions.pop_back();
   Euclid::MathUtils::Piecewise piecewise{knots, functions};
-  
+
   // When
   auto clonePtr = piecewise.clone();
-  
+
   // Then
   BOOST_CHECK(clonePtr);
   Euclid::MathUtils::Piecewise* resPiece = dynamic_cast<Euclid::MathUtils::Piecewise*>(clonePtr.get());
   BOOST_CHECK(resPiece);
   auto resKnots = resPiece->getKnots();
-  auto resFuncs = resPiece->getFunctions();
   BOOST_CHECK_EQUAL_COLLECTIONS(resKnots.begin(), resKnots.end(), knots.begin(), knots.end());
-  BOOST_CHECK_EQUAL_COLLECTIONS(resFuncs.begin(), resFuncs.end(), functions.begin(), functions.end());
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -135,7 +129,7 @@ BOOST_FIXTURE_TEST_CASE(Clone, Piecewise_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(FunctionOperator, Piecewise_Fixture) {
-  
+
   // Given
   std::vector<double> knots {-1.,-0.5,0.25,10.};
   std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
@@ -143,10 +137,10 @@ BOOST_FIXTURE_TEST_CASE(FunctionOperator, Piecewise_Fixture) {
     functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(knot)));
   }
   functions.pop_back();
-  
+
   // When
   Euclid::MathUtils::Piecewise piecewise{knots, functions};
-  
+
   // Then
   BOOST_CHECK_SMALL(piecewise(-2.), small_tolerance);
   BOOST_CHECK_CLOSE(piecewise(-1.), -1., close_tolerance);
@@ -157,7 +151,7 @@ BOOST_FIXTURE_TEST_CASE(FunctionOperator, Piecewise_Fixture) {
   BOOST_CHECK_CLOSE(piecewise(5.), .25, close_tolerance);
   BOOST_CHECK_CLOSE(piecewise(10.), .25, close_tolerance);
   BOOST_CHECK_SMALL(piecewise(11.), small_tolerance);
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -165,7 +159,7 @@ BOOST_FIXTURE_TEST_CASE(FunctionOperator, Piecewise_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(IntegrateInRange, Piecewise_Fixture) {
-  
+
   // Given
   std::vector<double> knots {-1.,0.,1.,2.};
   std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
@@ -173,7 +167,7 @@ BOOST_FIXTURE_TEST_CASE(IntegrateInRange, Piecewise_Fixture) {
   functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(2.)));
   functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(1.)));
   Euclid::MathUtils::Piecewise piecewise{knots, functions};
-  
+
   // When
   double integral1 = piecewise.integrate(-1., 2.);
   double integral2 = piecewise.integrate(-.5, .5);
@@ -185,7 +179,7 @@ BOOST_FIXTURE_TEST_CASE(IntegrateInRange, Piecewise_Fixture) {
   double integral8 = piecewise.integrate(.5, -.5);
   double integral9 = piecewise.integrate(1.5, -.5);
   double integral10 = piecewise.integrate(1., 0.);
-  
+
   // Then
   BOOST_CHECK_CLOSE(integral1, 4., close_tolerance);
   BOOST_CHECK_CLOSE(integral2, 1.5, close_tolerance);
@@ -197,7 +191,7 @@ BOOST_FIXTURE_TEST_CASE(IntegrateInRange, Piecewise_Fixture) {
   BOOST_CHECK_CLOSE(integral8, -1.5, close_tolerance);
   BOOST_CHECK_CLOSE(integral9, -3., close_tolerance);
   BOOST_CHECK_CLOSE(integral10, -2., close_tolerance);
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -205,7 +199,7 @@ BOOST_FIXTURE_TEST_CASE(IntegrateInRange, Piecewise_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(IntegrateOutOfRange, Piecewise_Fixture) {
-  
+
   // Given
   std::vector<double> knots {-1.,0.,1.,2.};
   std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
@@ -213,21 +207,21 @@ BOOST_FIXTURE_TEST_CASE(IntegrateOutOfRange, Piecewise_Fixture) {
   functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(2.)));
   functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(1.)));
   Euclid::MathUtils::Piecewise piecewise{knots, functions};
-  
+
   // When
   double integral1 = piecewise.integrate(-5., 10.);
   double integral2 = piecewise.integrate(-5., .5);
   double integral3 = piecewise.integrate(.5, 10.);
   double integral4 = piecewise.integrate(-5., -4.);
   double integral5 = piecewise.integrate(8., 9.);
-  
+
   // Then
   BOOST_CHECK_CLOSE(integral1, 4., close_tolerance);
   BOOST_CHECK_CLOSE(integral2, 2., close_tolerance);
   BOOST_CHECK_CLOSE(integral3, 2., close_tolerance);
   BOOST_CHECK_SMALL(integral4, small_tolerance);
   BOOST_CHECK_SMALL(integral5, small_tolerance);
-  
+
 }
 
 //-----------------------------------------------------------------------------

--- a/MathUtils/tests/src/interpolation/Spline_test.cpp
+++ b/MathUtils/tests/src/interpolation/Spline_test.cpp
@@ -79,12 +79,12 @@ BOOST_FIXTURE_TEST_CASE(fx, Spline_Fixture) {
 BOOST_FIXTURE_TEST_CASE(Spline_fx, Spline_Fixture) {
   auto cubic_f = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
   auto cubic_pieces = dynamic_cast<Piecewise *>(cubic_f.get());
-  auto splines = cubic_pieces->getFunctions();
+  auto& splines = cubic_pieces->getFunctions();
 
   for (size_t i = 0; i < splines.size() - 1; ++i) {
     auto x0 = x[i + 1];
-    auto left = splines[i];
-    auto right = splines[i + 1];
+    auto& left = splines[i];
+    auto& right = splines[i + 1];
     BOOST_CHECK_CLOSE((*left)(x0), (*right)(x0), close_tolerance);
     BOOST_CHECK_CLOSE((*left)(x0), y[i + 1], close_tolerance);
   }
@@ -96,12 +96,12 @@ BOOST_FIXTURE_TEST_CASE(Spline_fx, Spline_Fixture) {
 BOOST_FIXTURE_TEST_CASE(Spline_dfx, Spline_Fixture) {
   auto cubic_f = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
   auto cubic_pieces = dynamic_cast<Piecewise *>(cubic_f.get());
-  auto splines = cubic_pieces->getFunctions();
+  auto& splines = cubic_pieces->getFunctions();
 
   for (size_t i = 0; i < splines.size() - 1; ++i) {
     auto x0 = x[i + 1];
-    auto left = splines[i];
-    auto right = splines[i + 1];
+    auto& left = splines[i];
+    auto& right = splines[i + 1];
 
     auto left_dy = derivative(*left, x0);
     auto right_dy = derivative(*right, x0);
@@ -119,12 +119,12 @@ BOOST_FIXTURE_TEST_CASE(Spline_ddfx, Spline_Fixture) {
 
   auto cubic_f = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
   auto cubic_pieces = dynamic_cast<Piecewise *>(cubic_f.get());
-  auto splines = cubic_pieces->getFunctions();
+  auto& splines = cubic_pieces->getFunctions();
 
   for (size_t i = 0; i < splines.size() - 1; ++i) {
     auto x0 = x[i + 1];
-    auto left = splines[i];
-    auto right = splines[i + 1];
+    auto& left = splines[i];
+    auto& right = splines[i + 1];
 
     auto left_ddy = derivative2nd(*left, x0);
     auto right_ddy = derivative2nd(*right, x0);
@@ -145,10 +145,10 @@ BOOST_FIXTURE_TEST_CASE(Spline_ddfx, Spline_Fixture) {
 BOOST_FIXTURE_TEST_CASE(Spline_ddfx_endpoint, Spline_Fixture) {
   auto cubic_f = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
   auto cubic_pieces = dynamic_cast<Piecewise *>(cubic_f.get());
-  auto splines = cubic_pieces->getFunctions();
+  auto& splines = cubic_pieces->getFunctions();
 
-  auto left = splines.front();
-  auto right = splines.back();
+  auto& left = splines.front();
+  auto& right = splines.back();
 
   auto left_ddy = derivative2nd(*left, x.front());
   auto right_ddy = derivative2nd(*right, x.back());


### PR DESCRIPTION
Profiling shows a non-neglegible effect of the destruction of shared_ptr
when using this code inside SourceXtractor++

Does not affect Phosphoros.