### PR TITLE
WIP: Add npy support

### DIFF
--- a/NdArray/CMakeLists.txt
+++ b/NdArray/CMakeLists.txt
@@ -1,11 +1,20 @@
 elements_subdir(NdArray)
 
+find_package(Boost REQUIRED COMPONENTS iostreams)
+
 #===== Libraries ===============================================================
 elements_add_library(NdArray
         LINKER_LANGUAGE CXX
-        LINK_LIBRARIES AlexandriaKernel
+        LINK_LIBRARIES AlexandriaKernel Boost
         PUBLIC_HEADERS NdArray)
 
 #===== Boost tests =============================================================
 elements_add_unit_test(NdArray_test tests/src/NdArray_test.cpp
         LINK_LIBRARIES NdArray TYPE Boost)
+
+elements_add_unit_test(Npy_test tests/src/Npy_test.cpp
+        LINK_LIBRARIES NdArray TYPE Boost)
+
+elements_add_unit_test(NpyMmap_test tests/src/NpyMmap_test.cpp
+        LINK_LIBRARIES NdArray TYPE Boost)
+

--- a/NdArray/NdArray/io/Npy.h
+++ b/NdArray/NdArray/io/Npy.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef ALEXANDRIA_NDARRAY_NPY_H
+#define ALEXANDRIA_NDARRAY_NPY_H
+
+#include "NdArray/NdArray.h"
+#include <boost/filesystem/path.hpp>
+
+namespace Euclid {
+namespace NdArray {
+
+/**
+ * Write an NdArray to a file following numpy format
+ * @see
+ *  https://numpy.org/devdocs/reference/generated/numpy.lib.format.html
+ * @tparam T
+ *  NdArray cell type
+ * @tparam Container
+ *  NdArray container type
+ * @param out
+ *  Output stream
+ * @param array
+ *  NdArray to write
+ */
+template<typename T>
+void writeNpy(std::ostream& out, const NdArray<T>& array);
+
+/**
+ * Read an NdArray from a file following numpy format
+ * @tparam T
+ *  NdArray cell type
+ * @tparam Container
+ *  NdArray container type
+ * @param input
+ *  Input stream
+ * @return
+ *  A new NdArray
+ * @note
+ *  The underlying numpy format is expected to match the template type T
+ */
+template<typename T>
+NdArray<T> readNpy(std::istream& input);
+
+
+/**
+ * @see
+ *  https://numpy.org/devdocs/reference/generated/numpy.lib.format.html
+ * @tparam T
+ *  NdArray cell type
+ * @tparam Container
+ *  NdArray container type
+ * @param path
+ *  Output path
+ * @param array
+ *  NdArray to write
+ */
+template<typename T>
+void writeNpy(const boost::filesystem::path& path, const NdArray<T>& array) {
+  std::ofstream output(path.native(), std::ios_base::out | std::ios_base::binary);
+  writeNpy(output, array);
+}
+
+/**
+ * Read an NdArray from a file following numpy format
+ * @tparam T
+ *  NdArray cell type
+ * @tparam Container
+ *  NdArray container type
+ * @param path
+ *  Input path
+ * @return
+ *  A new NdArray
+ * @note
+ *  The underlying numpy format is expected to match the template type T
+ */
+template<typename T>
+NdArray<T> readNpy(const boost::filesystem::path& path) {
+  std::ifstream input(path.native(), std::ios_base::in | std::ios_base::binary);
+  return readNpy<T>(input);
+}
+
+
+} // end of namespace NdArray
+} // end of namespace Euclid
+
+#define NPY_IMPL
+#include "NdArray/io/_impl/NpyWriter.icpp"
+#include "NdArray/io/_impl/NpyReader.icpp"
+#undef NPY_IMPL
+
+#endif // ALEXANDRIA_NDARRAY_NPY_H

