### PR TITLE
Fix an out of bounds memory access on axis fix

### DIFF
--- a/GridContainer/GridContainer/_impl/GridContainer.icpp
+++ b/GridContainer/GridContainer/_impl/GridContainer.icpp
@@ -1,21 +1,21 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
+
  /**
  * @file GridContainer/_impl/GridContainer.icpp
  * @date May 13, 2014
@@ -47,7 +47,7 @@ template<typename GridCellManager, typename... AxesTypes>
 GridContainer<GridCellManager, AxesTypes...>::GridContainer(
                       const GridContainer<GridCellManager, AxesTypes...>& other,
                       size_t axis, size_t index)
-      : m_axes{other.m_axes}, m_axes_fixed{fixAxis(other.m_axes_fixed, axis, index)},
+      : m_axes{other.m_axes}, m_axes_fixed{fixAxis(other.m_axes, axis, index)},
         m_fixed_indices{other.m_fixed_indices}, m_cell_manager{other.m_cell_manager} {
   // Update the fixed indices
   if (m_fixed_indices.find(axis) != m_fixed_indices.end()) {
@@ -155,7 +155,7 @@ template<typename GridCellManager, typename... AxesTypes>
 template<int I>
 GridContainer<GridCellManager, AxesTypes...>  GridContainer<GridCellManager, AxesTypes...>::fixAxisByIndex(size_t index) {
   if (index >= getOriginalAxis<I>().size()) {
-    throw Elements::Exception() << "Index (" << index << ") out of axis " 
+    throw Elements::Exception() << "Index (" << index << ") out of axis "
                               << getOriginalAxis<I>().name() << " size ("
                               << getOriginalAxis<I>().size() << ")";
   }


### PR DESCRIPTION
fixAxisByIndex does an out-of-bounds check, but it uses the original axes.
However, later on when constructing the slice it will use the tuple of fixed_axes,
which will have a single element at the fixed position.

For some reason this "just worked", but in Fedora Rawhide the compiled code crashes with a `SIGABRT`
It was there, nevertheless. Valgrind would report on it:

```
==148209== Memcheck, a memory error detector
==148209== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==148209== Using Valgrind-3.16.0 and LibVEX; rerun with -h for copyright info
==148209== Command: ./build.x86_64-fc32-gcc101-dbg/bin/GridContainer_test
==148209== 
Running 28 test cases...
==148209== Invalid read of size 4
==148209==    at 0x1599DE: void Euclid::GridContainer::GridConstructionHelper<int, int, int, int>::findAndFixAxis<2>(std::tuple<Euclid::GridContainer::GridAxis<int>, Euclid::GridContainer::GridAxis<int>, Euclid::GridContainer::GridAxis<int>, Euclid::GridContainer::GridAxis<int> >&, unsigned long, unsigned long, Euclid::GridContainer::TemplateLoopCounter<2> const&) (GridConstructionHelper.h:169)
==148209==    by 0x159D84: findAndFixAxis<1> (GridConstructionHelper.h:173)
==148209==    by 0x159D84: findAndFixAxis<0> (GridConstructionHelper.h:173)
==148209==    by 0x159D84: std::tuple<Euclid::GridContainer::GridAxis<int>, Euclid::GridContainer::GridAxis<int>, Euclid::GridContainer::GridAxis<int>, Euclid::GridContainer::GridAxis<int> > Euclid::GridContainer::fixAxis<int, int, int, int>(std::tuple<Euclid::GridContainer::GridAxis<int>, Euclid::GridContainer::GridAxis<int>, Euclid::GridContainer::GridAxis<int>, Euclid::GridContainer::GridAxis<int> > const&, unsigned long, unsigned long) (GridContainer.icpp:42)
==148209==    by 0x15A1F4: Euclid::GridContainer::GridContainer<std::vector<double, std::allocator<double> >, int, int, int, int>::GridContainer(Euclid::GridContainer::GridContainer<std::vector<double, std::allocator<double> >, int, int, int, int> const&, unsigned long, unsigned long) (GridContainer.icpp:51)
==148209==    by 0x15A7C2: Euclid::GridContainer::GridContainer<std::vector<double, std::allocator<double> >, int, int, int, int> Euclid::GridContainer::GridContainer<std::vector<double, std::allocator<double> >, int, int, int, int>::fixAxisByIndex<2>(unsigned long) (GridContainer.icpp:162)
==148209==    by 0x140D81: GridContainer_test::sliceByIndexTwiceSameAxis::test_method() (GridContainer_test.cpp:845)
==148209==    by 0x142ACF: GridContainer_test::sliceByIndexTwiceSameAxis_invoker() (GridContainer_test.cpp:826)
==148209==    by 0x14D6C4: boost::detail::function::void_function_invoker0<void (*)(), void>::invoke(boost::detail::function::function_buffer&) (function_template.hpp:117)
==148209==    by 0x48CD911: ??? (in /usr/lib64/libboost_unit_test_framework.so.1.69.0)
==148209==    by 0x48CC41C: boost::execution_monitor::catch_signals(boost::function<int ()> const&) (in /usr/lib64/libboost_unit_test_framework.so.1.69.0)
==148209==    by 0x48CC777: boost::execution_monitor::execute(boost::function<int ()> const&) (in /usr/lib64/libboost_unit_test_framework.so.1.69.0)
==148209==    by 0x48CC814: boost::execution_monitor::vexecute(boost::function<void ()> const&) (in /usr/lib64/libboost_unit_test_framework.so.1.69.0)
==148209==    by 0x48F367F: boost::unit_test::unit_test_monitor_t::execute_and_translate(boost::function<void ()> const&, unsigned int) (in /usr/lib64/libboost_unit_test_framework.so.1.69.0)
```

Now it looks nice and tidy

```
==148639== Memcheck, a memory error detector
==148639== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==148639== Using Valgrind-3.16.0 and LibVEX; rerun with -h for copyright info
==148639== Command: ./build.x86_64-fc32-gcc101-dbg/bin/GridContainer_test
==148639== 
Running 28 test cases...

*** No errors detected
==148639== 
==148639== HEAP SUMMARY:
==148639==     in use at exit: 0 bytes in 0 blocks
==148639==   total heap usage: 7,149 allocs, 7,149 frees, 628,550 bytes allocated
==148639== 
==148639== All heap blocks were freed -- no leaks are possible
==148639== 
==148639== For lists of detected and suppressed errors, rerun with: -s
==148639== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Tests pass, both in Alexandria and Phosphoros.