### PR TITLE
Lift restrictions on whitespace

### DIFF
--- a/Table/src/lib/AsciiWriterHelper.h
+++ b/Table/src/lib/AsciiWriterHelper.h
@@ -1,21 +1,21 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
+
  /**
  * @file src/lib/AsciiWriterHelper.h
  * @date April 16, 2014
@@ -27,6 +27,7 @@
 
 #include <vector>
 #include <typeindex>
+#include <boost/io/detail/quoted_manip.hpp>
 
 #include "ElementsKernel/Export.h"
 
@@ -58,6 +59,37 @@ ELEMENTS_API std::string typeToKeyword(std::type_index type);
  * @return  the sizes of the columns
  */
 ELEMENTS_API std::vector<size_t> calculateColumnLengths(const Table& table);
+
+/**
+ * Wrapper for boost::io::quoted
+ * @details
+ *  The wrapping is done for two reasons:
+ *      1. When setting the width of a column, only the starting quote will be padded to the given width,
+ *         which breaks the expected alignment
+ *      2. For keeping known behaviour, quotes are added only if needed
+ * @param str
+ * @return
+ */
+std::string quoted(const std::string &str);
+
+/**
+ * This visitor will wrap strings between quotes so spaces (and quotes) can be
+ * used within strings. Other types will have their usual representation.
+ */
+struct ToStringVisitor : public boost::static_visitor<std::string> {
+  std::string operator()(const std::string& from) const {
+    std::stringstream q;
+    q << quoted(from);
+    return q.str();
+  }
+
+  template<typename T>
+  std::string operator()(const T& from) const {
+    std::stringstream q;
+    q << from;
+    return q.str();
+  }
+};
 
 }
 } // end of namespace Euclid