--- a/NdArray/NdArray/io/NpyMmap.h
+++ b/NdArray/NdArray/io/NpyMmap.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef ALEXANDRIA_NDARRAY_IO_NPYMMAP_H
+#define ALEXANDRIA_NDARRAY_IO_NPYMMAP_H
+
+#include <boost/filesystem/path.hpp>
+#include "NdArray/NdArray.h"
+
+namespace Euclid {
+namespace NdArray {
+
+/**
+ * Open using mmap an existing numpy file
+ * @tparam T
+ *  NdArray cell type
+ * @param path
+ *  Input path
+ * @param mode
+ *  Open mode. By default read/write, so changes are persisted to disk.
+ *  boost::iostreams::mapped_file_base::priv enabled a Copy-On-Write, so the memory can be modified
+ *  but the changes will not persist
+ * @return
+ *  A new NdArray
+ * @note
+ *  The underlying numpy format is expected to match the template type T
+ * @note
+ *  If you open in read-only mode, assign to a const NdArray to avoid accidental writes
+ */
+template<typename T>
+NdArray<T> mmapNpy(const boost::filesystem::path& path,
+                   boost::iostreams::mapped_file_base::mapmode mode = boost::iostreams::mapped_file_base::readwrite);
+
+/**
+ * Create using mmap an NdArray backed by a numpy file
+ * @tparam T
+ *  NdArray cell type
+ * @param path
+ *  Output path
+ * @param shape
+ *  NdArray shape
+ * @return
+ *  A new NdArray
+ */
+template<typename T>
+NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<size_t>& shape);
+
+} // end of namespace NdArray
+} // end of namespace Euclid
+
+#define NPYMMAP_IMPL
+#include "NdArray/io/_impl/NpyMmap.icpp"
+#undef NPYMMAP_IMPL
+
+#endif // ALEXANDRIA_NDARRAY_IO_NPYMMAP_H

--- a/NdArray/NdArray/io/_impl/NpyCommon.h
+++ b/NdArray/NdArray/io/_impl/NpyCommon.h
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef ALEXANDRIA_NDARRAY_IMPL_NPYCOMMON_H
+#define ALEXANDRIA_NDARRAY_IMPL_NPYCOMMON_H
+
+#include <boost/iostreams/device/mapped_file.hpp>
+#include <boost/endian/arithmetic.hpp>
+#include "AlexandriaKernel/StringUtils.h"
+
+namespace Euclid {
+namespace NdArray {
+
+using boost::endian::little_uint16_t;
+using boost::endian::little_uint32_t;
+
+/**
+ * Magic string for .npy files
+ */
+constexpr const char NPY_MAGIC[] = {'\x93', 'N', 'U', 'M', 'P', 'Y'};
+
+/**
+ * Map a primitive type to a string representation for numpy
+ */
+template<typename T>
+struct NpyDtype {
+};
+
+template<>
+struct NpyDtype<int8_t> {
+  static constexpr const char *str = "b";
+};
+
+template<>
+struct NpyDtype<int32_t> {
+  static constexpr const char *str = "i4";
+};
+
+template<>
+struct NpyDtype<int64_t> {
+  static constexpr const char *str = "i8";
+};
+
+template<>
+struct NpyDtype<uint8_t> {
+  static constexpr const char *str = "B";
+};
+
+template<>
+struct NpyDtype<uint32_t> {
+  static constexpr const char *str = "u4";
+};
+
+template<>
+struct NpyDtype<uint64_t> {
+  static constexpr const char *str = "u8";
+};
+
+template<>
+struct NpyDtype<float> {
+  static constexpr const char *str = "f4";
+};
+
+template<>
+struct NpyDtype<double> {
+  static constexpr const char *str = "f8";
+};
+
+/**
+ * Parse the dictionary serialized on the npy file
+ * @param header
+ *  String representation of the dictionary
+ * @param fortran_order [out]
+ *  Put here if the numpy array follows the Fortran convention
+ * @param big_endian [out]
+ *  Put here if the numpy array layout is big-endian
+ * @param dtype
+ *  Put here the read dtype
+ * @param shape [out]
+ *  Put here the read shape
+ * @param n_elements [out]
+ *  Total number of elements (multiplication of shape)
+ */
+void parseNpyDict(const std::string& header, bool& fortran_order, bool& big_endian,
+                  std::string& dtype, std::vector<size_t>& shape, size_t& n_elements) {
+  auto loc = header.find("fortran_order") + 16;
+  fortran_order = (header.substr(loc, 4) == "True");
+
+  loc = header.find("descr") + 9;
+  big_endian = (header[loc] == '>');
+
+  auto loc2 = header.find("'", loc);
+  dtype = header.substr(loc + 1, loc2 - loc - 1);
+
+  loc = header.find("shape") + 9;
+  loc2 = header.find(")", loc);
+  auto shape_str = header.substr(loc, loc2 - loc);
+  if (shape_str.back() == ',')
+    shape_str.resize(shape_str.size() - 1);
+  shape = stringToVector<size_t>(shape_str);
+  n_elements = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<size_t>());
+}
+
+/**
+ * Read the npy header
+ * @param input
+ *  Input stream
+ * @param dtype [out]
+ *  Put here the read dtype
+ * @param shape [out]
+ *  Put here the read shape
+ * @param n_elements [out]
+ *  Total number of elements (multiplication of shape)
+ * @return
+ */
+void readNpyHeader(std::istream& input, std::string& dtype, std::vector<size_t>& shape, size_t& n_elements) {
+  // Magic
+  char magic[6];
+  input.read(magic, sizeof(magic));
+  if (std::memcmp(magic, NPY_MAGIC, sizeof(NPY_MAGIC)) != 0) {
+    throw Elements::Exception() << "Unexpected magic sequence";
+  }
+
+  // Version and header len
+  little_uint32_t header_len;
+  little_uint16_t version;
+  input.read(reinterpret_cast<char *>(&version), sizeof(version));
+  if (version > 30) {
+    throw Elements::Exception() << "Only numpy arrays with version 3 or less are supported";
+  }
+  else if (version.data()[0] == 1) {
+    // 16 bits integer in little endian
+    little_uint16_t aux;
+    input.read(reinterpret_cast<char *>(&aux), sizeof(aux));
+    header_len = aux;
+  }
+  else {
+    // 32 bits integer in little endian
+    input.read(reinterpret_cast<char *>(&header_len), sizeof(header_len));
+  }
+
+  // Read header
+  std::string header(header_len, '\0');
+  input.read(&header[0], header_len);
+
+  // Parse header
+  bool fortran_order, big_endian;
+  parseNpyDict(header, fortran_order, big_endian, dtype, shape, n_elements);
+
+  if (fortran_order)
+    throw Elements::Exception() << "Fortran order not supported";
+
+  if (big_endian && (__BYTE_ORDER != __BIG_ENDIAN))
+    throw Elements::Exception() << "Only native endianness supported for reading";
+}
+
+/**
+ * A memory mapped container that can be used by NdArray.
+ * Builds on top of boost::iostream::mapped_file
+ * @tparam T
+ *  Contained value type
+ */
+template<typename T>
+class MappedContainer {
+public:
+  MappedContainer(size_t offset, size_t data_size, boost::iostreams::mapped_file&& input)
+    : m_size(data_size), m_input(std::move(input)), m_data(reinterpret_cast<T *>(m_input.data() + offset)) {
+  }
+
+  size_t size() const {
+    return m_size;
+  }
+
+  T* data () {
+    return m_data;
+  }
+
+private:
+  size_t m_size;
+  boost::iostreams::mapped_file m_input;
+  T *m_data;
+};
+
+} // end of namespace NdArray
+} // end of namespace Euclid
+
+#endif // ALEXANDRIA_NDARRAY_IMPL_NPYCOMMON_H

