### PR TITLE
Feature/photometry add methods

### DIFF
--- a/SourceCatalog/SourceCatalog/SourceAttributes/Photometry.h
+++ b/SourceCatalog/SourceCatalog/SourceAttributes/Photometry.h
@@ -147,6 +147,10 @@ public:
    */
   std::unique_ptr<FluxErrorPair> find(std::string filter_name) const;
 
+  const std::shared_ptr<std::vector<std::string>>& getFilterNames() const;
+
+  void updateFluxValues(const std::vector<FluxErrorPair>& value_vector);
+
 private:
 
   /// Shared pointer to the common list of filter names

--- a/SourceCatalog/SourceCatalog/SourceAttributes/Photometry.h
+++ b/SourceCatalog/SourceCatalog/SourceAttributes/Photometry.h
@@ -1,21 +1,21 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
+
  /**
  * @file SourceCatalog/SourceAttributes/Photometry.h
  *
@@ -81,6 +81,7 @@ public:
     reference operator*();
     bool operator==(const PhotometryConstIterator& other) const;
     bool operator!=(const PhotometryConstIterator& other) const;
+    ssize_t operator - (const PhotometryConstIterator& other) const;
     const std::string& filterName() const;
   private:
     std::vector<std::string>::const_iterator m_filters_iter;

--- a/SourceCatalog/src/lib/Photometry.cpp
+++ b/SourceCatalog/src/lib/Photometry.cpp
@@ -1,21 +1,21 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
+
  /**
  * @file src/lib/Photometry.cpp
  *
@@ -34,7 +34,7 @@ Photometry::PhotometryConstIterator::PhotometryConstIterator(
                         const std::vector<string>::const_iterator& filters_iter,
                         const std::vector<FluxErrorPair>::const_iterator& values_iter)
                 : m_filters_iter{filters_iter}, m_values_iter{values_iter} { }
-                
+
 auto Photometry::PhotometryConstIterator::operator ++() -> const_iterator& {
   ++m_filters_iter;
   ++m_values_iter;
@@ -51,6 +51,10 @@ bool Photometry::PhotometryConstIterator::operator ==(const const_iterator& othe
 
 bool Photometry::PhotometryConstIterator::operator !=(const const_iterator& other) const {
   return m_filters_iter != other.m_filters_iter;
+}
+
+ssize_t Photometry::PhotometryConstIterator::operator-(const PhotometryConstIterator& other) const {
+  return m_values_iter - other.m_values_iter;
 }
 
 const string& Photometry::PhotometryConstIterator::filterName() const {

--- a/SourceCatalog/src/lib/Photometry.cpp
+++ b/SourceCatalog/src/lib/Photometry.cpp
@@ -84,6 +84,13 @@ unique_ptr<FluxErrorPair> Photometry::find(string filter_name) const
   return flux_found_ptr;
 } // Eof Photometry::find
 
+const std::shared_ptr<std::vector<std::string>>& Photometry::getFilterNames() const {
+  return m_filter_name_vector_ptr;
+}
+
+void Photometry::updateFluxValues(const vector<FluxErrorPair>& value_vector) {
+  m_value_vector = value_vector;
+}
 
 } // namespace SourceCatalog
 } // end of namespace Euclid

--- a/SourceCatalog/tests/src/SourceAttributes/Photometry_test.cpp
+++ b/SourceCatalog/tests/src/SourceAttributes/Photometry_test.cpp
@@ -1,21 +1,21 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
+
  /**
  * @file tests/src/SourceAttributes/Photometry_test.cpp
  *
@@ -68,6 +68,8 @@ BOOST_FIXTURE_TEST_CASE( iterator_test, CatalogFixture ) {
   auto expected_filter_name_iter = filter_name_vector_ptr->begin();
   // This is to get the expected fluxes and errors from the fixture for comparison
   auto expected_photo_iter = photometry_vector.begin();
+
+  BOOST_CHECK_EQUAL(photometry.end() - photometry.begin(), photometry_vector.size());
 
   // loop over the photometry object to check the different filter names, values and errors
   for (auto photo_iter = photometry.begin(); photo_iter != photometry.end(); ++photo_iter) {


### PR DESCRIPTION
Two new methods (+1 operator for the iterator) on Photometry.
This can be used by Phosphoros to avoid some re-allocation, copies and de-allocations, reducing a single thread runtime over 50 sources from ~46 seconds to ~33.5 (30% savings)