### PR TITLE
Multiple fixes for failed tests on architectures other than x86_64

### DIFF
--- a/GridContainer/tests/src/GridContainer_test.cpp
+++ b/GridContainer/tests/src/GridContainer_test.cpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+ /**
  * @file GridContainer_test.cpp
  * @date July 4, 2014
  * @author Nikolaos Apostolakos
@@ -25,7 +25,10 @@
 #include <vector>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
+#include <ElementsKernel/Real.h>
 #include "GridContainer/GridContainer.h"
+
+using Elements::isEqual;
 
 struct GridContainer_Fixture {
   typedef Euclid::GridContainer::GridContainer<std::vector<double>, int, int, int, int> GridContainerType;
@@ -45,13 +48,13 @@ BOOST_AUTO_TEST_SUITE (GridContainer_test)
 //-----------------------------------------------------------------------------
 // Test construction with GridAxis objects
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(GridAxisConstructor, GridContainer_Fixture) {
-  
+
   // When
   GridContainerType result_grid {axis1, axis2, axis3, axis4};
   auto& result_axes_tuple = result_grid.getAxesTuple();
-  
+
   // Then
   BOOST_CHECK_EQUAL(result_grid.size(), total_size);
   for (auto& value : result_grid) {
@@ -73,19 +76,19 @@ BOOST_FIXTURE_TEST_CASE(GridAxisConstructor, GridContainer_Fixture) {
   BOOST_CHECK_EQUAL_COLLECTIONS(
       std::get<3>(result_axes_tuple).begin(), std::get<3>(result_axes_tuple).end(),
       axis4.begin(), axis4.end());
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test construction with GridAxis tuple
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(GridAxisTupleonstructor, GridContainer_Fixture) {
-  
+
   // When
   GridContainerType result_grid {axes_tuple};
   auto& result_axes_tuple = result_grid.getAxesTuple();
-  
+
   // Then
   BOOST_CHECK_EQUAL(result_grid.size(), total_size);
   for (auto& value : result_grid) {
@@ -107,137 +110,137 @@ BOOST_FIXTURE_TEST_CASE(GridAxisTupleonstructor, GridContainer_Fixture) {
   BOOST_CHECK_EQUAL_COLLECTIONS(
       std::get<3>(result_axes_tuple).begin(), std::get<3>(result_axes_tuple).end(),
       axis4.begin(), axis4.end());
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the rank method
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(rank, GridContainer_Fixture) {
-  
+
   // When
   GridContainerType grid {axes_tuple};
-  
+
   // Then
   BOOST_CHECK_EQUAL(grid.axisNumber(), 4u);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the getAxis method
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(getAxis, GridContainer_Fixture) {
-  
+
   // When
   GridContainerType grid {axes_tuple};
-  
+
   // Then
   BOOST_CHECK_EQUAL(grid.getAxis<0>().name(), axis1.name());
   BOOST_CHECK_EQUAL(grid.getAxis<1>().name(), axis2.name());
   BOOST_CHECK_EQUAL(grid.getAxis<2>().name(), axis3.name());
   BOOST_CHECK_EQUAL(grid.getAxis<3>().name(), axis4.name());
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the size method
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(size, GridContainer_Fixture) {
-  
+
   // When
   GridContainerType grid {axes_tuple};
-  
+
   // Then
   BOOST_CHECK_EQUAL(grid.size(), total_size);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the parenthesis operator
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(parenthesisOperator, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // When
   double custom_value = 0;
   for (auto& cell : grid) {
     custom_value += 0.1;
     cell = custom_value;
   }
-  
+
   // Then
   double expected_value {0};
-  for (size_t coord4=0; coord4<axis4.size(); ++coord4) {
-    for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
-      for (size_t coord2=0; coord2<axis2.size(); ++coord2) {
-        for (size_t coord1=0; coord1<axis1.size(); ++coord1) {
+  for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
+    for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
+      for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
+        for (size_t coord1 = 0; coord1 < axis1.size(); ++coord1) {
           expected_value += 0.1;
-          BOOST_CHECK_EQUAL(grid(coord1, coord2, coord3, coord4), expected_value);
-          BOOST_CHECK_EQUAL(const_grid(coord1, coord2, coord3, coord4), expected_value);
+          BOOST_CHECK_CLOSE(grid(coord1, coord2, coord3, coord4), expected_value, 1e-6);
+          BOOST_CHECK_CLOSE(const_grid(coord1, coord2, coord3, coord4), expected_value, 1e-6);
         }
       }
     }
   }
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the at method
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(at, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // When
   double custom_value = 0;
   for (auto& cell : grid) {
     custom_value += 0.1;
     cell = custom_value;
   }
-  
+
   // Then
   double expected_value {0};
-  for (size_t coord4=0; coord4<axis4.size(); ++coord4) {
-    for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
-      for (size_t coord2=0; coord2<axis2.size(); ++coord2) {
-        for (size_t coord1=0; coord1<axis1.size(); ++coord1) {
+  for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
+    for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
+      for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
+        for (size_t coord1 = 0; coord1 < axis1.size(); ++coord1) {
           expected_value += 0.1;
-          BOOST_CHECK_EQUAL(grid.at(coord1, coord2, coord3, coord4), expected_value);
-          BOOST_CHECK_EQUAL(const_grid.at(coord1, coord2, coord3, coord4), expected_value);
+          BOOST_CHECK_CLOSE(grid.at(coord1, coord2, coord3, coord4), expected_value, 1e-6);
+          BOOST_CHECK_CLOSE(const_grid.at(coord1, coord2, coord3, coord4), expected_value, 1e-6);
         }
       }
     }
   }
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the at method throws for out of bound
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(atOutOfBound, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // When
   double custom_value = 0;
   for (auto& cell : grid) {
     custom_value += 0.1;
     cell = custom_value;
   }
-  
+
   // Then
   BOOST_CHECK_THROW(grid.at(axis1.size(), 0, 0, 0), Elements::Exception);
   BOOST_CHECK_THROW(grid.at(0, axis2.size(), 0, 0), Elements::Exception);
@@ -247,54 +250,54 @@ BOOST_FIXTURE_TEST_CASE(atOutOfBound, GridContainer_Fixture) {
   BOOST_CHECK_THROW(const_grid.at(0, axis2.size(), 0, 0), Elements::Exception);
   BOOST_CHECK_THROW(const_grid.at(0, 0, axis3.size(), 0), Elements::Exception);
   BOOST_CHECK_THROW(const_grid.at(0, 0, 0, axis4.size()), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the iterator
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(iterator, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // When
   double custom_value = 0;
   for (auto& cell : grid) {
     custom_value += 0.1;
     cell = custom_value;
   }
-  
+
   // Then
   double expected_value {0};
   for (auto& result_value : grid) {
     expected_value += 0.1;
-    BOOST_CHECK_EQUAL(result_value, expected_value);
+    BOOST_CHECK_CLOSE(result_value, expected_value, 1e-6);
   }
   expected_value = 0;
   for (auto& result_value : const_grid) {
     expected_value += 0.1;
-    BOOST_CHECK_EQUAL(result_value, expected_value);
+    BOOST_CHECK_CLOSE(result_value, expected_value, 1e-6);
   }
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the iterators axisIndex
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(iteratorAxisIndex, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // When
   auto iterator = grid.begin();
   auto const_iterator = const_grid.begin();
-  
+
   // Then
   for (size_t coord4=0; coord4<axis4.size(); ++coord4) {
     for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
@@ -322,23 +325,23 @@ BOOST_FIXTURE_TEST_CASE(iteratorAxisIndex, GridContainer_Fixture) {
       }
     }
   }
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the iterators axisValue
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(iteratorAxisValue, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // When
   auto iterator = grid.begin();
   auto const_iterator = const_grid.begin();
-  
+
   // Then
   for (size_t coord4=0; coord4<axis4.size(); ++coord4) {
     for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
@@ -366,27 +369,27 @@ BOOST_FIXTURE_TEST_CASE(iteratorAxisValue, GridContainer_Fixture) {
       }
     }
   }
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test fixing iterator by index
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(fixIteratorByIndex, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   for (size_t fixed_index=0; fixed_index<axis1.size(); ++fixed_index) {
-    
+
     // When
     auto iterator = grid.begin();
     iterator.fixAxisByIndex<0>(fixed_index);
     auto const_iterator = const_grid.begin();
     const_iterator.fixAxisByIndex<0>(fixed_index);
-    
+
     // Then
     for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
       for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
@@ -410,17 +413,17 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndex, GridContainer_Fixture) {
         }
       }
     }
-    
+
   }
-  
+
   for (size_t fixed_index=0; fixed_index<axis2.size(); ++fixed_index) {
-    
+
     // When
     auto iterator = grid.begin();
     iterator.fixAxisByIndex<1>(fixed_index);
     auto const_iterator = const_grid.begin();
     const_iterator.fixAxisByIndex<1>(fixed_index);
-    
+
     // Then
     for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
       for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
@@ -444,17 +447,17 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndex, GridContainer_Fixture) {
         }
       }
     }
-    
+
   }
-  
+
   for (size_t fixed_index=0; fixed_index<axis3.size(); ++fixed_index) {
-    
+
     // When
     auto iterator = grid.begin();
     iterator.fixAxisByIndex<2>(fixed_index);
     auto const_iterator = const_grid.begin();
     const_iterator.fixAxisByIndex<2>(fixed_index);
-    
+
     // Then
     for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
       for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
@@ -478,17 +481,17 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndex, GridContainer_Fixture) {
         }
       }
     }
-    
+
   }
-  
+
   for (size_t fixed_index=0; fixed_index<axis4.size(); ++fixed_index) {
-    
+
     // When
     auto iterator = grid.begin();
     iterator.fixAxisByIndex<3>(fixed_index);
     auto const_iterator = const_grid.begin();
     const_iterator.fixAxisByIndex<3>(fixed_index);
-    
+
     // Then
     for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
       for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
@@ -512,25 +515,25 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndex, GridContainer_Fixture) {
         }
       }
     }
-    
+
   }
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test fixing iterator index out of bound exception
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(fixIteratorByIndexOutOfBound, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // When
   auto iterator = grid.begin();
   auto const_iterator = const_grid.begin();
-  
+
   // Then
   BOOST_CHECK_THROW(iterator.fixAxisByIndex<0>(axis1.size()), Elements::Exception);
   BOOST_CHECK_THROW(iterator.fixAxisByIndex<1>(axis2.size()), Elements::Exception);
@@ -540,25 +543,25 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndexOutOfBound, GridContainer_Fixture) {
   BOOST_CHECK_THROW(const_iterator.fixAxisByIndex<1>(axis2.size()), Elements::Exception);
   BOOST_CHECK_THROW(const_iterator.fixAxisByIndex<2>(axis3.size()), Elements::Exception);
   BOOST_CHECK_THROW(const_iterator.fixAxisByIndex<3>(axis4.size()), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test fixing iterator by index twice for same axis throws exception
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(fixIteratorByIndexTwiceForSameAxis, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // When
   auto iterator = grid.begin().fixAxisByIndex<0>(0).fixAxisByIndex<1>(0)
                               .fixAxisByIndex<2>(0).fixAxisByIndex<3>(0);
   auto const_iterator = const_grid.begin().fixAxisByIndex<0>(0).fixAxisByIndex<1>(0)
                                           .fixAxisByIndex<2>(0).fixAxisByIndex<3>(0);
-  
+
   // Then
   iterator.fixAxisByIndex<0>(0);
   iterator.fixAxisByIndex<1>(0);
@@ -568,27 +571,27 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndexTwiceForSameAxis, GridContainer_Fixtur
   const_iterator.fixAxisByIndex<1>(0);
   BOOST_CHECK_THROW(const_iterator.fixAxisByIndex<2>(1), Elements::Exception);
   BOOST_CHECK_THROW(const_iterator.fixAxisByIndex<3>(1), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test fixing iterator by value
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(fixIteratorByValue, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   for (size_t fixed_index=0; fixed_index<axis1.size(); ++fixed_index) {
-    
+
     // When
     auto iterator = grid.begin();
     iterator.fixAxisByValue<0>(axis1[fixed_index]);
     auto const_iterator = const_grid.begin();
     const_iterator.fixAxisByValue<0>(axis1[fixed_index]);
-    
+
     // Then
     for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
       for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
@@ -612,17 +615,17 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByValue, GridContainer_Fixture) {
         }
       }
     }
-    
+
   }
-  
+
   for (size_t fixed_index=0; fixed_index<axis2.size(); ++fixed_index) {
-    
+
     // When
     auto iterator = grid.begin();
     iterator.fixAxisByValue<1>(axis2[fixed_index]);
     auto const_iterator = const_grid.begin();
     const_iterator.fixAxisByValue<1>(axis2[fixed_index]);
-    
+
     // Then
     for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
       for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
@@ -646,17 +649,17 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByValue, GridContainer_Fixture) {
         }
       }
     }
-    
+
   }
-  
+
   for (size_t fixed_index=0; fixed_index<axis3.size(); ++fixed_index) {
-    
+
     // When
     auto iterator = grid.begin();
     iterator.fixAxisByValue<2>(axis3[fixed_index]);
     auto const_iterator = const_grid.begin();
     const_iterator.fixAxisByValue<2>(axis3[fixed_index]);
-    
+
     // Then
     for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
       for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
@@ -680,17 +683,17 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByValue, GridContainer_Fixture) {
         }
       }
     }
-    
+
   }
-  
+
   for (size_t fixed_index=0; fixed_index<axis4.size(); ++fixed_index) {
-    
+
     // When
     auto iterator = grid.begin();
     iterator.fixAxisByValue<3>(axis4[fixed_index]);
     auto const_iterator = const_grid.begin();
     const_iterator.fixAxisByValue<3>(axis4[fixed_index]);
-    
+
     // Then
     for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
       for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
@@ -714,25 +717,25 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByValue, GridContainer_Fixture) {
         }
       }
     }
-    
+
   }
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test fixing iterator value not found exception
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(fixIteratorByValueNotFound, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // When
   auto iterator = grid.begin();
   auto const_iterator = const_grid.begin();
-  
+
   // Then
   BOOST_CHECK_THROW(iterator.fixAxisByValue<0>(axis1.size()+1), Elements::Exception);
   BOOST_CHECK_THROW(iterator.fixAxisByValue<1>(axis2.size()+1), Elements::Exception);
@@ -742,25 +745,25 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByValueNotFound, GridContainer_Fixture) {
   BOOST_CHECK_THROW(const_iterator.fixAxisByValue<1>(axis2.size()+1), Elements::Exception);
   BOOST_CHECK_THROW(const_iterator.fixAxisByValue<2>(axis3.size()+1), Elements::Exception);
   BOOST_CHECK_THROW(const_iterator.fixAxisByValue<3>(axis4.size()+1), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test fixing iterator by value twice for same axis throws exception
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(fixIteratorByValueTwiceForSameAxis, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // When
   auto iterator = grid.begin().fixAxisByValue<0>(1).fixAxisByValue<1>(1)
                               .fixAxisByValue<2>(1).fixAxisByValue<3>(1);
   auto const_iterator = const_grid.begin().fixAxisByValue<0>(1).fixAxisByValue<1>(1)
                                           .fixAxisByValue<2>(1).fixAxisByValue<3>(1);
-  
+
   // Then
   iterator.fixAxisByValue<0>(1);
   iterator.fixAxisByValue<1>(1);
@@ -770,43 +773,43 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByValueTwiceForSameAxis, GridContainer_Fixtur
   const_iterator.fixAxisByValue<1>(1);
   BOOST_CHECK_THROW(const_iterator.fixAxisByValue<2>(2), Elements::Exception);
   BOOST_CHECK_THROW(const_iterator.fixAxisByValue<3>(2), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test fixing all exes of iterator by other iterator
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(fixIteratorAllAxes, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid1 {axes_tuple};
   auto iter1 = grid1.begin();
   GridContainerType grid2 {axes_tuple};
   auto iter2 = grid2.begin();
-  
+
   // When
   iter1.fixAxisByIndex<0>(3).fixAxisByIndex<1>(2).fixAxisByIndex<2>(1).fixAxisByIndex<3>(0);
   iter2.fixAllAxes(iter1);
-  
+
   // Then
   BOOST_CHECK_EQUAL(iter2.axisIndex<0>(), 3u);
   BOOST_CHECK_EQUAL(iter2.axisIndex<1>(), 2u);
   BOOST_CHECK_EQUAL(iter2.axisIndex<2>(), 1u);
   BOOST_CHECK_EQUAL(iter2.axisIndex<3>(), 0u);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test slicing using index out of bound exception
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(sliceByIndexOutOfBound, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // Then
   BOOST_CHECK_THROW(grid.fixAxisByIndex<0>(axis1.size()), Elements::Exception);
   BOOST_CHECK_THROW(grid.fixAxisByIndex<1>(axis2.size()), Elements::Exception);
@@ -816,19 +819,19 @@ BOOST_FIXTURE_TEST_CASE(sliceByIndexOutOfBound, GridContainer_Fixture) {
   BOOST_CHECK_THROW(const_grid.fixAxisByIndex<1>(axis2.size()), Elements::Exception);
   BOOST_CHECK_THROW(const_grid.fixAxisByIndex<2>(axis3.size()), Elements::Exception);
   BOOST_CHECK_THROW(const_grid.fixAxisByIndex<3>(axis4.size()), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test slicing using index twice at the same axis throws exception
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(sliceByIndexTwiceSameAxis, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // When
   auto slice0 = grid.fixAxisByIndex<0>(0);
   auto slice1 = grid.fixAxisByIndex<1>(0);
@@ -838,7 +841,7 @@ BOOST_FIXTURE_TEST_CASE(sliceByIndexTwiceSameAxis, GridContainer_Fixture) {
   auto& const_slice1 = const_grid.fixAxisByIndex<1>(0);
   auto& const_slice2 = const_grid.fixAxisByIndex<2>(0);
   auto& const_slice3 = const_grid.fixAxisByIndex<3>(0);
-  
+
   // Then
   BOOST_CHECK_THROW(slice0.fixAxisByIndex<0>(0), Elements::Exception);
   BOOST_CHECK_THROW(slice1.fixAxisByIndex<1>(0), Elements::Exception);
@@ -848,19 +851,19 @@ BOOST_FIXTURE_TEST_CASE(sliceByIndexTwiceSameAxis, GridContainer_Fixture) {
   BOOST_CHECK_THROW(const_slice1.fixAxisByIndex<1>(0), Elements::Exception);
   BOOST_CHECK_THROW(const_slice2.fixAxisByIndex<2>(1), Elements::Exception);
   BOOST_CHECK_THROW(const_slice3.fixAxisByIndex<3>(1), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test slicing using value not found exception
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(sliceByValueNotFound, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // Then
   BOOST_CHECK_THROW(grid.fixAxisByValue<0>(axis1.size()+1), Elements::Exception);
   BOOST_CHECK_THROW(grid.fixAxisByValue<1>(axis2.size()+1), Elements::Exception);
@@ -870,19 +873,19 @@ BOOST_FIXTURE_TEST_CASE(sliceByValueNotFound, GridContainer_Fixture) {
   BOOST_CHECK_THROW(const_grid.fixAxisByValue<1>(axis2.size()+1), Elements::Exception);
   BOOST_CHECK_THROW(const_grid.fixAxisByValue<2>(axis3.size()+1), Elements::Exception);
   BOOST_CHECK_THROW(const_grid.fixAxisByValue<3>(axis4.size()+1), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test slicing using value twice at the same axis throws exception
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(sliceByValueTwiceSameAxis, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // When
   auto slice0 = grid.fixAxisByValue<0>(1);
   auto slice1 = grid.fixAxisByValue<1>(1);
@@ -892,7 +895,7 @@ BOOST_FIXTURE_TEST_CASE(sliceByValueTwiceSameAxis, GridContainer_Fixture) {
   auto& const_slice1 = const_grid.fixAxisByValue<1>(1);
   auto& const_slice2 = const_grid.fixAxisByValue<2>(1);
   auto& const_slice3 = const_grid.fixAxisByValue<3>(1);
-  
+
   // Then
   BOOST_CHECK_THROW(slice0.fixAxisByValue<0>(1), Elements::Exception);
   BOOST_CHECK_THROW(slice1.fixAxisByValue<1>(1), Elements::Exception);
@@ -902,46 +905,46 @@ BOOST_FIXTURE_TEST_CASE(sliceByValueTwiceSameAxis, GridContainer_Fixture) {
   BOOST_CHECK_THROW(const_slice1.fixAxisByValue<1>(1), Elements::Exception);
   BOOST_CHECK_THROW(const_slice2.fixAxisByValue<2>(2), Elements::Exception);
   BOOST_CHECK_THROW(const_slice3.fixAxisByValue<3>(2), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test that modifications to the slices are reflected to the original
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(sliceChancesReflected, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   auto slice_index = grid.fixAxisByIndex<0>(2).fixAxisByIndex<1>(2).fixAxisByIndex<2>(2).fixAxisByIndex<3>(1);
   auto slice_value = grid.fixAxisByValue<0>(2).fixAxisByValue<1>(2).fixAxisByValue<2>(2).fixAxisByValue<3>(1);
-  
+
   // When
   *slice_index.begin() = -10;
   *slice_value.begin() = -20;
-  
-  
+
+
   // Then
   BOOST_CHECK_EQUAL(grid(2, 2, 2, 1), -10);
   BOOST_CHECK_EQUAL(grid(1, 1, 1, 0), -20);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test that slices have correct axes and size
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(sliceAxes, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
   std::vector<int> expected_fixed_axis = {2};
-  
+
   // When
   auto slice = grid.fixAxisByIndex<1>(1);
   auto& const_slice = const_grid.fixAxisByIndex<1>(1);
-  
+
   // Then
   BOOST_CHECK_EQUAL(slice.size(), grid.size() / axis2.size());
   BOOST_CHECK_EQUAL(slice.getAxis<0>().name(), axis1.name());
@@ -963,19 +966,19 @@ BOOST_FIXTURE_TEST_CASE(sliceAxes, GridContainer_Fixture) {
   BOOST_CHECK_EQUAL_COLLECTIONS(const_slice.getAxis<2>().begin(), const_slice.getAxis<2>().end(), axis3.begin(), axis3.end());
   BOOST_CHECK_EQUAL(const_slice.getAxis<3>().name(), axis4.name());
   BOOST_CHECK_EQUAL_COLLECTIONS(const_slice.getAxis<3>().begin(), const_slice.getAxis<3>().end(), axis4.begin(), axis4.end());
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test that slices iterator works fine
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(sliceIterator, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   const GridContainerType& const_grid = grid;
-  
+
   // When
   auto slice = grid.fixAxisByIndex<1>(1).fixAxisByIndex<3>(0);
   auto slice_iter = slice.begin();
@@ -983,7 +986,7 @@ BOOST_FIXTURE_TEST_CASE(sliceIterator, GridContainer_Fixture) {
   auto& const_slice = const_grid.fixAxisByIndex<1>(1).fixAxisByIndex<3>(0);
   auto const_slice_iter = const_slice.begin();
   auto const_grid_iter = const_grid.begin().fixAxisByIndex<1>(1).fixAxisByIndex<3>(0);
-  
+
   // Then
   for (; slice_iter!=slice.end(); ++slice_iter, ++grid_iter) {
     BOOST_CHECK_EQUAL(*slice_iter, *grid_iter);
@@ -1001,15 +1004,15 @@ BOOST_FIXTURE_TEST_CASE(sliceIterator, GridContainer_Fixture) {
     BOOST_CHECK_EQUAL(const_slice_iter.axisValue<3>(), const_grid_iter.axisValue<3>());
   }
   BOOST_CHECK(const_grid_iter == const_grid.end());
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test that slices parenthesis operator works fine
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(sliceParenthesisOperator, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   double custom_value = 0;
@@ -1017,10 +1020,10 @@ BOOST_FIXTURE_TEST_CASE(sliceParenthesisOperator, GridContainer_Fixture) {
     custom_value += 0.1;
     cell = custom_value;
   }
-  
+
   // When
   auto slice = grid.fixAxisByIndex<1>(2).fixAxisByIndex<3>(1);
-  
+
   // Then
   for (size_t coord1=0; coord1<axis1.size(); ++coord1) {
     for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
@@ -1032,9 +1035,9 @@ BOOST_FIXTURE_TEST_CASE(sliceParenthesisOperator, GridContainer_Fixture) {
 //-----------------------------------------------------------------------------
 // Test that slices at works fine
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(sliceAtOperator, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
   double custom_value = 0;
@@ -1042,38 +1045,38 @@ BOOST_FIXTURE_TEST_CASE(sliceAtOperator, GridContainer_Fixture) {
     custom_value += 0.1;
     cell = custom_value;
   }
-  
+
   // When
   auto slice = grid.fixAxisByIndex<1>(2).fixAxisByIndex<3>(1);
-  
+
   // Then
   for (size_t coord1=0; coord1<axis1.size(); ++coord1) {
     for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
       BOOST_CHECK_EQUAL(slice.at(coord1, 0, coord3, 0), grid(coord1, 2, coord3, 1));
     }
   }
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test that slices fixed axes throw exception for non zero indices when at is used
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(sliceFixAxisNonZeroIndexAccess, GridContainer_Fixture) {
-  
+
   // Given
   GridContainerType grid {axes_tuple};
-  
+
   // When
   auto slice = grid.fixAxisByIndex<0>(0).fixAxisByIndex<1>(2).fixAxisByIndex<2>(2).fixAxisByIndex<3>(1);
-  
+
   // Then
   BOOST_CHECK_EQUAL(slice.at(0, 0, 0, 0), 0.);
   BOOST_CHECK_THROW(slice.at(1, 0, 0, 0), Elements::Exception);
   BOOST_CHECK_THROW(slice.at(0, 1, 0, 0), Elements::Exception);
   BOOST_CHECK_THROW(slice.at(0, 0, 1, 0), Elements::Exception);
   BOOST_CHECK_THROW(slice.at(0, 0, 0, 1), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------

--- a/MathUtils/tests/src/interpolation/Spline_test.cpp
+++ b/MathUtils/tests/src/interpolation/Spline_test.cpp
@@ -23,7 +23,6 @@
 */
 
 #include <boost/test/unit_test.hpp>