--- a/NdArray/NdArray/io/_impl/NpyMmap.icpp
+++ b/NdArray/NdArray/io/_impl/NpyMmap.icpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifdef NPYMMAP_IMPL
+
+#include "NpyCommon.h"
+#include <boost/iostreams/stream.hpp>
+#include <boost/iostreams/device/mapped_file.hpp>
+#include <boost/filesystem/path.hpp>
+#include <numeric>
+
+namespace Euclid {
+namespace NdArray {
+
+typedef boost::iostreams::stream<boost::iostreams::mapped_file> MappedStream;
+
+template<typename T>
+NdArray <T> mmapNpy(const boost::filesystem::path& path, boost::iostreams::mapped_file_base::mapmode mode) {
+  std::string dtype;
+  size_t n_elements = 0;
+  std::vector<size_t> shape;
+
+  boost::iostreams::mapped_file_params map_params;
+  map_params.path = path.native();
+  map_params.flags = mode;
+
+  boost::iostreams::mapped_file input(map_params);
+  MappedStream stream(input);
+  stream.set_auto_close(false);
+  readNpyHeader(stream, dtype, shape, n_elements);
+
+  if (dtype != NpyDtype<T>::str)
+    throw Elements::Exception() << "Can not cast " << dtype << " into " << typeid(T).name();
+
+  return {shape, std::move(MappedContainer<T>(stream.tellg(), n_elements, std::move(input)))};
+}
+
+template<typename T>
+NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<size_t>& shape) {
+  // Pre-generate header
+  std::stringstream header;
+  writeNpyHeader<T>(header, shape);
+  auto header_str = header.str();
+  auto header_size = header_str.size();
+
+  // Compute file expected size
+  size_t n_elements = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<size_t>());
+  size_t data_size = n_elements * sizeof(T);
+  size_t total_size = header_size + data_size;
+
+  boost::iostreams::mapped_file_params map_params;
+  map_params.path = path.native();
+  map_params.flags = boost::iostreams::mapped_file_base::readwrite;
+  map_params.new_file_size = total_size;
+
+  boost::iostreams::mapped_file output(map_params);
+  std::copy(header_str.begin(), header_str.end(), output.begin());
+  return {shape, std::move(MappedContainer<T>(header_size, n_elements, std::move(output)))};
+}
+
+} // end of namespace NdArray
+} // end of namespace Euclid
+
+#endif // NPYMMAP_IMPL

