### PR TITLE
Remove updateFluxes, add non-const iterator

### DIFF
--- a/SourceCatalog/SourceCatalog/SourceAttributes/Photometry.h
+++ b/SourceCatalog/SourceCatalog/SourceAttributes/Photometry.h
@@ -87,60 +87,42 @@ public:
     /**
      * Constructor from non-const iterator
      */
-    PhotometryIterator(const PhotometryIterator<false>& other) : m_filters_iter{other.m_filters_iter},
-                                                                 m_values_iter{other.m_values_iter} {
-    }
+    PhotometryIterator(const PhotometryIterator<false>& other);
 
     /**
      * Increment the iterator
      */
-    PhotometryIterator& operator++() {
-      ++m_filters_iter;
-      ++m_values_iter;
-      return *this;
-    }
+    PhotometryIterator& operator++();
 
     /**
      * @return true if this iterator and other point to the same position
      */
-    bool operator == (const PhotometryIterator& other) const {
-      return m_filters_iter == other.m_filters_iter;
-    }
+    bool operator == (const PhotometryIterator& other) const;
 
     /**
      * @return true if this iterator and other do *not* point to the same position
      */
-    bool operator != (const PhotometryIterator& other) const {
-      return m_filters_iter != other.m_filters_iter;
-    }
+    bool operator != (const PhotometryIterator& other) const;
 
     /**
      * @return A reference to the FluxErrorPair pointed by this iterator
      */
-    reference operator*() {
-      return *m_values_iter;
-    }
+    reference operator*();
 
     /**
      * @return A pointer to the FluxErrorPair pointed by this iterator
      */
-    pointer operator ->() {
-      return m_values_iter.operator->();
-    }
+    pointer operator ->();
 
     /**
      * @return The number of elements between this iterator and other
      */
-    ssize_t operator - (const PhotometryIterator& other) const {
-      return m_values_iter - other.m_values_iter;
-    }
+    ssize_t operator - (const PhotometryIterator& other) const;
 
     /**
      * @return The filter name corresponding to this FluxErrorPair
      */
-    const std::string& filterName() const {
-      return *m_filters_iter;
-    }
+    const std::string& filterName() const;
 
   protected:
     /**
@@ -150,8 +132,7 @@ public:
      * @param values_iter
      *  FluxErrorPair iterator
      */
-    PhotometryIterator(const filters_iter_t& filters_iter, const values_iter_t& values_iter)
-      : m_filters_iter{filters_iter}, m_values_iter{values_iter} {}
+    PhotometryIterator(const filters_iter_t& filters_iter, const values_iter_t& values_iter);
 
     friend class Photometry;
 
@@ -189,8 +170,7 @@ public:
   }
 
   /// default destructor
-  virtual ~Photometry() {
-  }
+  virtual ~Photometry() = default;
 
   const_iterator cbegin() const {
     return const_iterator{m_filter_name_vector_ptr->cbegin(), m_value_vector.cbegin()};
@@ -247,6 +227,10 @@ private:
 
 };
 // Eof class Photometry
+
+#define PHOTOMETRY_IMPL
+#include "SourceCatalog/_impl/Photometry.icpp"
+#undef PHOTOMETRY_IMPL
 
 } /* namespace SourceCatalog */
 } // end of namespace Euclid

