### PR TITLE
Check out-of-bounds resizes on memory mapped files

### DIFF
--- a/NdArray/NdArray/io/_impl/NpyMmap.icpp
+++ b/NdArray/NdArray/io/_impl/NpyMmap.icpp
@@ -40,6 +40,8 @@ NdArray <T> mmapNpy(const boost::filesystem::path& path, boost::iostreams::mappe
   map_params.flags = mode;
   if (max_size)
     map_params.length = max_size;
+  else
+    max_size = boost::filesystem::file_size(path);
 
   boost::iostreams::mapped_file input(map_params);
   MappedStream stream(input);
@@ -49,7 +51,7 @@ NdArray <T> mmapNpy(const boost::filesystem::path& path, boost::iostreams::mappe
   if (dtype != NpyDtype<T>::str)
     throw Elements::Exception() << "Can not cast " << dtype << " into " << typeid(T).name();
 
-  return {shape, std::move(MappedContainer<T>(path, stream.tellg(), n_elements, std::move(input)))};
+  return {shape, std::move(MappedContainer<T>(path, stream.tellg(), n_elements, std::move(input), max_size))};
 }
 
 template<typename T>
@@ -69,12 +71,14 @@ NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<
   map_params.path = path.native();
   map_params.flags = boost::iostreams::mapped_file_base::readwrite;
   map_params.new_file_size = total_size;
-  if (max_size)
+  if (max_size >= total_size)
     map_params.length = max_size;
+  else
+    max_size = total_size;
 
   boost::iostreams::mapped_file output(map_params);
   std::copy(header_str.begin(), header_str.end(), output.begin());
-  return {shape, std::move(MappedContainer<T>(path, header_size, n_elements, std::move(output)))};
+  return {shape, std::move(MappedContainer<T>(path, header_size, n_elements, std::move(output), max_size))};
 }
 
 } // end of namespace NdArray

--- a/NdArray/tests/src/NpyMmap_test.cpp
+++ b/NdArray/tests/src/NpyMmap_test.cpp
@@ -111,7 +111,7 @@ assert np.isclose(np.average(a[:,0], weights=a[:,1]),66.33333, 1e-3)
 BOOST_AUTO_TEST_CASE(MmapAppend_test) {
   Elements::TempFile file("npy_resize_mmap_%%.npy");
 
-  auto ndarray = createMmapNpy<double>(file.path(), {100, 2});
+  auto ndarray = createMmapNpy<double>(file.path(), {100, 2}, 10240);
   for (size_t i = 0; i < 100; ++i) {
     ndarray.at(i, 0) = i;
     ndarray.at(i, 1) = 2 * i;
@@ -132,6 +132,22 @@ assert np.isclose(np.average(a[0:100,0], weights=a[0:100,1]), 66.33333, 1e-3)
 assert np.allclose(a[100:,:], 4.2)
 )EDOCYP";
   runPython(PYCODE, file.path());
+}
+
+BOOST_AUTO_TEST_CASE(MmapAppend_NotEnough_test) {
+  Elements::TempFile file("npy_resize_mmap_%%.npy");
+
+  // This allocates only enough for the 100x2 doubles
+  auto ndarray = createMmapNpy<double>(file.path(), {100, 2});
+  for (size_t i = 0; i < 100; ++i) {
+    ndarray.at(i, 0) = i;
+    ndarray.at(i, 1) = 2 * i;
+  }
+
+  NdArray<double> another({50, 2});
+  std::fill(another.begin(), another.end(), 4.2);
+
+  BOOST_CHECK_THROW(ndarray.concatenate(another), Elements::Exception);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
An oversight on the code: one may add more data than the amount of memory that was allocated, which may work until you step outside your address space, or start overwriting memory.
Hit this issue with PhosphorosCore when rebuilding the reference sample, and you would get a segfault.
Now it fails with this:

```
Elements Exception : resize request bigger than maximum allocated size: 1073742306 > 1073741824
```