--- a/NdArray/NdArray/io/_impl/NpyReader.icpp
+++ b/NdArray/NdArray/io/_impl/NpyReader.icpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifdef NPY_IMPL
+
+#include <endian.h>
+#include <cstring>
+#include <istream>
+#include <boost/endian/arithmetic.hpp>
+#include <ElementsKernel/Exception.h>
+#include "AlexandriaKernel/StringUtils.h"
+#include "NdArray/NdArray.h"
+#include "NpyCommon.h"
+
+namespace Euclid {
+namespace NdArray {
+
+using boost::endian::little_uint16_t;
+using boost::endian::little_uint32_t;
+
+template<typename T>
+NdArray <T> readNpy(std::istream& input) {
+  std::string dtype;
+  size_t n_elements;
+  std::vector<size_t> shape;
+
+  readNpyHeader(input, dtype, shape, n_elements);
+  if (dtype != NpyDtype<T>::str)
+    throw Elements::Exception() << "Can not cast " << dtype << " into " << typeid(T).name();
+
+  std::vector<T> data(n_elements);
+  input.read(reinterpret_cast<char *>(&data[0]), sizeof(T) * data.size());
+  return {shape, std::move(data)};
+}
+
+} // end of namespace NdArray
+} // end of namespace Euclid
+
+#endif // NPY_IMPL

--- a/NdArray/NdArray/io/_impl/NpyWriter.icpp
+++ b/NdArray/NdArray/io/_impl/NpyWriter.icpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifdef NPY_IMPL
+
+#include <endian.h>
+#include <sstream>
+#include <boost/endian/arithmetic.hpp>
+#include <ElementsKernel/Exception.h>
+#include "NdArray/NdArray.h"
+#include "NpyCommon.h"
+
+namespace Euclid {
+namespace NdArray {
+
+using boost::endian::little_uint16_t;
+using boost::endian::little_uint32_t;
+
+/**
+ * We write arrays following 2.0 version (32 bits header size)
+ */
+constexpr const uint8_t NPY_VERSION[] = {'\x02', '\x00'};
+
+/**
+ * Generate a string that represents an NdArray shape vector as a Python tuple
+ * @param shape
+ * @return
+ *  A string with the Python representation of a tuple
+ */
+inline std::string npyShape(const std::vector<size_t>& shape) {
+  std::stringstream shape_stream;
+  shape_stream << "(";
+  for (auto s : shape) {
+    shape_stream << s << ',';
+  }
+  shape_stream << ")";
+  return shape_stream.str();
+}
+
+/**
+ * Endianness marker for the numpy array
+ */
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+constexpr const char *ENDIAN_MARKER = "<";
+#elif __BYTE_ORDER == __BIG_ENDIAN
+constexpr const char* ENDIAN_MARKER = ">";
+#else
+#error "__PDP_ENDIAN not supported"
+#endif
+
+/**
+ * Write header
+ */
+template<typename T>
+void writeNpyHeader(std::ostream& out, const std::vector<size_t>& shape) {
+  // Serialize header as a Python dict
+  std::stringstream header;
+  header << "{"
+         << "'descr': '" << ENDIAN_MARKER << NpyDtype<T>::str << "', 'fortran_order': False, 'shape': "
+         << npyShape(shape)
+         << "}";
+  auto header_str = header.str();
+  little_uint32_t header_len = header_str.size();
+
+  // Pad header with spaces so the header block is 64 bytes aligned
+  size_t total_length = sizeof(NPY_MAGIC) + sizeof(NPY_VERSION) + sizeof(header_len) + header_len - 1; // Keep 1 for \n
+  size_t padding = 64 - total_length % 64;
+  if (padding) {
+    header << std::string(padding, '\x20') << '\n';
+    header_str = header.str();
+    header_len = header_str.size();
+  }
+
+  // Magic and version
+  out.write(NPY_MAGIC, sizeof(NPY_MAGIC));
+  out.write(reinterpret_cast<const char *>(&NPY_VERSION), sizeof(NPY_VERSION));
+
+  // HEADER_LEN
+  out.write(reinterpret_cast<char*>(&header_len), sizeof(header_len));
+
+  // HEADER
+  out.write(header_str.data(), header_str.size());
+}
+
+/*
+ * Implementation of writeNpy
+ */
+template<typename T>
+void writeNpy(std::ostream& out, const NdArray<T>& array) {
+  writeNpyHeader<T>(out, array.shape());
+  // The header already has the endian type, so just dump the content of the array
+  for (auto v : array) {
+    out.write(reinterpret_cast<const char *>(&v), sizeof(v));
+  }
+}
+
+} // end of namespace NdArray
+} // end of namespace Euclid
+
+#endif // NPY_IMPL