--- a/SourceCatalog/SourceCatalog/_impl/Photometry.icpp
+++ b/SourceCatalog/SourceCatalog/_impl/Photometry.icpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifdef PHOTOMETRY_IMPL
+
+//-----------------------------------------------------------------------------
+// Implementation of the iterator
+
+template<bool Const>
+Photometry::PhotometryIterator<Const>::PhotometryIterator(const filters_iter_t& filters_iter,
+                                                          const values_iter_t& values_iter)
+  : m_filters_iter{filters_iter}, m_values_iter{values_iter} {
+}
+
+template<bool Const>
+Photometry::PhotometryIterator<Const>::PhotometryIterator(const PhotometryIterator<false>& other)
+  : m_filters_iter{other.m_filters_iter}, m_values_iter{other.m_values_iter} {
+}
+
+template<bool Const>
+Photometry::PhotometryIterator<Const>& Photometry::PhotometryIterator<Const>::operator++() {
+  ++m_filters_iter;
+  ++m_values_iter;
+  return *this;
+}
+
+template<bool Const>
+bool Photometry::PhotometryIterator<Const>::operator==(const PhotometryIterator& other) const {
+  return m_filters_iter == other.m_filters_iter;
+}
+
+template<bool Const>
+bool Photometry::PhotometryIterator<Const>::operator!=(const PhotometryIterator& other) const {
+  return m_filters_iter != other.m_filters_iter;
+}
+
+template<bool Const>
+auto Photometry::PhotometryIterator<Const>::operator*() -> reference {
+  return *m_values_iter;
+}
+
+template<bool Const>
+auto Photometry::PhotometryIterator<Const>::operator->() -> pointer {
+  return m_values_iter.operator->();
+}
+
+template<bool Const>
+ssize_t Photometry::PhotometryIterator<Const>::operator-(const PhotometryIterator& other) const {
+  return m_values_iter - other.m_values_iter;
+}
+
+template<bool Const>
+const std::string& Photometry::PhotometryIterator<Const>::filterName() const {
+  return *m_filters_iter;
+}
+
+#endif

