### PR TITLE
Fix CI after the merging of npy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
   matrix:
     - OS_TYPE=fedora OS_VERSION=31
     - OS_TYPE=fedora OS_VERSION=32
-    - OS_TYPE=fedora OS_VERSION=33
     - OS_TYPE=centos OS_VERSION=7
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ env:
   global:
     - OS_ARCH=x86_64
   matrix:
-    - OS_TYPE=fedora OS_VERSION=30
     - OS_TYPE=fedora OS_VERSION=31
     - OS_TYPE=fedora OS_VERSION=32
+    - OS_TYPE=fedora OS_VERSION=33
     - OS_TYPE=centos OS_VERSION=7
 
 services:

--- a/.travis/build-rpm.sh
+++ b/.travis/build-rpm.sh
@@ -53,7 +53,7 @@ yum install -y ${rpm_dev_deps} ${rpm_doc_deps}
 
 # Dependencies
 yum install -y cmake make gcc-c++ rpm-build
-yum install -y boost-devel $PYTHON-pytest log4cpp-devel doxygen CCfits-devel
+yum install -y boost-devel $PYTHON-pytest log4cpp-devel doxygen CCfits-devel $PYTHON-numpy
 yum install -y graphviz $PYTHON-sphinx $PYTHON-sphinxcontrib-apidoc
 
 # Build

--- a/NdArray/CMakeLists.txt
+++ b/NdArray/CMakeLists.txt
@@ -12,9 +12,12 @@ elements_add_library(NdArray
 elements_add_unit_test(NdArray_test tests/src/NdArray_test.cpp
         LINK_LIBRARIES NdArray TYPE Boost)
 
+if (Boost_VERSION GREATER "105800")
 elements_add_unit_test(Npy_test tests/src/Npy_test.cpp
         LINK_LIBRARIES NdArray TYPE Boost)
 
 elements_add_unit_test(NpyMmap_test tests/src/NpyMmap_test.cpp
         LINK_LIBRARIES NdArray TYPE Boost)
-
+else ()
+  message(WARNING "Boost Endian added after Boost 1.58 (Found ${Boost_VERSION}). Disabling NdArray I/O tests")
+endif ()

--- a/NdArray/tests/src/TestHelper.h
+++ b/NdArray/tests/src/TestHelper.h
@@ -33,8 +33,13 @@ static std::stringstream runPython(const char *code, const boost::filesystem::pa
   out << code;
   out.close();
 
+  auto python_exec = bp::search_path("python3");
+  if (python_exec.empty())
+    python_exec = bp::search_path("python");
+  BOOST_CHECK(!python_exec.empty());
+
   bp::ipstream py_output;
-  int r = bp::system(bp::search_path("python"), code_file.path().native(), npy.native(), bp::std_out > py_output);
+  int r = bp::system(python_exec, code_file.path().native(), npy.native(), bp::std_out > py_output);
   BOOST_CHECK_EQUAL(r, 0);
 
   std::stringstream stream;


### PR DESCRIPTION
The tests failed because

1. `python` is not available (`python3` instead)
2. I forgot to install numpy

In CentOS7 we have boost 1.53, which doesn't have support for `boost::endian`, so disable npy tests there.
Eventually, we could install `boost169` instead, but that has to be synchronized with the other projects.