--- a/NdArray/doc/NdArray.dox
+++ b/NdArray/doc/NdArray.dox
@@ -15,16 +15,19 @@ contiguously in memory in row-major order. For instance, a 3D array with the sha
 \prod_{i=0}^{n}shape[i]
 \f]
 
-The order in memory is for that array would be:
+The order in memory for that array would be:
 
 \code
 v[0,0,0], v[0,0,1], v[0,0,2], v[0,0,3], v[0,1,0], v[0,1,1], v[0,1,2], v[0,1,3] ... v[2,1,3]
 \endcode
 
-\note The NdArray class has two template parameters: the contained and the container types. By default, the container
-is a vector, so the former explanation is true. However, nothing prevents the usage of this class with a container
-that does not allocate elements contiguously in memory. On the other hand, this parametrization allows also
-to use this class with containers as, say, thrust::device_vector.
+\note The NdArray class has one template parameters: the contained type.
+A second template parameter, used only at construction time, is a Container class (std::vector by default),
+which owns the memory used by NdArray.
+However, NdArray uses type erasure so it can be moved around regardless of the underlying storage.
+This allows to switch between RAM and memory mapped files transparently, without modifying any method that expects
+an NdArray.
+The underlying container is assumed to allocate a sequential address space.
 
 \section Usage
 
@@ -92,6 +95,40 @@ this operator (technically, `boost::lexical_cast` does). The output has the form
 \code{.cpp}
 std::cout << nd_array << std::endl;
 //<3,2,4>42,42,42,42,42,42
+\endcode
+
+\section npy Npy files
+
+Alexandria 2.17 adds support for <a href="https://numpy.org/devdocs/reference/generated/numpy.lib.format.html">numpy
+array files</a>. For using them, you need to include the header `NdArray/io/Npy.h`, and `NdArray/io/NpyMmap.h` for
+memory mapped files. This allows the exchange of data between Alexandria based software and Python.
+
+Note, however, that the support is limited to primitive types - ints of different sizes, floats, doubles - with
+native <a href="https://en.wikipedia.org/wiki/Endianness">endianness</a>. Structured arrays are not supported.
+
+The generated files can be read by `numpy` in any architecture, as the metadata is properly initialized.
+
+An example for reading a `numpy` array:
+
+\code{.cpp}
+auto nd_array_int = readNpy<int64_t>("/tmp/myints.npy");
+auto nd_array_double = readNpy<double>("/tmp/mydoubles.npy");
+\endcode
+
+For writing:
+
+\code{.cpp}
+writeNpy("/tmp/output.npy", ndarray);
+\endcode
+
+As you can notice, the type has to be known in advance.
+
+Alexandria also supports memory mapped files both for reading and writing, although for creation the shape
+has to be known in advance:
+
+\code{.cpp}
+auto nd_array_int_mmap = mmapNpy<int64_t>("/tmp/myints.npy");
+auto nd_array_float_mmap = createMmapNpy<float>("/tmp/mynewfloats.npy", {1000, 1000, 2});
 \endcode
 
 */

--- a/NdArray/doc/NdArray.puml
+++ b/NdArray/doc/NdArray.puml
@@ -1,9 +1,9 @@
 @startuml
 