--- a/SourceCatalog/src/lib/Photometry.cpp
+++ b/SourceCatalog/src/lib/Photometry.cpp
@@ -30,37 +30,6 @@ using namespace std;
 namespace Euclid {
 namespace SourceCatalog {
 
-Photometry::PhotometryConstIterator::PhotometryConstIterator(
-                        const std::vector<string>::const_iterator& filters_iter,
-                        const std::vector<FluxErrorPair>::const_iterator& values_iter)
-                : m_filters_iter{filters_iter}, m_values_iter{values_iter} { }
-
-auto Photometry::PhotometryConstIterator::operator ++() -> const_iterator& {
-  ++m_filters_iter;
-  ++m_values_iter;
-  return *this;
-}
-
-auto Photometry::PhotometryConstIterator::operator *() -> reference {
-  return *m_values_iter;
-}
-
-bool Photometry::PhotometryConstIterator::operator ==(const const_iterator& other) const {
-  return m_filters_iter == other.m_filters_iter;
-}
-
-bool Photometry::PhotometryConstIterator::operator !=(const const_iterator& other) const {
-  return m_filters_iter != other.m_filters_iter;
-}
-
-ssize_t Photometry::PhotometryConstIterator::operator-(const PhotometryConstIterator& other) const {
-  return m_values_iter - other.m_values_iter;
-}
-
-const string& Photometry::PhotometryConstIterator::filterName() const {
-  return *m_filters_iter;
-}
-
 //-----------------------------------------------------------------------------
 // find the value and error in the map for a specific filter name
 // return a ptr to a ValuePair(value, error) and null pointer otherwise
@@ -86,10 +55,6 @@ unique_ptr<FluxErrorPair> Photometry::find(string filter_name) const
 
 const std::shared_ptr<std::vector<std::string>>& Photometry::getFilterNames() const {
   return m_filter_name_vector_ptr;
-}
-
-void Photometry::updateFluxValues(const vector<FluxErrorPair>& value_vector) {
-  m_value_vector = value_vector;
 }
 
 } // namespace SourceCatalog

--- a/SourceCatalog/tests/src/CatalogFixture.h
+++ b/SourceCatalog/tests/src/CatalogFixture.h
@@ -1,21 +1,21 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
+
  /**
  * @file tests/src/CatalogFixture.h
  *
@@ -40,7 +40,7 @@ using namespace std;
 
 struct CatalogFixture {
 
-  double tolerence = 1e-8;
+  double tolerance = 1e-8;
   //
   // Building a photometry attribute mock object
   //
@@ -127,4 +127,4 @@ struct CatalogFixture {
 
 };
 
-#endif // CATALOGFIXTURE_H_ 
+#endif // CATALOGFIXTURE_H_

--- a/SourceCatalog/tests/src/SourceAttributes/Photometry_test.cpp
+++ b/SourceCatalog/tests/src/SourceAttributes/Photometry_test.cpp
@@ -45,10 +45,10 @@ BOOST_FIXTURE_TEST_CASE( find_test, CatalogFixture ) {
   shared_ptr<FluxErrorPair> ptr1 = photometry.find(expected_filter_name_1);
   shared_ptr<FluxErrorPair> ptr2 = photometry.find(expected_filter_name_2);
 
-  BOOST_CHECK_CLOSE(expected_flux_1, ptr1->flux, tolerence);
-  BOOST_CHECK_CLOSE(expected_error_1, ptr1->error, tolerence);
-  BOOST_CHECK_CLOSE(expected_flux_2, ptr2->flux, tolerence);
-  BOOST_CHECK_CLOSE(expected_error_2, ptr2->error, tolerence);
+  BOOST_CHECK_CLOSE(expected_flux_1, ptr1->flux, tolerance);
+  BOOST_CHECK_CLOSE(expected_error_1, ptr1->error, tolerance);
+  BOOST_CHECK_CLOSE(expected_flux_2, ptr2->flux, tolerance);
+  BOOST_CHECK_CLOSE(expected_error_2, ptr2->error, tolerance);
 }
 
 BOOST_FIXTURE_TEST_CASE( not_found_test, CatalogFixture ) {
@@ -75,8 +75,8 @@ BOOST_FIXTURE_TEST_CASE( iterator_test, CatalogFixture ) {
   for (auto photo_iter = photometry.begin(); photo_iter != photometry.end(); ++photo_iter) {
     BOOST_CHECK( photo_iter.filterName() ==  *expected_filter_name_iter );
     ++expected_filter_name_iter;
-    BOOST_CHECK_CLOSE( (*photo_iter).flux, expected_photo_iter->flux, tolerence);
-    BOOST_CHECK_CLOSE( (*photo_iter).error, expected_photo_iter->error, tolerence);
+    BOOST_CHECK_CLOSE((*photo_iter).flux, expected_photo_iter->flux, tolerance);
+    BOOST_CHECK_CLOSE((*photo_iter).error, expected_photo_iter->error, tolerance);
     ++expected_photo_iter;
   }
 
@@ -92,11 +92,44 @@ BOOST_FIXTURE_TEST_CASE( iterator_getter_test, CatalogFixture ) {
 
   // loop over the photometry object to check the different values and errors
   for (auto FluxErrorPair :  photometry) {
-    BOOST_CHECK_CLOSE( FluxErrorPair.flux, expected_photo_iter->flux, tolerence);
-    BOOST_CHECK_CLOSE( FluxErrorPair.error, expected_photo_iter->error, tolerence);
+    BOOST_CHECK_CLOSE(FluxErrorPair.flux, expected_photo_iter->flux, tolerance);
+    BOOST_CHECK_CLOSE(FluxErrorPair.error, expected_photo_iter->error, tolerance);
     ++expected_photo_iter;
   }
+}
 
+// Iterate modifying the values
+BOOST_FIXTURE_TEST_CASE ( iterator_modify_test, CatalogFixture ) {
+  BOOST_TEST_MESSAGE("--> iterator set test ");
+
+  vector<FluxErrorPair> new_values {{1.56, 0.3}, {4.4, 1e-3}};
+
+  // Modify the photometries
+  size_t i = 0;
+  for (auto iter = photometry.begin(); iter != photometry.end(); ++iter, ++i) {
+    iter->flux = new_values[i].flux;
+    iter->error = new_values[i].error;
+  }
+
+  // make sure they have been modified
+  i = 0;
+  for (auto FluxErrorPair :  photometry) {
+    BOOST_CHECK_CLOSE(FluxErrorPair.flux, new_values[i].flux, tolerance);
+    BOOST_CHECK_CLOSE(FluxErrorPair.error, new_values[i].error, tolerance);
+    ++i;
+  }
+}
+
+// Cast a non-const iterator to a const iterator
+BOOST_FIXTURE_TEST_CASE ( iterator_cast, CatalogFixture ) {
+  BOOST_TEST_MESSAGE("--> iterator const cast ");
+
+  auto f = [](Photometry::const_iterator begin, Photometry::const_iterator end){
+    BOOST_CHECK_EQUAL(end - begin, 2);
+  };
+
+  BOOST_CHECK_EQUAL(photometry.end() - photometry.begin(), 2);
+  f(photometry.begin(), photometry.end());
 }
 
 

--- a/SourceCatalog/tests/src/SourceAttributes/Photometry_test.cpp
+++ b/SourceCatalog/tests/src/SourceAttributes/Photometry_test.cpp
@@ -121,11 +121,16 @@ BOOST_FIXTURE_TEST_CASE ( iterator_modify_test, CatalogFixture ) {
 }
 
 // Cast a non-const iterator to a const iterator
-BOOST_FIXTURE_TEST_CASE ( iterator_cast, CatalogFixture ) {
+BOOST_FIXTURE_TEST_CASE ( iterator_cast_test, CatalogFixture ) {
   BOOST_TEST_MESSAGE("--> iterator const cast ");
 
-  auto f = [](Photometry::const_iterator begin, Photometry::const_iterator end){
+  auto f = [this](Photometry::const_iterator begin, Photometry::const_iterator end){
     BOOST_CHECK_EQUAL(end - begin, 2);
+    auto expected_photo_iter = photometry_vector.begin();
+    for (auto i = begin; i != end; ++i) {
+      BOOST_CHECK_CLOSE(i->flux, expected_photo_iter->flux, tolerance);
+      ++expected_photo_iter;
+    }
   };
 
   BOOST_CHECK_EQUAL(photometry.end() - photometry.begin(), 2);

--- a/SourceCatalog/tests/src/Source_test.cpp
+++ b/SourceCatalog/tests/src/Source_test.cpp
@@ -1,21 +1,21 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
+
  /**
  * @file tests/src/Source_test.cpp
  *
@@ -58,22 +58,22 @@ BOOST_FIXTURE_TEST_CASE( getAttribute_test, CatalogFixture ) {
 //   cout << " Flux  : " << (ptrPhoto->find(expectedFilterName))->flux
 //        << " Error : " << (ptrPhoto->find(expectedFilterName))->error
 //        << endl;
-   BOOST_CHECK_CLOSE(expected_flux_1,(photometry_ptr->find(expected_filter_name_1))->flux, tolerence);
-   BOOST_CHECK_CLOSE(expected_error_2,(photometry_ptr->find(expected_filter_name_2))->error, tolerence);
+   BOOST_CHECK_CLOSE(expected_flux_1, (photometry_ptr->find(expected_filter_name_1))->flux, tolerance);
+   BOOST_CHECK_CLOSE(expected_error_2, (photometry_ptr->find(expected_filter_name_2))->error, tolerance);
 
    shared_ptr<Coordinates> coordinate_ptr(source_1.getAttribute<Coordinates>());
 //   cout << " Ra  : " << ptrCoord->getRa()
 //        << " Dec : " << ptrCoord->getDec()
 //        << endl;
-   BOOST_CHECK_CLOSE(expected_ra_1, coordinate_ptr->getRa(), tolerence);
-   BOOST_CHECK_CLOSE(expected_dec_1,coordinate_ptr->getDec(), tolerence);
+   BOOST_CHECK_CLOSE(expected_ra_1, coordinate_ptr->getRa(), tolerance);
+   BOOST_CHECK_CLOSE(expected_dec_1, coordinate_ptr->getDec(), tolerance);
 
    shared_ptr<SpectroscopicRedshift> redshift_ptr(source_1.getAttribute<SpectroscopicRedshift>());
 //   cout << " Zvalue : " << ptrRedshift->getValue()
 //        << " Error  : " << ptrRedshift->getError()
 //        << endl;
-   BOOST_CHECK_CLOSE(expected_z_value, redshift_ptr->getValue(), tolerence);
-   BOOST_CHECK_CLOSE(expected_z_error, redshift_ptr->getError(), tolerence);
+   BOOST_CHECK_CLOSE(expected_z_value, redshift_ptr->getValue(), tolerance);
+   BOOST_CHECK_CLOSE(expected_z_error, redshift_ptr->getError(), tolerance);
 
 }
 


### PR DESCRIPTION
Sorry this kind of undo my changes from yesterday, but I had this idea while trying to sleep, because of course... :sleeping: 

So rather than having the `updateFluxValues`, which worked but it is not so idiomatic, I have re-worked the iterator class within `Photometry`, so you can directly update the fluxes as `iterator->flux` and `iterator->error`

It is more idiomatic, it hides the specific type to contain the fluxes (vector, list, whatnot), and, as a plus, it is even faster when Phosphoros is adapted to this, as you can avoid allocation/deallocation of a vector of fluxes and just update in place.