-#include <boost/test/floating_point_comparison.hpp>
 #include <cmath>
 #include "MathUtils/interpolation/interpolation.h"
 #include "MathUtils/function/Piecewise.h"
@@ -115,7 +114,7 @@ BOOST_FIXTURE_TEST_CASE(Spline_dfx, Spline_Fixture) {
 // also the second derivative of the splines to each side must match
 //-----------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(Spline_ddfx, Spline_Fixture) {
-  const double eps = std::numeric_limits<double>::epsilon();
+  const double eps = std::sqrt(std::numeric_limits<double>::epsilon());
 
   auto cubic_f = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
   auto cubic_pieces = dynamic_cast<Piecewise *>(cubic_f.get());

--- a/Table/Table/CastVisitor.h
+++ b/Table/Table/CastVisitor.h
@@ -1,20 +1,20 @@
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 /**
  * @file Table/CastVisitor.h
@@ -39,27 +39,27 @@ namespace Table {
 
 template <typename To>
 class CastVisitor : public boost::static_visitor<To> {
-  
+
 public:
-  
+
   template <typename From>
   To operator() (const From& from, typename std::enable_if<std::is_same<From, To>::value>::type* = 0) const {
     return from;
   }
-  
+
   template <typename From>
   To operator() (const From&, typename std::enable_if<!std::is_same<From, To>::value>::type* = 0) const {
     throw Elements::Exception() << "CastVisitor cannot convert "
             << typeid(From).name() << " type to " << typeid(To).name();
   }
-  
+
 };
 
 template <>
 class CastVisitor<std::string> : public boost::static_visitor<std::string> {
-  
+
 public:
-  
+
   template <typename From>
   std::string operator() (const From& from) const {
     std::stringstream result {};
@@ -71,25 +71,25 @@ public:
 
 template <>
 class CastVisitor<double> : public boost::static_visitor<double> {
-  
+
   template <typename From>
   static constexpr bool generic() {
     return std::is_arithmetic<From>::value;
   }
-  
+
 public:
-  
+
   template <typename From>
   double operator() (const From& , typename std::enable_if<!generic<From>()>::type* = 0) const {
     throw Elements::Exception() << "CastVisitor cannot convert "
             << typeid(From).name() << " type to " << typeid(double).name();
   }
-  
+
   template <typename From>
   double operator() (const From& from, typename std::enable_if<generic<From>()>::type* = 0) const {
     return from;
   }
-  
+
   double operator() (const std::string& from) const {
     char *endptr = nullptr;
     double value = std::strtod(from.c_str(), &endptr);
@@ -108,26 +108,26 @@ public:
 
 template <>
 class CastVisitor<float> : public boost::static_visitor<float> {
-  
+
   template <typename From>
   static constexpr bool generic() {
     return std::is_arithmetic<From>::value &&
            !std::is_same<From, double>::value;
   }
-  
+
 public:
-  
+
   template <typename From>
   double operator() (const From& , typename std::enable_if<!generic<From>()>::type* = 0) const {
     throw Elements::Exception() << "CastVisitor cannot convert "
             << typeid(From).name() << " type to " << typeid(float).name();
   }
-  
+
   template <typename From>
   float operator() (const From& from, typename std::enable_if<generic<From>()>::type* = 0) const {
     return from;
   }
-  
+
   float operator() (const std::string& from) const {
     char *endptr = nullptr;
     float value = std::strtof(from.c_str(), &endptr);
@@ -146,28 +146,28 @@ public:
 
 template <>
 class CastVisitor<int64_t> : public boost::static_visitor<int64_t> {
-  
+
   template <typename From>
   static constexpr bool generic() {
     return std::is_integral<From>::value;
   }
-  
+
 public:
-  
+
   template <typename From>
   double operator() (const From& , typename std::enable_if<!generic<From>()>::type* = 0) const {
     throw Elements::Exception() << "CastVisitor cannot convert "
             << typeid(From).name() << " type to " << typeid(int64_t).name();
   }
-  
+
   template <typename From>
   int64_t operator() (const From& from, typename std::enable_if<generic<From>()>::type* = 0) const {
     return from;
   }
-  
+
   int64_t operator() (const std::string& from) const {
     char *endptr = nullptr;
-    int64_t value = std::strtol(from.c_str(), &endptr, 10);
+    int64_t value = std::strtoll(from.c_str(), &endptr, 10);
     if (endptr == from.c_str()) {
       throw Elements::Exception() << "CastVisitor cannot convert the string '"
             << from << "' to " << typeid(int64_t).name();
@@ -179,29 +179,29 @@ public:
 
 template <>
 class CastVisitor<int32_t> : public boost::static_visitor<int32_t> {
-  
+
   template <typename From>
   static constexpr bool generic() {
     return std::is_integral<From>::value &&
             !std::is_same<From, int64_t>::value;
   }
-  
+
 public:
-  
+
   template <typename From>
   double operator() (const From& , typename std::enable_if<!generic<From>()>::type* = 0) const {
     throw Elements::Exception() << "CastVisitor cannot convert "
             << typeid(From).name() << " type to " << typeid(int32_t).name();
   }
-  
+
   template <typename From>
   int32_t operator() (const From& from, typename std::enable_if<generic<From>()>::type* = 0) const {
     return from;
   }
-  
+
   int32_t operator() (const std::string& from) const {
     char *endptr = nullptr;
-    int64_t value = std::strtol(from.c_str(), &endptr, 10);
+    int64_t value = std::strtoll(from.c_str(), &endptr, 10);
     if (endptr == from.c_str()) {
       throw Elements::Exception() << "CastVisitor cannot convert the string '"
                                   << from << "' to " << typeid(int32_t).name();
@@ -217,16 +217,16 @@ public:
 
 template <typename VectorType>
 class CastVisitor<std::vector<VectorType>> : public boost::static_visitor<std::vector<VectorType>> {
-  
+
 public:
-  
+
   template <typename From>
   std::vector<VectorType> operator() (const From& from) const {
     std::vector<VectorType> result {};
     result.push_back(CastVisitor<VectorType>{}(from));
     return result;
   }
-  
+
   template <typename From>
   std::vector<VectorType> operator() (const std::vector<From>& from) const {
     std::vector<VectorType> result {};
@@ -235,7 +235,7 @@ public:
     }
     return result;
   }
-  
+
   std::vector<VectorType> operator() (const std::string& from) const {
     std::vector<VectorType> result {};
     boost::char_separator<char> sep {","};
@@ -245,12 +245,12 @@ public:
     }
     return result;
   }
-    
+
   // If the types match exactly we avoid an expensive copying
   const std::vector<VectorType>& operator() (const std::vector<VectorType>& from) const {
     return from;
   }
-  
+
 };
 
 } /* namespace Table */

--- a/XYDataset/src/lib/QualifiedName.cpp
+++ b/XYDataset/src/lib/QualifiedName.cpp
@@ -93,7 +93,14 @@ size_t QualifiedName::hash() const {
 }
 
 bool QualifiedName::operator<(const QualifiedName& other) const {
-  return this->qualifiedName() < other.qualifiedName();
+  size_t thisHash = this->hash();
+  size_t otherHash = other.hash();
+  if (thisHash != otherHash) {
+    return thisHash < otherHash;
+  }
+  else {
+    return this->qualifiedName() < other.qualifiedName();
+  }
 }
 
 bool QualifiedName::operator==(const QualifiedName& other) const {

--- a/XYDataset/src/lib/QualifiedName.cpp
+++ b/XYDataset/src/lib/QualifiedName.cpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+ /**
  * @file src/lib/QualifiedName.cpp
  * @date May 19, 2014
  * @author Nikolaos Apostolakos
@@ -44,7 +44,7 @@ QualifiedName::QualifiedName(std::vector<std::string> groups, std::string name)
   }
   m_qualified_name.append(m_dataset_name);
 }
-            
+
 std::vector<std::string> getGroups(const std::string& qualified_name) {
   std::vector<std::string> groups {};
   boost::split(groups, qualified_name, boost::is_any_of("/"));
@@ -52,7 +52,7 @@ std::vector<std::string> getGroups(const std::string& qualified_name) {
   groups.pop_back();
   return groups;
 }
-            
+
 std::string getName(const std::string& qualified_name) {
   std::vector<std::string> groups {};
   boost::split(groups, qualified_name, boost::is_any_of("/"));
@@ -79,7 +79,7 @@ bool QualifiedName::belongsInGroup(const QualifiedName& group) const {
     return false;
   }
   bool group_check = std::equal(group.m_groups.begin(), group.m_groups.end(), this->m_groups.begin());
-  return group_check 
+  return group_check
         ? group.m_dataset_name == this->m_groups.at(group.m_groups.size())
         : false;
 }
@@ -93,13 +93,7 @@ size_t QualifiedName::hash() const {
 }
 
 bool QualifiedName::operator<(const QualifiedName& other) const {
-  size_t thisHash = this->hash();
-  size_t otherHash = other.hash();
-  if (thisHash != otherHash) {
-    return thisHash < otherHash;
-  } else{
-    return this->qualifiedName() < other.qualifiedName();
-  }
+  return this->qualifiedName() < other.qualifiedName();
 }
 
 bool QualifiedName::operator==(const QualifiedName& other) const {

--- a/XYDataset/tests/src/QualifiedName_test.cpp
+++ b/XYDataset/tests/src/QualifiedName_test.cpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+ /**
  * @file tests/src/QualifiedName_test.cpp
  * @date May 19, 2014
  * @author Nikolaos Apostolakos
@@ -38,12 +38,12 @@ BOOST_AUTO_TEST_SUITE (QualifiedName_test)
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(constructorExceptions_test) {
-  
+
   BOOST_CHECK_THROW((Euclid::XYDataset::QualifiedName{{"","g"}, "b"}),Elements::Exception);
   BOOST_CHECK_THROW((Euclid::XYDataset::QualifiedName{{"asd/sad", "g"}, "b"}), Elements::Exception);
   BOOST_CHECK_THROW((Euclid::XYDataset::QualifiedName{{"a","g"}, ""}), Elements::Exception);
   BOOST_CHECK_THROW((Euclid::XYDataset::QualifiedName{{"a","g"}, "bdf/sdf"}), Elements::Exception);
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -51,12 +51,12 @@ BOOST_AUTO_TEST_CASE(constructorExceptions_test) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(nameMethods_test) {
-  
+
   // Given
   std::string group1 = "TestGroup1";
   std::string group2 = "TestGroup2";
   std::string name = "TestName";
-  
+
   // When
   Euclid::XYDataset::QualifiedName qualifiedName1 {{group1,group2}, name};
   auto groups1 = qualifiedName1.groups();
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(nameMethods_test) {
   auto groups2 = qualifiedName2.groups();
   Euclid::XYDataset::QualifiedName qualifiedName3 {{}, name};
   auto groups3 = qualifiedName3.groups();
-  
+
   // Then
   BOOST_CHECK_EQUAL(groups1.size(), 2);
   BOOST_CHECK_EQUAL(groups1[0], group1);
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(nameMethods_test) {
   BOOST_CHECK_EQUAL(groups3.size(), 0);
   BOOST_CHECK_EQUAL(qualifiedName3.datasetName(), name);
   BOOST_CHECK_EQUAL(qualifiedName3.qualifiedName(), name);
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -86,10 +86,10 @@ BOOST_AUTO_TEST_CASE(nameMethods_test) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(belongsInGroup_test) {
-  
+
   // Given
   Euclid::XYDataset::QualifiedName qualified_name {"group1/group2/group3/name"};
-  
+
   // When
   Euclid::XYDataset::QualifiedName group1 {"group1"};
   Euclid::XYDataset::QualifiedName group1_group2 {"group1/group2"};
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(belongsInGroup_test) {
   Euclid::XYDataset::QualifiedName wrong_group_1 {"wrong_group"};
   Euclid::XYDataset::QualifiedName wrong_group_2 {"group1group2"};
   Euclid::XYDataset::QualifiedName wrong_group_3 {"group1/group4/group3"};
-  
+
   // Then
   BOOST_CHECK(qualified_name.belongsInGroup(group1));
   BOOST_CHECK(qualified_name.belongsInGroup(group1_group2));
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(belongsInGroup_test) {
   BOOST_CHECK(!qualified_name.belongsInGroup(wrong_group_2));
   BOOST_CHECK(!qualified_name.belongsInGroup(wrong_group_3));
   BOOST_CHECK(!qualified_name.belongsInGroup(qualified_name));
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -114,38 +114,38 @@ BOOST_AUTO_TEST_CASE(belongsInGroup_test) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(hashMethod_test) {
-  
+
   // Given
   Euclid::XYDataset::QualifiedName qualifiedName1 {{"group1","group2"}, "name"};
   Euclid::XYDataset::QualifiedName qualifiedName2 {{"group1","group2"}, "name"};
-  
+
   // Then
   BOOST_CHECK_EQUAL(qualifiedName1.hash(), qualifiedName2.hash());
-  
+
   // Given
   qualifiedName1 = Euclid::XYDataset::QualifiedName {{"group1","group2"}, "name"};
   qualifiedName2 = Euclid::XYDataset::QualifiedName {{"group1","group2"}, "name2"};
-  
+
   // Then
   BOOST_CHECK_NE(qualifiedName1.hash(), qualifiedName2.hash());
-  
+
   // Given
   qualifiedName1 = Euclid::XYDataset::QualifiedName {{"group1","group2"}, "name"};
   qualifiedName2 = Euclid::XYDataset::QualifiedName {{"group1","grou2"}, "name"};
-  
+
   // Then
   BOOST_CHECK_NE(qualifiedName1.hash(), qualifiedName2.hash());
-  
+
   // Given
   qualifiedName1 = Euclid::XYDataset::QualifiedName {{"group1","group2"}, "name"};
   qualifiedName2 = Euclid::XYDataset::QualifiedName {{"group1","group2"}, "name2"};
-  
+
   // Then
   BOOST_CHECK_NE(qualifiedName1.hash(), qualifiedName2.hash());
-  
+
   // Given
   std::hash<Euclid::XYDataset::QualifiedName> stdHashFunction;
-  
+
   // Then
   BOOST_CHECK_EQUAL(qualifiedName1.hash(), stdHashFunction(qualifiedName1));
 }
@@ -155,24 +155,24 @@ BOOST_AUTO_TEST_CASE(hashMethod_test) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(comparison_test) {
-  
+
   // Given
   Euclid::XYDataset::QualifiedName qualifiedName1 {{"group1","group2"}, "name"};
   Euclid::XYDataset::QualifiedName qualifiedName2 {{"group1","group2"}, "name"};
-  
+
   // Then
   BOOST_CHECK(!(qualifiedName1 < qualifiedName2));
   BOOST_CHECK(!(qualifiedName2 < qualifiedName1));
-  
+
   // Given
   qualifiedName1 = Euclid::XYDataset::QualifiedName {{"agroup"}, "aname"};
   qualifiedName2 = Euclid::XYDataset::QualifiedName {{"bgroup"}, "aname"};
   Euclid::XYDataset::QualifiedName qualifiedName3 {{"bgroup"}, "bname"};
-  
+
   // Then
-  BOOST_CHECK_EQUAL(qualifiedName1 < qualifiedName2, qualifiedName1.hash() < qualifiedName2.hash());
-  BOOST_CHECK_EQUAL(qualifiedName2 < qualifiedName3, qualifiedName2.hash() < qualifiedName3.hash());
-  BOOST_CHECK_EQUAL(qualifiedName1 < qualifiedName3, qualifiedName1.hash() < qualifiedName3.hash());
+  BOOST_CHECK(qualifiedName1 < qualifiedName2);
+  BOOST_CHECK(qualifiedName2 < qualifiedName3);
+  BOOST_CHECK(qualifiedName1 < qualifiedName3);
 
 }
 
@@ -181,20 +181,20 @@ BOOST_AUTO_TEST_CASE(comparison_test) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(equality_test) {
-  
-  
+
+
   // Given
   Euclid::XYDataset::QualifiedName qualifiedName1 {{"group1","group2"}, "name"};
   Euclid::XYDataset::QualifiedName qualifiedName2 {{"group1","group2"}, "name"};
-  
+
   // Then
   BOOST_CHECK(qualifiedName1 == qualifiedName2);
-  
+
   // Given
   qualifiedName1 = Euclid::XYDataset::QualifiedName {{"agroup"}, "aname"};
   qualifiedName2 = Euclid::XYDataset::QualifiedName {{"bgroup"}, "aname"};
   Euclid::XYDataset::QualifiedName qualifiedName3 {{"bgroup"}, "bname"};
-  
+
   // Then
   BOOST_CHECK(!(qualifiedName1 == qualifiedName2));
   BOOST_CHECK(!(qualifiedName2 == qualifiedName3));
@@ -203,63 +203,33 @@ BOOST_AUTO_TEST_CASE(equality_test) {
 }
 
 //-----------------------------------------------------------------------------
-// Check the ordering by hash
-//-----------------------------------------------------------------------------
-
-BOOST_AUTO_TEST_CASE(hashOrdering_test) {
-  
-  // Given
-  Euclid::XYDataset::QualifiedName qualifiedName1 {{"SDSS"}, "g"};
-  Euclid::XYDataset::QualifiedName qualifiedName2 {{"COSMOS"}, "g"};
-  Euclid::XYDataset::QualifiedName qualifiedName3 {{"COSMOS"}, "z"};
-  
-  // When
-  std::set<Euclid::XYDataset::QualifiedName> filterSet {};
-  filterSet.insert(qualifiedName1);
-  filterSet.insert(qualifiedName2);
-  filterSet.insert(qualifiedName3);
-  
-  // Then
-  BOOST_CHECK(qualifiedName3.hash() < qualifiedName2.hash());
-  BOOST_CHECK(qualifiedName2.hash() < qualifiedName1.hash());
-  BOOST_CHECK(qualifiedName3.hash() < qualifiedName1.hash());
-  auto iterator = filterSet.begin();
-  BOOST_CHECK((*iterator) == qualifiedName3);
-  ++iterator;
-  BOOST_CHECK((*iterator) == qualifiedName2);
-  ++iterator;
-  BOOST_CHECK((*iterator) == qualifiedName1);
-  
-}
-
-//-----------------------------------------------------------------------------
 // Check the ordering alphabetically
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(alphabeticalOrdering_test) {
-  
+
   // Given
   Euclid::XYDataset::QualifiedName qualifiedName1 {{"SDSS"}, "g"};
   Euclid::XYDataset::QualifiedName qualifiedName2 {{"COSMOS"}, "g"};
   Euclid::XYDataset::QualifiedName qualifiedName3 {{"COSMOS"}, "z"};
-  
+
   // When
   std::set<Euclid::XYDataset::QualifiedName, Euclid::XYDataset::QualifiedName::AlphabeticalComparator> filterSet {};
   filterSet.insert(qualifiedName1);
   filterSet.insert(qualifiedName2);
   filterSet.insert(qualifiedName3);
-  
+
   // Then
-  BOOST_CHECK(qualifiedName3.hash() < qualifiedName2.hash());
-  BOOST_CHECK(qualifiedName2.hash() < qualifiedName1.hash());
-  BOOST_CHECK(qualifiedName3.hash() < qualifiedName1.hash());
+  BOOST_CHECK(qualifiedName3.hash() != qualifiedName2.hash());
+  BOOST_CHECK(qualifiedName2.hash() != qualifiedName1.hash());
+  BOOST_CHECK(qualifiedName3.hash() != qualifiedName1.hash());
   auto iterator = filterSet.begin();
   BOOST_CHECK((*iterator) == qualifiedName2);
   ++iterator;
   BOOST_CHECK((*iterator) == qualifiedName3);
   ++iterator;
   BOOST_CHECK((*iterator) == qualifiedName1);
-  
+
 }
 
 BOOST_AUTO_TEST_SUITE_END ()

--- a/XYDataset/tests/src/QualifiedName_test.cpp
+++ b/XYDataset/tests/src/QualifiedName_test.cpp
@@ -170,10 +170,9 @@ BOOST_AUTO_TEST_CASE(comparison_test) {
   Euclid::XYDataset::QualifiedName qualifiedName3 {{"bgroup"}, "bname"};
 
   // Then
-  BOOST_CHECK(qualifiedName1 < qualifiedName2);
-  BOOST_CHECK(qualifiedName2 < qualifiedName3);
-  BOOST_CHECK(qualifiedName1 < qualifiedName3);
-
+  BOOST_CHECK(qualifiedName1 < qualifiedName2 ^ qualifiedName2 < qualifiedName1);
+  BOOST_CHECK(qualifiedName2 < qualifiedName3 ^ qualifiedName3 < qualifiedName2);
+  BOOST_CHECK(qualifiedName1 < qualifiedName3 ^ qualifiedName3 < qualifiedName1);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
I have also dropped the assumption that the hash of strings keep the relative order of those strings, because that's a false expectation. It is odd it has been working so far, switching between compilers and OS, though. I would say luck.

These problems are visible now because I can compile and run the tests, but not install them, when packaging for Fedora, where things are build for i686, x86_64, ppc64le, s390x, aarch64 and armv7.