-class NdArray<T, Container> {
+class NdArray<T> {
   - m_shape : vector<size_t>
   - m_stride_size : vector<size_t>
-  - m_container : Container<T>
+  - m_container : ContainerWrapper<T>
   --
   + NdArray(shape)
   + NdArray(shape, data)
@@ -19,5 +19,14 @@ class NdArray<T, Container> {
   + operator == () : bool
   + operator != () : bool
 }
+
+class ContainerWrapper<T> {
+  + m_data : T*
+  --
+  + size() : size_t
+  + copy() : ContainerWrapper<T>
+}
+
+NdArray o-- ContainerWrapper
 
 @enduml

--- a/NdArray/tests/src/NpyMmap_test.cpp
+++ b/NdArray/tests/src/NpyMmap_test.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <ElementsKernel/Temporary.h>
+#include "NdArray/io/Npy.h"
+#include "NdArray/io/NpyMmap.h"
+#include "TestHelper.h"
+
+using namespace Euclid::NdArray;
+
+BOOST_AUTO_TEST_SUITE(NpyMmap_test)
+
+BOOST_AUTO_TEST_CASE(MmapOpen_test) {
+  Elements::TempFile file("npy_mmap_%%.npy");
+
+  // Create npy
+  NdArray<int32_t> ndarray({50, 10, 40});
+  std::generate(ndarray.begin(), ndarray.end(), []() { return std::rand() % 1024; });
+  writeNpy(file.path(), ndarray);
+
+  // Open with mmap
+  {
+    auto mmapped = mmapNpy<int32_t>(file.path());
+    BOOST_CHECK_EQUAL(mmapped.shape().size(), 3);
+    BOOST_CHECK_EQUAL(mmapped.shape()[0], 50);
+    BOOST_CHECK_EQUAL(mmapped.shape()[1], 10);
+    BOOST_CHECK_EQUAL(mmapped.shape()[2], 40);
+    BOOST_CHECK_EQUAL_COLLECTIONS(ndarray.begin(), ndarray.end(), mmapped.begin(), mmapped.end());
+    // Modify a couple of elements
+    // Note we start at 1024 so there is no chance they have been generated randomly
+    mmapped.at(0, 1, 2) = 1024 + 42;
+    mmapped.at(42, 5, 33) = 1024 + 108;
+  }
+
+  // Re-open as regular file
+  // Changes should have persisted
+  auto read = readNpy<int32_t>(file.path());
+  BOOST_CHECK_EQUAL(read.at(0, 1, 2), 1024 + 42);
+  BOOST_CHECK_EQUAL(read.at(42, 5, 33), 1024 + 108);
+}
+
+BOOST_AUTO_TEST_CASE(MmapOpenPrivate_test) {
+  Elements::TempFile file("npy_mmap_%%.npy");
+
+  // Create npy
+  NdArray<int32_t> ndarray({50, 10, 40});
+  std::generate(ndarray.begin(), ndarray.end(), []() { return std::rand() % 1024; });
+  writeNpy(file.path(), ndarray);
+
+  // Open with mmap
+  {
+    auto mmapped = mmapNpy<int32_t>(file.path(), boost::iostreams::mapped_file_base::priv);
+    BOOST_CHECK_EQUAL(mmapped.shape().size(), 3);
+    BOOST_CHECK_EQUAL(mmapped.shape()[0], 50);
+    BOOST_CHECK_EQUAL(mmapped.shape()[1], 10);
+    BOOST_CHECK_EQUAL(mmapped.shape()[2], 40);
+    BOOST_CHECK_EQUAL_COLLECTIONS(ndarray.begin(), ndarray.end(), mmapped.begin(), mmapped.end());
+    // Modify a couple of elements
+    // Note we start at 1024 so there is no chance they have been generated randomly
+    mmapped.at(0, 1, 2) = 1024 + 42;
+    mmapped.at(42, 5, 33) = 1024 + 108;
+
+    BOOST_CHECK_EQUAL(mmapped.at(0, 1, 2), 1024 + 42);
+    BOOST_CHECK_EQUAL(mmapped.at(42, 5, 33), 1024 + 108);
+  }
+
+  // Re-open as regular file
+  // Changes should have persisted
+  auto read = readNpy<int32_t>(file.path());
+  BOOST_CHECK_EQUAL_COLLECTIONS(ndarray.begin(), ndarray.end(), read.begin(), read.end());
+}
+
+BOOST_AUTO_TEST_CASE(MmapCreate_test) {
+  Elements::TempFile file("npy_create_mmap_%%.npy");
+
+  {
+    auto ndarray = createMmapNpy<double>(file.path(), {100, 2});
+    for (size_t i = 0; i < 100; ++i) {
+      ndarray.at(i, 0) = i;
+      ndarray.at(i, 1) = 2 * i;
+    }
+  }
+
+  constexpr const char* PYCODE = R"EDOCYP(
+import sys
+import numpy as np
+a = np.load(sys.argv[1])
+assert a.dtype == np.float64
+assert a.shape == (100, 2)
+assert np.isclose(np.average(a[:,0], weights=a[:,1]),66.33333, 1e-3)
+)EDOCYP";
+  runPython(PYCODE, file.path());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/NdArray/tests/src/Npy_test.cpp
+++ b/NdArray/tests/src/Npy_test.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <boost/mpl/list.hpp>
+#include <ElementsKernel/Temporary.h>
+#include "NdArray/io/Npy.h"
+#include "TestHelper.h"
+
+using namespace Euclid::NdArray;
+
+BOOST_AUTO_TEST_SUITE(Npy_test)
+
+typedef boost::mpl::list<int32_t, int64_t, float, double> array_type;
+
+
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(Npy1d_readwrite_test, T, array_type) {
+  std::stringstream stream;
+
+  // Construct NdArray
+  NdArray<T> ndarray({100});
+  std::generate(ndarray.begin(), ndarray.end(), []() { return std::rand() % 100; });
+
+  // Write NPY
+  writeNpy(stream, ndarray);
+
+  // Read NPY
+  auto rend = readNpy<T>(stream);
+
+  BOOST_CHECK_EQUAL(rend.shape().size(), 1);
+  BOOST_CHECK_EQUAL(rend.shape()[0], 100);
+  BOOST_CHECK_EQUAL(rend.size(), ndarray.size());
+  BOOST_CHECK_EQUAL_COLLECTIONS(ndarray.begin(), ndarray.end(), rend.begin(), rend.end());
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(Npy2d_readwrite_test, T, array_type) {
+  std::stringstream stream;
+
+  // Construct NdArray
+  NdArray<T> ndarray({50, 2});
+  std::generate(ndarray.begin(), ndarray.end(), []() { return std::rand() % 100; });
+
+  // Write NPY
+  writeNpy(stream, ndarray);
+
+  // Read NPY
+  auto rend = readNpy<T>(stream);
+
+  BOOST_CHECK_EQUAL(rend.shape().size(), 2);
+  BOOST_CHECK_EQUAL(rend.shape()[0], 50);
+  BOOST_CHECK_EQUAL(rend.shape()[1], 2);
+  BOOST_CHECK_EQUAL(rend.size(), ndarray.size());
+  BOOST_CHECK_EQUAL_COLLECTIONS(ndarray.begin(), ndarray.end(), rend.begin(), rend.end());
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(Npy1d_python_test, T, array_type) {
+  Elements::TempFile file(std::string("npy_1d_test_") + typeid(T).name() + "_%%.npy");
+
+  // Construct NdArray
+  NdArray<T> ndarray({100});
+  std::generate(ndarray.begin(), ndarray.end(), []() { return std::rand() % 100; });
+
+  // Write NPY
+  writeNpy(file.path(), ndarray);
+
+  // Read NPY
+  constexpr const char* PYCODE = R"EDOCYP(
+import sys
+import numpy as np
+a = np.load(sys.argv[1])
+assert a.shape == (100,)
+print(a.sum())
+)EDOCYP";
+  auto output = runPython(PYCODE, file.path());
+
+  T sum;
+  output >> sum;
+  BOOST_CHECK_EQUAL(std::accumulate(ndarray.begin(), ndarray.end(), 0), sum);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(Npy2d_python_test, T, array_type) {
+  Elements::TempFile file(std::string("npy_testpy_") + typeid(T).name() + "_%%.npy");
+
+  // Construct NdArray
+  NdArray<T> ndarray({50, 2});
+  std::generate(ndarray.begin(), ndarray.end(), []() { return std::rand() % 100; });
+
+  // Write NPY
+  writeNpy(file.path(), ndarray);
+
+  // Read NPY
+  constexpr const char* PYCODE = R"EDOCYP(
+import sys
+import numpy as np
+a = np.load(sys.argv[1])
+assert a.shape == (50, 2)
+print((a[:,0] * a[:,1]).sum())
+)EDOCYP";
+  auto output = runPython(PYCODE, file.path());
+
+  // Must match
+  T expected = 0;
+  for (size_t i = 0; i < ndarray.shape()[0]; ++i) {
+    expected += ndarray.at(i, 0) * ndarray.at(i, 1);
+  }
+
+  T weighted_sum;
+  output >> weighted_sum;
+  BOOST_CHECK_EQUAL(expected, weighted_sum);
+}
+
+BOOST_AUTO_TEST_CASE(Npy2d_frompython_test) {
+  Elements::TempFile file("npy_test_frompython_%%.npy");
+
+  // Write NPY from Python
+  constexpr const char* PYCODE = R"EDOCYP(
+import sys
+import numpy as np
+a = np.save(sys.argv[1], np.arange(0, 100, dtype='=u4').reshape(2, 5, 10))
+)EDOCYP";
+  runPython(PYCODE, file.path());
+
+  // Read
+  auto ndarray = readNpy<uint32_t>(file.path());
+
+  BOOST_CHECK_EQUAL(ndarray.shape().size(), 3);
+  BOOST_CHECK_EQUAL(ndarray.shape()[0], 2);
+  BOOST_CHECK_EQUAL(ndarray.shape()[1], 5);
+  BOOST_CHECK_EQUAL(ndarray.shape()[2], 10);
+}
+
+BOOST_AUTO_TEST_CASE(Npy_badtype_test) {
+  std::stringstream stream;
+
+  // Construct NdArray
+  NdArray<double> ndarray({50, 2});
+  std::generate(ndarray.begin(), ndarray.end(), []() { return std::rand() % 100; });
+
+  // Write NPY
+  writeNpy(stream, ndarray);
+
+  // Read NPY
+  BOOST_CHECK_THROW(readNpy<int64_t>(stream), Elements::Exception);
+}
+
+BOOST_AUTO_TEST_CASE(Npy_badendian_test) {
+  Elements::TempFile file(std::string("npy_testpy_endian_%%.npy"));
+
+  constexpr const char *PYCODE = R"EDOCYP(
+import sys
+import numpy as np
+np.save(sys.argv[1], np.arange(100, 400, dtype='>i8'))
+)EDOCYP";
+
+  runPython(PYCODE, file.path());
+
+  BOOST_CHECK_THROW(readNpy<int64_t>(file.path()), Elements::Exception);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/NdArray/tests/src/TestHelper.h
+++ b/NdArray/tests/src/TestHelper.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef NDARRAY_TEST_H
+#define NDARRAY_TEST_H
+
+#include <sstream>
+#include <boost/filesystem/path.hpp>
+#include <boost/process.hpp>
+
+/**
+ * Run embedded Python code
+ */
+static std::stringstream runPython(const char *code, const boost::filesystem::path& npy) {
+  namespace bp = boost::process;
+  Elements::TempFile code_file("npy_%%%%.py");
+  std::ofstream out(code_file.path().native());
+  out << code;
+  out.close();
+
+  bp::ipstream py_output;
+  int r = bp::system(bp::search_path("python"), code_file.path().native(), npy.native(), bp::std_out > py_output);
+  BOOST_CHECK_EQUAL(r, 0);
+
+  std::stringstream stream;
+  stream << py_output.rdbuf();
+  return stream;
+}
+
+#endif // NDARRAY_TEST_H


### PR DESCRIPTION
Here is the new support for `npy` files. For primitive types, it is relative simple, but I have not added support for more complex types (i.e. structured arrays). I don't think it is worth, anyways `NdArray` does not support those.

Not to be merged yet, but I would like it to be reviewed and to discuss some points:

## Reference sample
I think moving most of the reference sample to a set of memory mapped numpy arrays is feasible: The index is just a bunch of integers (object id => offset) and the pdz is basically an array with as many rows as reference object and as many columns as pdz bins. We need to store the bins separately, but one extra small file is not a big deal.

SEDs are more complicated, since they do not have the same number of bins *necessarily*. But they do, in fact, at least if we keep one single family (i.e. star SEDs from Pickles, all have 4771 knots, galaxy SEDs from Cosmos, all have 1761 knots,
and Cosmos with emission lines 1782.

If they did not, would an interpolation or a padding (i.e. add enough 0s) be acceptable, so everything can be stored contiguously on an array?

## NPZ

Is NPZ support worthwhile? It is basically a zip file with npy inside. The problem is that EDEN 2.1 does not include any C/C++ library to handle zips. Also, NPZ files can not be memory mapped, at least not for writing, as you need the CRC32 of the files.