--- a/Table/src/lib/ColumnDescription.cpp
+++ b/Table/src/lib/ColumnDescription.cpp
@@ -42,9 +42,9 @@ ColumnDescription::ColumnDescription(std::string name, std::type_index type,
     if (name.empty()) {
       throw Elements::Exception() << "Empty string name is not allowed";
     }
-    if (regex_match(name, regex{".*\\s.*"})) {
+    if (regex_match(name, regex{".*\\v.*"})) {
       throw Elements::Exception() << "Column name '" << name << "' contains "
-                                << "whitespace characters";
+                                << "vertical whitespace characters";
     }
 }
 

--- a/Table/src/lib/Row.cpp
+++ b/Table/src/lib/Row.cpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+ /**
  * @file src/lib/Row.cpp
  * @date April 8, 2014
  * @author Nikolaos Apostolakos
@@ -85,16 +85,16 @@ Row::Row(std::vector<cell_type> values, std::shared_ptr<ColumnInfo> column_info)
                                   << ", got " << demangle(value_type.name());
     }
   }
-  regex whitespace {".*\\s.*"}; // Checks if input contains any whitespace characters
+  regex vertical_whitespace {".*\\v.*"}; // Checks if input contains any vertical whitespace characters
   for (auto cell : m_values) {
     if (cell.type() == typeid(std::string)) {
       std::string value = boost::get<std::string>(cell);
       if (value.empty()) {
         throw Elements::Exception() << "Empty string cell values are not allowed";
       }
-      if (regex_match(value, whitespace)) {
+      if (regex_match(value, vertical_whitespace)) {
         throw Elements::Exception() << "Cell value '" << value << "' contains "
-                                  << "whitespace characters";
+                                  << "vertical whitespace characters";
       }
     }
   }

--- a/Table/tests/src/AsciiWriter_test.cpp
+++ b/Table/tests/src/AsciiWriter_test.cpp
@@ -34,7 +34,7 @@ using namespace Euclid::NdArray;
 struct AsciiWriter_Fixture {
   std::vector<ColumnInfo::info_type> info_list {
       ColumnInfo::info_type("Boolean", typeid(bool), "unit1", "Desc1"),
-      ColumnInfo::info_type("ThisIsAVeryLongColumnName", typeid(std::string)),
+      ColumnInfo::info_type("A Long Column Name", typeid(std::string)),
       ColumnInfo::info_type("Integer", typeid(int32_t), "unit3"),
       ColumnInfo::info_type("D", typeid(double), "", "Desc4"),
       ColumnInfo::info_type("F", typeid(float)),
@@ -43,13 +43,13 @@ struct AsciiWriter_Fixture {
   };
   std::shared_ptr<ColumnInfo> column_info {new ColumnInfo {info_list}};
   std::vector<Row::cell_type> values0 {
-    true, std::string{"Two-1"}, 1, 4.1, 0.f, std::vector<double>{1.1, 1.2}, NdArray<double>{{2,2}, {1,2,3,4}}};
+    true, std::string{"Two 1"}, 1, 4.1, 0.f, std::vector<double>{1.1, 1.2}, NdArray<double>{{2,2}, {1,2,3,4}}};
   Row row0 {values0, column_info};
   std::vector<Row::cell_type> values1 {
-    false, std::string{"Two-2"}, 1234567890, 42e-16, 0.f, std::vector<double>{2.1, 2.2}, NdArray<double>{{2,2}, {9,8,7,6}}};
+    false, std::string{"Two 2"}, 1234567890, 42e-16, 0.f, std::vector<double>{2.1, 2.2}, NdArray<double>{{2,2}, {9,8,7,6}}};
   Row row1 {values1, column_info};
   std::vector<Row::cell_type> values2 {
-    true, std::string{"Two-3"}, 234, 4.3, 0.f, std::vector<double>{3.1, 3.2, 3.3, 3.4}, NdArray<double>{{2,2}, {1,3,5,7}}};
+    true, std::string{"Two 3"}, 234, 4.3, 0.f, std::vector<double>{3.1, 3.2, 3.3, 3.4}, NdArray<double>{{2,2}, {1,3,5,7}}};
   Row row2 {values2, column_info};
   std::vector<Row> row_list {row0, row1, row2};
   Table table {row_list};
@@ -79,44 +79,6 @@ BOOST_AUTO_TEST_CASE(EmptyCommentIndicator) {
 }
 
 //-----------------------------------------------------------------------------
-// ASCII format does not support spaces on the column names
-//-----------------------------------------------------------------------------
-
-BOOST_AUTO_TEST_CASE(SpaceColumName) {
-  auto column_info = std::make_shared<ColumnInfo>(std::vector<ColumnInfo::info_type>{
-    {"Name With Spaces", typeid(int)}
-  });
-
-  std::vector<Row::cell_type> values0{55};
-  Row row0{values0, column_info};
-  std::vector<Row> row_list{row0};
-  Table table{row_list};
-
-  std::stringstream stream;
-  AsciiWriter writer{stream};
-  BOOST_CHECK_THROW(writer.addData(table), Elements::Exception);
-}
-
-//-----------------------------------------------------------------------------
-// ASCII format does not support values with spaces
-//-----------------------------------------------------------------------------
-
-BOOST_AUTO_TEST_CASE(SpaceCellValue) {
-  auto column_info = std::make_shared<ColumnInfo>(std::vector<ColumnInfo::info_type>{
-    {"OkName", typeid(std::string)}
-  });
-
-  std::vector<Row::cell_type> values0{std::string("Value With Spaces")};
-  Row row0{values0, column_info};
-  std::vector<Row> row_list{row0};
-  Table table{row_list};
-
-  std::stringstream stream;
-  AsciiWriter writer{stream};
-  BOOST_CHECK_THROW(writer.addData(table), Elements::Exception);
-}
-
-//-----------------------------------------------------------------------------
 // Test the addData method
 //-----------------------------------------------------------------------------
 
@@ -135,36 +97,36 @@ BOOST_FIXTURE_TEST_CASE(addData, AsciiWriter_Fixture) {
 
   // Then
   BOOST_CHECK_EQUAL(stream_hash.str(),
-    "# Column: Boolean bool (unit1) - Desc1\n"
-    "# Column: ThisIsAVeryLongColumnName string\n"
-    "# Column: Integer int (unit3)\n"
-    "# Column: D double - Desc4\n"
-    "# Column: F float\n"
-    "# Column: DoubleVector [double]\n"
-    "# Column: NdArray [double+]\n"
-    "\n"
-    "# Boolean ThisIsAVeryLongColumnName    Integer       D F    DoubleVector      NdArray\n"
-    "\n"
-    "        1                     Two-1          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
-    "        0                     Two-2 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
-    "        1                     Two-3        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"
-  );
-  BOOST_CHECK_EQUAL(stream_double_slash.str(),
-    "// Column: Boolean bool (unit1) - Desc1\n"
-    "// Column: ThisIsAVeryLongColumnName string\n"
-    "// Column: Integer int (unit3)\n"
-    "// Column: D double - Desc4\n"
-    "// Column: F float\n"
-    "// Column: DoubleVector [double]\n"
-    "// Column: NdArray [double+]\n"
-    "\n"
-    "// Boolean ThisIsAVeryLongColumnName    Integer       D F    DoubleVector      NdArray\n"
-    "\n"
-    "         1                     Two-1          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
-    "         0                     Two-2 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
-    "         1                     Two-3        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"
-  );
+R"(# Column: Boolean bool (unit1) - Desc1
+# Column: "A Long Column Name" string
+# Column: Integer int (unit3)
+# Column: D double - Desc4
+# Column: F float
+# Column: DoubleVector [double]
+# Column: NdArray [double+]
 
+# Boolean "A Long Column Name"    Integer       D F    DoubleVector      NdArray
+
+        1              "Two 1"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4
+        0              "Two 2" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6
+        1              "Two 3"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7
+)");
+
+  BOOST_CHECK_EQUAL(stream_double_slash.str(),
+R"(// Column: Boolean bool (unit1) - Desc1
+// Column: "A Long Column Name" string
+// Column: Integer int (unit3)
+// Column: D double - Desc4
+// Column: F float
+// Column: DoubleVector [double]
+// Column: NdArray [double+]
+
+// Boolean "A Long Column Name"    Integer       D F    DoubleVector      NdArray
+
+         1              "Two 1"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4
+         0              "Two 2" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6
+         1              "Two 3"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7
+)");
 }
 
 //-----------------------------------------------------------------------------
@@ -188,20 +150,19 @@ BOOST_FIXTURE_TEST_CASE(addDataNoColumnInfo, AsciiWriter_Fixture) {
 
   // Then
   BOOST_CHECK_EQUAL(stream_hash.str(),
-    "# Boolean ThisIsAVeryLongColumnName    Integer       D F    DoubleVector      NdArray\n"
-    "\n"
-    "        1                     Two-1          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
-    "        0                     Two-2 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
-    "        1                     Two-3        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"
-  );
-  BOOST_CHECK_EQUAL(stream_double_slash.str(),
-    "// Boolean ThisIsAVeryLongColumnName    Integer       D F    DoubleVector      NdArray\n"
-    "\n"
-    "         1                     Two-1          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
-    "         0                     Two-2 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
-    "         1                     Two-3        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"
-  );
+R"(# Boolean "A Long Column Name"    Integer       D F    DoubleVector      NdArray
 
+        1              "Two 1"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4
+        0              "Two 2" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6
+        1              "Two 3"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7
+)");
+  BOOST_CHECK_EQUAL(stream_double_slash.str(),
+R"(// Boolean "A Long Column Name"    Integer       D F    DoubleVector      NdArray
+
+         1              "Two 1"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4
+         0              "Two 2" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6
+         1              "Two 3"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7
+)");
 }
 
 //-----------------------------------------------------------------------------
@@ -231,46 +192,43 @@ BOOST_FIXTURE_TEST_CASE(addDataComments, AsciiWriter_Fixture) {
 
   // Then
   BOOST_CHECK_EQUAL(stream_hash.str(),
-    "# First comment\n"
-    "# Second comment\n"
-    "\n"
-    "# Column: Boolean bool (unit1) - Desc1\n"
-    "# Column: ThisIsAVeryLongColumnName string\n"
-    "# Column: Integer int (unit3)\n"
-    "# Column: D double - Desc4\n"
-    "# Column: F float\n"
-    "# Column: DoubleVector [double]\n"
-    "# Column: NdArray [double+]\n"
-    "\n"
-    "# Boolean ThisIsAVeryLongColumnName    Integer       D F    DoubleVector      NdArray\n"
-    "\n"
-    "        1                     Two-1          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
-    "        0                     Two-2 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
-    "        1                     Two-3        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"
-  );
-  BOOST_CHECK_EQUAL(stream_double_slash.str(),
-    "// First comment\n"
-    "// Second comment\n"
-    "\n"
-    "// Column: Boolean bool (unit1) - Desc1\n"
-    "// Column: ThisIsAVeryLongColumnName string\n"
-    "// Column: Integer int (unit3)\n"
-    "// Column: D double - Desc4\n"
-    "// Column: F float\n"
-    "// Column: DoubleVector [double]\n"
-    "// Column: NdArray [double+]\n"
-    "\n"
-    "// Boolean ThisIsAVeryLongColumnName    Integer       D F    DoubleVector      NdArray\n"
-    "\n"
-    "         1                     Two-1          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
-    "         0                     Two-2 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
-    "         1                     Two-3        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"
-  );
+R"(# First comment
+# Second comment
 
+# Column: Boolean bool (unit1) - Desc1
+# Column: "A Long Column Name" string
+# Column: Integer int (unit3)
+# Column: D double - Desc4
+# Column: F float
+# Column: DoubleVector [double]
+# Column: NdArray [double+]
+
+# Boolean "A Long Column Name"    Integer       D F    DoubleVector      NdArray
+
+        1              "Two 1"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4
+        0              "Two 2" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6
+        1              "Two 3"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7
+)");
+  BOOST_CHECK_EQUAL(stream_double_slash.str(),
+R"(// First comment
+// Second comment
+
+// Column: Boolean bool (unit1) - Desc1
+// Column: "A Long Column Name" string
+// Column: Integer int (unit3)
+// Column: D double - Desc4
+// Column: F float
+// Column: DoubleVector [double]
+// Column: NdArray [double+]
+
+// Boolean "A Long Column Name"    Integer       D F    DoubleVector      NdArray
+
+         1              "Two 1"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4
+         0              "Two 2" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6
+         1              "Two 3"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7
+)");
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_SUITE_END ()
-
-

--- a/Table/tests/src/AsciiWriter_test.cpp
+++ b/Table/tests/src/AsciiWriter_test.cpp
@@ -65,17 +65,55 @@ BOOST_AUTO_TEST_SUITE (AsciiWriter_test)
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(EmptyCommentIndicator) {
-  
+
   // Given
   std::stringstream stream {};
   std::string comment = "";
-  
+
   // When
   AsciiWriter writer {stream};
-  
+
   // Then
   BOOST_CHECK_THROW(writer.setCommentIndicator(comment), Elements::Exception);
-  
+
+}
+
+//-----------------------------------------------------------------------------
+// ASCII format does not support spaces on the column names
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(SpaceColumName) {
+  auto column_info = std::make_shared<ColumnInfo>(std::vector<ColumnInfo::info_type>{
+    {"Name With Spaces", typeid(int)}
+  });
+
+  std::vector<Row::cell_type> values0{55};
+  Row row0{values0, column_info};
+  std::vector<Row> row_list{row0};
+  Table table{row_list};
+
+  std::stringstream stream;
+  AsciiWriter writer{stream};
+  BOOST_CHECK_THROW(writer.addData(table), Elements::Exception);
+}
+
+//-----------------------------------------------------------------------------
+// ASCII format does not support values with spaces
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(SpaceCellValue) {
+  auto column_info = std::make_shared<ColumnInfo>(std::vector<ColumnInfo::info_type>{
+    {"OkName", typeid(std::string)}
+  });
+
+  std::vector<Row::cell_type> values0{std::string("Value With Spaces")};
+  Row row0{values0, column_info};
+  std::vector<Row> row_list{row0};
+  Table table{row_list};
+
+  std::stringstream stream;
+  AsciiWriter writer{stream};
+  BOOST_CHECK_THROW(writer.addData(table), Elements::Exception);
 }
 
 //-----------------------------------------------------------------------------
@@ -83,18 +121,18 @@ BOOST_AUTO_TEST_CASE(EmptyCommentIndicator) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(addData, AsciiWriter_Fixture) {
-  
+
   // Given
   std::stringstream stream_hash {};
   std::stringstream stream_double_slash {};
   AsciiWriter writer_hash {stream_hash};
   AsciiWriter writer_double_slash {stream_double_slash};
   writer_double_slash.setCommentIndicator("//");
-  
+
   // When
   writer_hash.addData(table);
   writer_double_slash.addData(table);
-  
+
   // Then
   BOOST_CHECK_EQUAL(stream_hash.str(),
     "# Column: Boolean bool (unit1) - Desc1\n"
@@ -126,7 +164,7 @@ BOOST_FIXTURE_TEST_CASE(addData, AsciiWriter_Fixture) {
     "         0                     Two-2 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
     "         1                     Two-3        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"
   );
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -134,20 +172,20 @@ BOOST_FIXTURE_TEST_CASE(addData, AsciiWriter_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(addDataNoColumnInfo, AsciiWriter_Fixture) {
-  
+
   // Given
   std::stringstream stream_hash {};
   std::stringstream stream_double_slash {};
   AsciiWriter writer_hash {stream_hash};
   AsciiWriter writer_double_slash {stream_double_slash};
   writer_double_slash.setCommentIndicator("//");
-  
+
   // When
   writer_hash.showColumnInfo(false);
   writer_hash.addData(table);
   writer_double_slash.showColumnInfo(false);
   writer_double_slash.addData(table);
-  
+
   // Then
   BOOST_CHECK_EQUAL(stream_hash.str(),
     "# Boolean ThisIsAVeryLongColumnName    Integer       D F    DoubleVector      NdArray\n"
@@ -163,7 +201,7 @@ BOOST_FIXTURE_TEST_CASE(addDataNoColumnInfo, AsciiWriter_Fixture) {
     "         0                     Two-2 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
     "         1                     Two-3        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"
   );
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -171,7 +209,7 @@ BOOST_FIXTURE_TEST_CASE(addDataNoColumnInfo, AsciiWriter_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(addDataComments, AsciiWriter_Fixture) {
-  
+
   // Given
   std::stringstream stream_hash {};
   std::stringstream stream_double_slash {};
@@ -182,7 +220,7 @@ BOOST_FIXTURE_TEST_CASE(addDataComments, AsciiWriter_Fixture) {
     "First comment",
     "Second comment"
   };
-  
+
   // When
   for (auto& c : comments) {
     writer_hash.addComment(c);
@@ -190,7 +228,7 @@ BOOST_FIXTURE_TEST_CASE(addDataComments, AsciiWriter_Fixture) {
   }
   writer_hash.addData(table);
   writer_double_slash.addData(table);
-  
+
   // Then
   BOOST_CHECK_EQUAL(stream_hash.str(),
     "# First comment\n"
@@ -228,7 +266,7 @@ BOOST_FIXTURE_TEST_CASE(addDataComments, AsciiWriter_Fixture) {
     "         0                     Two-2 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
     "         1                     Two-3        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"
   );
-  
+
 }
 
 //-----------------------------------------------------------------------------

--- a/Table/tests/src/ColumnDescription_test.cpp
+++ b/Table/tests/src/ColumnDescription_test.cpp
@@ -42,10 +42,10 @@ BOOST_AUTO_TEST_CASE(NominalCase) {
   std::type_index type = typeid(double);
   std::string unit = "u";
   std::string description = "Desc";
-  
-  // When 
+
+  // When
   ColumnDescription result {name, type, unit, description};
-  
+
   // Then
   BOOST_CHECK_EQUAL(result.name, name);
   BOOST_CHECK_EQUAL(result.type.name(), type.name());
@@ -60,10 +60,10 @@ BOOST_AUTO_TEST_CASE(DefaultValues) {
 
   // Given
   std::string name = "Name";
-  
-  // When 
+
+  // When
   ColumnDescription result {name};
-  
+
   // Then
   BOOST_CHECK_EQUAL(result.name, name);
   BOOST_CHECK_EQUAL(result.type.name(), typeid(std::string).name());
@@ -75,33 +75,33 @@ BOOST_AUTO_TEST_CASE(DefaultValues) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(EmptyStringName) {
-  
+
   // Given
   std::string name = "";
-  
+
   // Then
   BOOST_CHECK_THROW(ColumnDescription{name}, Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(NameWithWhitespaces) {
-  
+
   // Given
   std::string space = "Sp ace";
   std::string tab = "Ta\tb";
   std::string carriage_return = "Carrage\rReturn";
   std::string new_line = "New\nLine";
   std::string new_page = "New\fPage";
-  
+
   // Then
-  BOOST_CHECK_THROW(ColumnDescription{space}, Elements::Exception);
-  BOOST_CHECK_THROW(ColumnDescription{tab}, Elements::Exception);
+  ColumnDescription{space};
+  ColumnDescription{tab};
   BOOST_CHECK_THROW(ColumnDescription{carriage_return}, Elements::Exception);
   BOOST_CHECK_THROW(ColumnDescription{new_line}, Elements::Exception);
   BOOST_CHECK_THROW(ColumnDescription{new_page}, Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------

--- a/Table/tests/src/FitsWriter_test.cpp
+++ b/Table/tests/src/FitsWriter_test.cpp
@@ -47,7 +47,7 @@ struct BinaryFitsWriter_Fixture {
                                       NdArray<double>({1}, {41})};
   Row row0 {values0, column_info};
   std::vector<Row::cell_type> values1{false, 12345, int64_t{123456789}, 2.3e-2F, 1.12345e-18,
-                                      std::string{"second"},
+                                      std::string{"second with spaces on top of that"},
                                       NdArray<double>({ 2, 3 }, { 6, 5, 4, 3, 2, 1 }),
                                       NdArray<double>({1}, {42})};
   Row row1 {values1, column_info};
@@ -69,7 +69,7 @@ struct AsciiFitsWriter_Fixture {
   std::shared_ptr<ColumnInfo> column_info {new ColumnInfo {info_list}};
   std::vector<Row::cell_type> values0{true, 1, int64_t{123}, 0.F, 0., std::string{"first"}};
   Row row0 {values0, column_info};
-  std::vector<Row::cell_type> values1{false, 12345, int64_t{123456789}, 2.3e-2F, 1.12345e-18, std::string{"second"}};
+  std::vector<Row::cell_type> values1{false, 12345, int64_t{123456789}, 2.3e-2F, 1.12345e-18, std::string{"very spaced"}};
   Row row1 {values1, column_info};
   std::vector<Row> row_list {row0, row1};
   Table table {row_list};
@@ -116,7 +116,7 @@ BOOST_FIXTURE_TEST_CASE(writeBinary, BinaryFitsWriter_Fixture) {
   BOOST_CHECK_EQUAL(result.column(3).format(), "K");
   BOOST_CHECK_EQUAL(result.column(4).format(), "E");
   BOOST_CHECK_EQUAL(result.column(5).format(), "D");
-  BOOST_CHECK_EQUAL(result.column(6).format(), "6A");
+  BOOST_CHECK_EQUAL(result.column(6).format(), "33A");
   BOOST_CHECK_EQUAL(result.column(7).format(), "6D");
   BOOST_CHECK_EQUAL(result.column(8).format(), "1D");
 
@@ -183,7 +183,7 @@ BOOST_FIXTURE_TEST_CASE(writeBinary, BinaryFitsWriter_Fixture) {
 
   // Then
   BOOST_CHECK_EQUAL(string_data[0], "first");
-  BOOST_CHECK_EQUAL(string_data[1], "second");
+  BOOST_CHECK_EQUAL(string_data[1], "second with spaces on top of that");
 
   // When
   std::valarray<double> na1, na2;
@@ -240,7 +240,7 @@ BOOST_FIXTURE_TEST_CASE(writeAscii, AsciiFitsWriter_Fixture) {
   BOOST_CHECK_EQUAL(result.column(3).format(), "I9");
   BOOST_CHECK_EQUAL(result.column(4).format(), "E12");
   BOOST_CHECK_EQUAL(result.column(5).format(), "E12");
-  BOOST_CHECK_EQUAL(result.column(6).format(), "A6");
+  BOOST_CHECK_EQUAL(result.column(6).format(), "A11");
 
   BOOST_CHECK_EQUAL(result.column(1).unit(), "deg");
   BOOST_CHECK_EQUAL(result.column(2).unit(), "mag");
@@ -304,7 +304,7 @@ BOOST_FIXTURE_TEST_CASE(writeAscii, AsciiFitsWriter_Fixture) {
 
   // Then
   BOOST_CHECK_EQUAL(string_data[0], "first");
-  BOOST_CHECK_EQUAL(string_data[1], "second");
+  BOOST_CHECK_EQUAL(string_data[1], "very spaced");
 
 }
 

--- a/Table/tests/src/Row_test.cpp
+++ b/Table/tests/src/Row_test.cpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+ /**
  * @file tests/src/Row_test.cpp
  * @date April 8, 2014
  * @author Nikolaos Apostolakos
@@ -47,13 +47,13 @@ BOOST_AUTO_TEST_SUITE (Row_test)
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(ConstructorWrongNumberOfValues, Row_Fixture) {
-  
+
   // Given
   std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, 3.};
-  
+
   // Then
   BOOST_CHECK_THROW(Euclid::Table::Row(values, column_info), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -61,14 +61,14 @@ BOOST_FIXTURE_TEST_CASE(ConstructorWrongNumberOfValues, Row_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(ConstructorNullColumnInfo, Row_Fixture) {
-  
+
   // Given
   std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
   std::shared_ptr<Euclid::Table::ColumnInfo> null_col_info {};
-  
+
   // Then
   BOOST_CHECK_THROW(Euclid::Table::Row(values, null_col_info), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -76,13 +76,13 @@ BOOST_FIXTURE_TEST_CASE(ConstructorNullColumnInfo, Row_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(ConstructorWrongCellType, Row_Fixture) {
-  
+
   // Given
   std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, std::string{"Three"}, 4., 5, std::vector<double>{6.1, 6.2}};
 
   // Then
   BOOST_CHECK_THROW(Euclid::Table::Row(values, column_info), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -90,13 +90,13 @@ BOOST_FIXTURE_TEST_CASE(ConstructorWrongCellType, Row_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(ConstructorEmptyCellValue, Row_Fixture) {
-  
+
   // Given
   std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{""}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
-  
+
   // Then
   BOOST_CHECK_THROW(Euclid::Table::Row(values, column_info), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -104,21 +104,21 @@ BOOST_FIXTURE_TEST_CASE(ConstructorEmptyCellValue, Row_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(ConstructorCellValueWithWhitespace, Row_Fixture) {
-  
+
   // Given
   std::vector<Euclid::Table::Row::cell_type> space {std::string{"One"}, std::string{"Sp ace"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
   std::vector<Euclid::Table::Row::cell_type> tab {std::string{"One"}, std::string{"T\tab"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
   std::vector<Euclid::Table::Row::cell_type> carriage_return {std::string{"One"}, std::string{"Carriage\rReturn"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
   std::vector<Euclid::Table::Row::cell_type> new_line {std::string{"One"}, std::string{"New\nLine"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
   std::vector<Euclid::Table::Row::cell_type> new_page {std::string{"One"}, std::string{"New\fPage"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
-  
+
   // Then
-  BOOST_CHECK_THROW(Euclid::Table::Row(space, column_info), Elements::Exception);
-  BOOST_CHECK_THROW(Euclid::Table::Row(tab, column_info), Elements::Exception);
+  Euclid::Table::Row(space, column_info);
+  Euclid::Table::Row(tab, column_info);
   BOOST_CHECK_THROW(Euclid::Table::Row(carriage_return, column_info), Elements::Exception);
   BOOST_CHECK_THROW(Euclid::Table::Row(new_line, column_info), Elements::Exception);
   BOOST_CHECK_THROW(Euclid::Table::Row(new_page, column_info), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -126,17 +126,17 @@ BOOST_FIXTURE_TEST_CASE(ConstructorCellValueWithWhitespace, Row_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(getColumnInfo, Row_Fixture) {
-  
+
   // Given
   std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
   Euclid::Table::Row row {values, column_info};
-  
+
   // When
   auto result = row.getColumnInfo();
-  
+
   // Then
   BOOST_CHECK(*result == *column_info);
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -144,17 +144,17 @@ BOOST_FIXTURE_TEST_CASE(getColumnInfo, Row_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Size, Row_Fixture) {
-  
+
   // Given
   std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
   Euclid::Table::Row row {values, column_info};
-  
+
   // When
   std::size_t size = row.size();
-  
+
   // Then
   BOOST_CHECK_EQUAL(size, values.size());
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -162,11 +162,11 @@ BOOST_FIXTURE_TEST_CASE(Size, Row_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(IndexBracketOperator, Row_Fixture) {
-  
+
   // Given
   std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
   Euclid::Table::Row row {values, column_info};
-  
+
   // When
   Euclid::Table::Row::cell_type value0 = row[0];
   Euclid::Table::Row::cell_type value1 = row[1];
@@ -174,7 +174,7 @@ BOOST_FIXTURE_TEST_CASE(IndexBracketOperator, Row_Fixture) {
   Euclid::Table::Row::cell_type value3 = row[3];
   Euclid::Table::Row::cell_type value4 = row[4];
   Euclid::Table::Row::cell_type value5 = row[5];
-  
+
   // Then
   BOOST_CHECK_EQUAL(value0, values[0]);
   BOOST_CHECK_EQUAL(value1, values[1]);
@@ -183,7 +183,7 @@ BOOST_FIXTURE_TEST_CASE(IndexBracketOperator, Row_Fixture) {
   BOOST_CHECK_EQUAL(value4, values[4]);
   BOOST_CHECK_EQUAL(value5, values[5]);
   BOOST_CHECK_THROW(row[6], Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -191,11 +191,11 @@ BOOST_FIXTURE_TEST_CASE(IndexBracketOperator, Row_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(StringBracketOperator, Row_Fixture) {
-  
+
   // Given
   std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
   Euclid::Table::Row row {values, column_info};
-  
+
   // When
   Euclid::Table::Row::cell_type value0 = row["First"];
   Euclid::Table::Row::cell_type value1 = row["Second"];
@@ -203,7 +203,7 @@ BOOST_FIXTURE_TEST_CASE(StringBracketOperator, Row_Fixture) {
   Euclid::Table::Row::cell_type value3 = row["Fourth"];
   Euclid::Table::Row::cell_type value4 = row["Fifth"];
   Euclid::Table::Row::cell_type value5 = row["Sixth"];
-  
+
   // Then
   BOOST_CHECK_EQUAL(value0, values[0]);
   BOOST_CHECK_EQUAL(value1, values[1]);
@@ -212,7 +212,7 @@ BOOST_FIXTURE_TEST_CASE(StringBracketOperator, Row_Fixture) {
   BOOST_CHECK_EQUAL(value4, values[4]);
   BOOST_CHECK_EQUAL(value5, values[5]);
   BOOST_CHECK_THROW(row["None"], Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -220,12 +220,12 @@ BOOST_FIXTURE_TEST_CASE(StringBracketOperator, Row_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Iterator, Row_Fixture) {
-  
+
   // Given
   std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
   Euclid::Table::Row row {values, column_info};
   auto valuesIter = values.cbegin();
-  
+
   // When
   for (auto cell : row) {
     // Then
@@ -233,7 +233,7 @@ BOOST_FIXTURE_TEST_CASE(Iterator, Row_Fixture) {
     ++valuesIter;
   }
   BOOST_CHECK(valuesIter == values.cend());
-  
+
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Only ASCII format is concerned, so restrict the limitation there.
Whitespaces within strings are required for writing LDAC FITS catalogs.