### PR TITLE
NdArray: Add support for (simple) numpy record arrays

### DIFF
--- a/GridContainer/tests/src/GridAxis_test.cpp
+++ b/GridContainer/tests/src/GridAxis_test.cpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+ /**
  * @file tests/src/GridAxis_test.cpp
  * @date June 16, 2014
  * @author Nikolaos Apostolakos
@@ -32,39 +32,39 @@ BOOST_AUTO_TEST_SUITE (GridAxis_test)
 //-----------------------------------------------------------------------------
 // Test the name is set correctly
 //-----------------------------------------------------------------------------
-    
+
 BOOST_AUTO_TEST_CASE(name) {
-  
+
   // Given
   std::string test_name = "AxisName";
   std::vector<double> knots {};
   Euclid::GridContainer::GridAxis<double> axis {test_name, knots};
-  
+
   // When
   auto& result = axis.name();
-  
+
   // Then
   BOOST_CHECK_EQUAL(result, test_name);
-  
+
 }
 
 //-----------------------------------------------------------------------------
 // Test the number of knots is counted correctly
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_CASE(size) {
-  
+BOOST_AUTO_TEST_CASE(axisSize) {
+
   // Given
   std::string test_name = "AxisName";
   std::vector<double> knots {{1., 2., 2.5, 3.8}};
   Euclid::GridContainer::GridAxis<double> axis {test_name, knots};
-  
+
   // When
   auto size = axis.size();
-  
+
   // Then
   BOOST_CHECK_EQUAL(size, knots.size());
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -72,24 +72,24 @@ BOOST_AUTO_TEST_CASE(size) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(iterator) {
-  
+
   // Given
   std::string test_name = "AxisName";
   std::vector<double> knots {{1., 2., 2.5, 3.8}};
   Euclid::GridContainer::GridAxis<double> axis {test_name, knots};
-  
+
   // When
   auto axis_iter = axis.begin();
   auto axis_end = axis.end();
   auto knots_iter = knots.begin();
-  
+
   // Then
   while (axis_iter != axis_end) {
     BOOST_CHECK_EQUAL(*axis_iter, *knots_iter);
     ++axis_iter;
     ++ knots_iter;
   }
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -97,24 +97,24 @@ BOOST_AUTO_TEST_CASE(iterator) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(indexAccess) {
-  
+
   // Given
   std::string test_name = "AxisName";
   std::vector<double> knots {{1., 2., 2.5, 3.8}};
   Euclid::GridContainer::GridAxis<double> axis {test_name, knots};
-  
+
   // When
   auto axis_iter = axis.begin();
   auto axis_end = axis.end();
   auto knots_iter = knots.begin();
-  
+
   // Then
   while (axis_iter != axis_end) {
     BOOST_CHECK_EQUAL(*axis_iter, *knots_iter);
     ++axis_iter;
     ++ knots_iter;
   }
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -122,23 +122,23 @@ BOOST_AUTO_TEST_CASE(indexAccess) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(equalityOperatorSameType) {
-  
+
   // Given
   std::string name_1 = "Axis1";
   std::vector<double> knots_1 {{1., 2., 2.5, 3.8}};
   std::string name_2 = "Axis2";
   std::vector<double> knots_2 {{1., 2., 2.5, 3.8}};
-  
+
   // When
   Euclid::GridContainer::GridAxis<double> axis_1 {name_1, knots_1};
   Euclid::GridContainer::GridAxis<double> axis_2 {name_2, knots_2};
-  
+
   // Then
   BOOST_CHECK(axis_1 == axis_2);
   BOOST_CHECK(axis_2 == axis_1);
   BOOST_CHECK(!(axis_1 != axis_2));
   BOOST_CHECK(!(axis_2 != axis_1));
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -146,23 +146,23 @@ BOOST_AUTO_TEST_CASE(equalityOperatorSameType) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(equalityOperatorSameTypeDifferentValues) {
-  
+
   // Given
   std::string name_1 = "Axis1";
   std::vector<double> knots_1 {{1., 2., 2.5, 3.8}};
   std::string name_2 = "Axis2";
   std::vector<double> knots_2 {{1., 2., 3.5, 3.8}};
-  
+
   // When
   Euclid::GridContainer::GridAxis<double> axis_1 {name_1, knots_1};
   Euclid::GridContainer::GridAxis<double> axis_2 {name_2, knots_2};
-  
+
   // Then
   BOOST_CHECK(axis_1 != axis_2);
   BOOST_CHECK(axis_2 != axis_1);
   BOOST_CHECK(!(axis_1 == axis_2));
   BOOST_CHECK(!(axis_2 == axis_1));
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -170,23 +170,23 @@ BOOST_AUTO_TEST_CASE(equalityOperatorSameTypeDifferentValues) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(equalityOperatorSameTypeDifferentSize) {
-  
+
   // Given
   std::string name_1 = "Axis1";
   std::vector<double> knots_1 {{1., 2., 2.5, 3.8}};
   std::string name_2 = "Axis2";
   std::vector<double> knots_2 {{1., 2., 2.5, 3.8, 4.}};
-  
+
   // When
   Euclid::GridContainer::GridAxis<double> axis_1 {name_1, knots_1};
   Euclid::GridContainer::GridAxis<double> axis_2 {name_2, knots_2};
-  
+
   // Then
   BOOST_CHECK(axis_1 != axis_2);
   BOOST_CHECK(axis_2 != axis_1);
   BOOST_CHECK(!(axis_1 == axis_2));
   BOOST_CHECK(!(axis_2 == axis_1));
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -194,23 +194,23 @@ BOOST_AUTO_TEST_CASE(equalityOperatorSameTypeDifferentSize) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(equalityOperatorDifferentType) {
-  
+
   // Given
   std::string name_1 = "Axis1";
   std::vector<double> knots_1 {{1., 2., 3., 4.}};
   std::string name_2 = "Axis2";
   std::vector<int> knots_2 {{1, 2, 3, 4}};
-  
+
   // When
   Euclid::GridContainer::GridAxis<double> axis_1 {name_1, knots_1};
   Euclid::GridContainer::GridAxis<int> axis_2 {name_2, knots_2};
-  
+
   // Then
   BOOST_CHECK(axis_1 == axis_2);
   BOOST_CHECK(axis_2 == axis_1);
   BOOST_CHECK(!(axis_1 != axis_2));
   BOOST_CHECK(!(axis_2 != axis_1));
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -218,23 +218,23 @@ BOOST_AUTO_TEST_CASE(equalityOperatorDifferentType) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(equalityOperatorDifferentTypeDifferentValues) {
-  
+
   // Given
   std::string name_1 = "Axis1";
   std::vector<double> knots_1 {{1., 2., 3.5, 4.}};
   std::string name_2 = "Axis2";
   std::vector<int> knots_2 {{1, 2, 3, 4}};
-  
+
   // When
   Euclid::GridContainer::GridAxis<double> axis_1 {name_1, knots_1};
   Euclid::GridContainer::GridAxis<int> axis_2 {name_2, knots_2};
-  
+
   // Then
   BOOST_CHECK(axis_1 != axis_2);
   BOOST_CHECK(axis_2 != axis_1);
   BOOST_CHECK(!(axis_1 == axis_2));
   BOOST_CHECK(!(axis_2 == axis_1));
-  
+
 }
 
 //-----------------------------------------------------------------------------
@@ -242,23 +242,23 @@ BOOST_AUTO_TEST_CASE(equalityOperatorDifferentTypeDifferentValues) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(equalityOperatorDifferentTypeDifferentSize) {
-  
+
   // Given
   std::string name_1 = "Axis1";
   std::vector<double> knots_1 {{1., 2., 3., 4.}};
   std::string name_2 = "Axis2";
   std::vector<int> knots_2 {{1, 2, 3, 4, 5}};
-  
+
   // When
   Euclid::GridContainer::GridAxis<double> axis_1 {name_1, knots_1};
   Euclid::GridContainer::GridAxis<int> axis_2 {name_2, knots_2};
-  
+
   // Then
   BOOST_CHECK(axis_1 != axis_2);
   BOOST_CHECK(axis_2 != axis_1);
   BOOST_CHECK(!(axis_1 == axis_2));
   BOOST_CHECK(!(axis_2 == axis_1));
-  
+
 }
 
 //-----------------------------------------------------------------------------

--- a/NdArray/NdArray/NdArray.h
+++ b/NdArray/NdArray/NdArray.h
@@ -391,6 +391,7 @@ public:
 
 private:
   std::vector<size_t> m_shape, m_stride_size;
+  std::vector<std::string> m_attr_names;
   size_t m_size;
 
   struct ContainerInterface {

--- a/NdArray/NdArray/NdArray.h
+++ b/NdArray/NdArray/NdArray.h
@@ -233,6 +233,19 @@ public:
   NdArray(const std::vector<size_t>& shape, Iterator begin, Iterator end);
 
   /**
+   * Constructs a matrix, giving a name to each of the items on the last dimension
+   * @param attr_names
+   *    Names for the dimensions of the last axis
+   * @param shape
+   *    Shape for the matrix
+   * @note
+   *    Unlike numpy, attr_names is treated strictly as an alias, so
+   *    NdArray<float>({20}, {"X", "Y"}) has a shape of (20, 2)
+   */
+  template<typename ...Args>
+  NdArray(const std::vector<size_t>& shape, const std::vector<std::string>& attr_names, Args&& ... args);
+
+  /**
    * Constructs a default-initialized matrix with the given shape (as an initializer list).
    * @param shape
    *    The shape of the matrix. The number of elements in shape corresponds to the number
@@ -263,7 +276,7 @@ public:
    * Create a copy of the NdArray
    */
   NdArray copy() const {
-    return {m_shape, m_container->copy()};
+    return self_type{this};
   }
 
   /**
@@ -284,6 +297,8 @@ public:
    *    If the new shape does not match the number of elements already contained within the NdArray.
    * @return
    *    *this
+   * @throws std::invalid_argument
+   *    If the array has attribute names
    */
   self_type& reshape(const std::vector<size_t> new_shape);
 
@@ -317,6 +332,28 @@ public:
    *    If the number of coordinates is invalid, or any of them is out of bounds.
    */
   const T& at(const std::vector<size_t>& coords) const;
+
+  /**
+   * Gets a reference to the value stored at the given coordinates.
+   * @param coords
+   *    Elements coordinates, except last one
+   * @param attr
+   *    Attribute name used to determine the last coordinate
+   * @throws std::out_of_range
+   *    If the number of coordinates is invalid, or any of them is out of bounds.
+   */
+  T& at(const std::vector<size_t>& coords, const std::string& attr);
+
+  /**
+   * Gets a constant reference to the value stored at the given coordinates.
+   * @param coords
+   *    Elements coordinates, except last one
+   * @param attr
+   *    Attribute name used to determine the last coordinate
+   * @throws std::out_of_range
+   *    If the number of coordinates is invalid, or any of them is out of bounds.
+   */
+  const T& at(const std::vector<size_t>& coords, const std::string& attr) const;
 
   /**
    * Gets a reference to the value stored at the given coordinates.
@@ -388,6 +425,12 @@ public:
    * @return *this
    */
   self_type& concatenate(const self_type &other);
+
+  /**
+   * @return
+   *    Attribute names
+   */
+  const std::vector<std::string>& attributes() const;
 
 private:
   std::vector<size_t> m_shape, m_stride_size;
@@ -476,7 +519,7 @@ private:
   /**
    * Private constructor used for deep copies
    */
-  NdArray(const std::vector<size_t>& shape, const std::shared_ptr<ContainerInterface>& container);
+  explicit NdArray(const self_type* other);
 
   /**
    * Gets the total offset for the given coordinates.
@@ -484,6 +527,13 @@ private:
    *    If the number of coordinates is invalid, or any of them is out of bounds.
    */
   size_t get_offset(const std::vector<size_t>& coords) const;
+
+  /**
+   * Gets the total offset for the given coordinates.
+   * @throws std::out_of_range
+   *    If the number of coordinates is invalid, or any of them is out of bounds, or the attribute does not exist.
+   */
+  size_t get_offset(std::vector<size_t> coords, const std::string& attr) const;
 
   /**
    * Compute the stride size for each dimension
@@ -500,6 +550,11 @@ private:
    * Helper to expand at with a variable number of arguments (base case)
    */
   T& at_helper(std::vector<size_t>& acc);
+
+  /**
+   * Helper to expand at with a variable number of arguments, being the last an attribute name
+   */
+  T& at_helper(std::vector<size_t>& acc, const std::string& attr);
 
   /**
    * Helper to expand constant at with a variable number of arguments

--- a/NdArray/NdArray/_impl/NdArray.icpp
+++ b/NdArray/NdArray/_impl/NdArray.icpp
@@ -158,7 +158,8 @@ NdArray<T>::NdArray(const std::vector<size_t>& shape, Container<T>&& data)
 template<typename T>
 template<typename II>
 NdArray<T>::NdArray(const std::vector<size_t>& shape, II begin, II end)
-  : m_shape{shape}, m_size{std::accumulate(m_shape.begin(), m_shape.end(), 1u, std::multiplies<size_t>())},
+  : m_shape{shape},
+    m_size{std::accumulate(m_shape.begin(), m_shape.end(), 1u, std::multiplies<size_t>())},
     m_container{new ContainerWrapper<std::vector>(begin, end)} {
   if (m_size != m_container->size()) {
     throw std::invalid_argument("Data size does not match the shape");
@@ -167,14 +168,31 @@ NdArray<T>::NdArray(const std::vector<size_t>& shape, II begin, II end)
 }
 
 template<typename T>
-NdArray<T>::NdArray(const std::vector<size_t>& shape, const std::shared_ptr<ContainerInterface>& container)
-  : m_shape{shape}, m_size{std::accumulate(m_shape.begin(), m_shape.end(), 1u, std::multiplies<size_t>())},
-    m_container{container} {
+NdArray<T>::NdArray(const self_type* other)
+  : m_shape{other->m_shape}, m_attr_names{other->m_attr_names},
+    m_size{std::accumulate(m_shape.begin(), m_shape.end(), 1u, std::multiplies<size_t>())},
+    m_container{other->m_container->copy()} {
   update_strides();
+}
+
+inline std::vector<size_t> appendAttrShape(std::vector<size_t> shape, size_t append) {
+  if (append)
+    shape.push_back(append);
+  return shape;
+}
+
+template<typename T>
+template<typename ...Args>
+NdArray<T>::NdArray(const std::vector<size_t>& shape, const std::vector<std::string>& attr_names, Args&& ... args)
+  : NdArray{appendAttrShape(shape, attr_names.size()), std::forward<Args>(args)...} {
+  m_attr_names = attr_names;
 }
 
 template<typename T>
 auto NdArray<T>::reshape(const std::vector<size_t> new_shape) -> self_type& {
+  if (!m_attr_names.empty())
+    throw std::invalid_argument("Can not reshape arrays with attribute names");
+
   size_t new_size = std::accumulate(new_shape.begin(), new_shape.end(), 1, std::multiplies<size_t>());
   if (new_size != m_size) {
     throw std::range_error("New shape does not match the number of contained elements");
@@ -200,6 +218,18 @@ T& NdArray<T>::at(const std::vector<size_t>& coords) {
 template<typename T>
 const T& NdArray<T>::at(const std::vector<size_t>& coords) const {
   auto offset = get_offset(coords);
+  return m_container->at(offset);
+}
+
+template<typename T>
+T& NdArray<T>::at(const std::vector<size_t>& coords, const std::string& attr) {
+  auto offset = get_offset(coords, attr);
+  return m_container->at(offset);
+}
+
+template<typename T>
+const T& NdArray<T>::at(const std::vector<size_t>& coords, const std::string& attr) const {
+  auto offset = get_offset(coords, attr);
   return m_container->at(offset);
 }
 
@@ -259,6 +289,11 @@ bool NdArray<T>::operator!=(const self_type& b) const {
 }
 
 template<typename T>
+const std::vector<std::string>& NdArray<T>::attributes() const {
+  return m_attr_names;
+}
+
+template<typename T>
 auto NdArray<T>::concatenate(const self_type& other) -> self_type& {
   // Verify dimensionality
   if (m_shape.size() != other.m_shape.size()) {
@@ -308,6 +343,16 @@ size_t NdArray<T>::get_offset(const std::vector<size_t>& coords) const {
 }
 
 template<typename T>
+size_t NdArray<T>::get_offset(std::vector<size_t> coords, const std::string& attr) const {
+  auto i = std::find(m_attr_names.begin(), m_attr_names.end(), attr);
+  if (i == m_attr_names.end())
+    throw std::out_of_range(attr);
+  auto last = i - m_attr_names.begin();
+  coords.emplace_back(last);
+  return get_offset(coords);
+}
+
+template<typename T>
 void NdArray<T>::update_strides() {
   m_stride_size.resize(m_shape.size());
 
@@ -331,6 +376,11 @@ T& NdArray<T>::at_helper(std::vector<size_t>& acc, size_t i, D... rest) {
 template<typename T>
 T& NdArray<T>::at_helper(std::vector<size_t>& acc) {
   return at(acc);
+}
+
+template<typename T>
+T& NdArray<T>::at_helper(std::vector<size_t>& acc, const std::string& attr) {
+  return at(acc, attr);
 }
 
 template<typename T>

--- a/NdArray/NdArray/_impl/NdArray.icpp
+++ b/NdArray/NdArray/_impl/NdArray.icpp
@@ -18,6 +18,8 @@
 
 #ifdef NDARRAY_IMPL
 
+#include <algorithm>
+
 namespace Euclid {
 namespace NdArray {
 

--- a/NdArray/NdArray/io/NpyMmap.h
+++ b/NdArray/NdArray/io/NpyMmap.h
@@ -67,7 +67,26 @@ NdArray<T> mmapNpy(const boost::filesystem::path& path,
  */
 template<typename T>
 NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<size_t>& shape,
-                         const std::vector<std::string>& attr_names = {}, size_t max_size = 0);
+                         const std::vector<std::string>& attr_names, size_t max_size = 0);
+
+/**
+ * Create using mmap an NdArray backed by a numpy file
+ * @tparam T
+ *  NdArray cell type
+ * @param path
+ *  Output path
+ * @param shape
+ *  NdArray shape
+ * @param max_size
+ *  Maximum size of the file. If you are going to call NdArray<T>::concatenate, mind this parameter!
+ * @return
+ *  A new NdArray
+ */
+template<typename T>
+NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<size_t>& shape,
+                         size_t max_size = 0) {
+  return createMmapNpy<T>(path, shape, {}, max_size);
+}
 
 } // end of namespace NdArray
 } // end of namespace Euclid

--- a/NdArray/NdArray/io/NpyMmap.h
+++ b/NdArray/NdArray/io/NpyMmap.h
@@ -58,13 +58,16 @@ NdArray<T> mmapNpy(const boost::filesystem::path& path,
  *  Output path
  * @param shape
  *  NdArray shape
+ * @param attr_names
+ *  Attribute names
  * @param max_size
  *  Maximum size of the file. If you are going to call NdArray<T>::concatenate, mind this parameter!
  * @return
  *  A new NdArray
  */
 template<typename T>
-NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<size_t>& shape, size_t max_size = 0);
+NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<size_t>& shape,
+                         const std::vector<std::string>& attr_names = {}, size_t max_size = 0);
 
 } // end of namespace NdArray
 } // end of namespace Euclid

--- a/NdArray/NdArray/io/_impl/NpyCommon.h
+++ b/NdArray/NdArray/io/_impl/NpyCommon.h
@@ -22,6 +22,7 @@
 #include <boost/endian/arithmetic.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/iostreams/device/mapped_file.hpp>
+#include <boost/regex.hpp>
 #include "AlexandriaKernel/StringUtils.h"
 
 namespace Euclid {
@@ -59,6 +60,11 @@ struct NpyDtype<int8_t> {
 };
 
 template<>
+struct NpyDtype<int16_t> {
+  static constexpr const char *str = "i2";
+};
+
+template<>
 struct NpyDtype<int32_t> {
   static constexpr const char *str = "i4";
 };
@@ -71,6 +77,11 @@ struct NpyDtype<int64_t> {
 template<>
 struct NpyDtype<uint8_t> {
   static constexpr const char *str = "B";
+};
+
+template<>
+struct NpyDtype<uint16_t> {
+  static constexpr const char *str = "u2";
 };
 
 template<>
@@ -94,6 +105,48 @@ struct NpyDtype<double> {
 };
 
 /**
+ * Parse a single dtype description (i.e. '<f8')
+ */
+inline void parseSingleValue(const std::string& descr, bool& big_endian, std::string& dtype) {
+  big_endian = (descr.front() == '>');
+  dtype = descr.substr(1);
+}
+
+/**
+ * Parse the description field from npy arrays with named fields, which are stored as the
+ * string representation of a list of tuples (name, dtype). i.e:
+ * [('a', '<i4'), ('b', '<i4')]
+ * @throws std::invalid_argument
+ *  NdArrays only support uniform types, so this method will fail if there are mixed types on the
+ *  npy file
+ */
+inline void parseFieldValues(const std::string& descr, bool& big_endian, std::vector<std::string>& attrs,
+                             std::string& dtype) {
+  static const boost::regex field_expr("\\('([^']*)',\\s*'([^']*)'\\)");
+
+  boost::match_results<std::string::const_iterator> match;
+  auto start = descr.begin();
+  auto end = descr.end();
+
+  while (boost::regex_search(start, end, match, field_expr)) {
+    bool endian_aux;
+    std::string dtype_aux;
+
+    parseSingleValue(match[2].str(), endian_aux, dtype_aux);
+    if (dtype.empty()) {
+      dtype = dtype_aux;
+      big_endian = endian_aux;
+    }
+    else if (dtype != dtype_aux || big_endian != endian_aux) {
+      throw std::invalid_argument("NdArray only supports uniform types");
+    }
+    attrs.emplace_back(match[1].str());
+
+    start = match[0].second;
+  }
+}
+
+/**
  * Parse the dictionary serialized on the npy file
  * @param header
  *  String representation of the dictionary
@@ -105,22 +158,33 @@ struct NpyDtype<double> {
  *  Put here the read dtype
  * @param shape [out]
  *  Put here the read shape
+ * @param attrs[out]
+ *  Put here the attribute names
  * @param n_elements [out]
  *  Total number of elements (multiplication of shape)
  */
 inline void parseNpyDict(const std::string& header, bool& fortran_order, bool& big_endian,
-                         std::string& dtype, std::vector<size_t>& shape, size_t& n_elements) {
+                         std::string& dtype, std::vector<size_t>& shape, std::vector<std::string>& attrs,
+                         size_t& n_elements) {
   auto loc = header.find("fortran_order") + 16;
   fortran_order = (header.substr(loc, 4) == "True");
 
-  loc = header.find("descr") + 9;
-  big_endian = (header[loc] == '>');
+  loc = header.find("descr") + 8;
 
-  auto loc2 = header.find("'", loc);
-  dtype = header.substr(loc + 1, loc2 - loc - 1);
+  if (header[loc] == '\'') {
+    auto end = header.find('\'', loc + 1);
+    parseSingleValue(header.substr(loc + 1, end - loc - 1), big_endian, dtype);
+  }
+  else if (header[loc] == '[') {
+    auto end = header.find(']', loc + 1);
+    parseFieldValues(header.substr(loc + 1, end - loc - 1), big_endian, attrs, dtype);
+  }
+  else {
+    throw Elements::Exception() << "Failed to parse the array description: " << header;
+  }
 
   loc = header.find("shape") + 9;
-  loc2 = header.find(")", loc);
+  auto loc2 = header.find(')', loc);
   auto shape_str = header.substr(loc, loc2 - loc);
   if (shape_str.back() == ',')
     shape_str.resize(shape_str.size() - 1);
@@ -136,11 +200,14 @@ inline void parseNpyDict(const std::string& header, bool& fortran_order, bool& b
  *  Put here the read dtype
  * @param shape [out]
  *  Put here the read shape
+ * @param attrs [out]
+ *  Put here the attribute names
  * @param n_elements [out]
  *  Total number of elements (multiplication of shape)
  * @return
  */
-inline void readNpyHeader(std::istream& input, std::string& dtype, std::vector<size_t>& shape, size_t& n_elements) {
+inline void readNpyHeader(std::istream& input, std::string& dtype, std::vector<size_t>& shape,
+                          std::vector<std::string>& attrs, size_t& n_elements) {
   // Magic
   char magic[6];
   input.read(magic, sizeof(magic));
@@ -172,7 +239,7 @@ inline void readNpyHeader(std::istream& input, std::string& dtype, std::vector<s
 
   // Parse header
   bool fortran_order, big_endian;
-  parseNpyDict(header, fortran_order, big_endian, dtype, shape, n_elements);
+  parseNpyDict(header, fortran_order, big_endian, dtype, shape, attrs, n_elements);
 
   if (fortran_order)
     throw Elements::Exception() << "Fortran order not supported";
@@ -202,14 +269,14 @@ inline std::string npyShape(std::vector<size_t> shape) {
 }
 
 
-std::string typeDescription(const std::string& type, const std::vector<std::string>& attrs) {
+inline std::string typeDescription(const std::string& type, const std::vector<std::string>& attrs) {
   std::stringstream dtype;
   if (attrs.empty()) {
     dtype << '\'' << ENDIAN_MARKER << type << '\'';
   }
   else {
     dtype << '[';
-    for (auto &attr : attrs) {
+    for (auto& attr : attrs) {
       dtype << "('" << attr << "', '" << ENDIAN_MARKER << type << "'), ";
     }
     dtype << ']';
@@ -269,7 +336,8 @@ public:
   MappedContainer(const boost::filesystem::path& path, size_t data_offset, size_t n_elements,
                   const std::vector<std::string>& attr_names,
                   boost::iostreams::mapped_file&& input, size_t max_size)
-    : m_path(path), m_data_offset(data_offset), m_n_elements(n_elements), m_attr_names(attr_names), m_max_size(max_size),
+    : m_path(path), m_data_offset(data_offset), m_n_elements(n_elements),
+      m_max_size(max_size), m_attr_names(attr_names),
       m_mapped(std::move(input)), m_data(reinterpret_cast<T *>(m_mapped.data() + data_offset)) {
   }
 

--- a/NdArray/NdArray/io/_impl/NpyMmap.icpp
+++ b/NdArray/NdArray/io/_impl/NpyMmap.icpp
@@ -51,14 +51,15 @@ NdArray <T> mmapNpy(const boost::filesystem::path& path, boost::iostreams::mappe
   if (dtype != NpyDtype<T>::str)
     throw Elements::Exception() << "Can not cast " << dtype << " into " << typeid(T).name();
 
-  return {shape, std::move(MappedContainer<T>(path, stream.tellg(), n_elements, std::move(input), max_size))};
+  return {shape, std::move(MappedContainer<T>(path, stream.tellg(), n_elements, {}, std::move(input), max_size))};
 }
 
 template<typename T>
-NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<size_t>& shape, size_t max_size) {
+NdArray <T> createMmapNpy(const boost::filesystem::path& path, const std::vector<size_t>& shape,
+                          const std::vector<std::string>& attrs, size_t max_size) {
   // Pre-generate header
   std::stringstream header;
-  writeNpyHeader<T>(header, shape);
+  writeNpyHeader<T>(header, shape, attrs);
   auto header_str = header.str();
   auto header_size = header_str.size();
 
@@ -78,7 +79,7 @@ NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<
 
   boost::iostreams::mapped_file output(map_params);
   std::copy(header_str.begin(), header_str.end(), output.begin());
-  return {shape, std::move(MappedContainer<T>(path, header_size, n_elements, std::move(output), max_size))};
+  return {shape, attrs, std::move(MappedContainer<T>(path, header_size, n_elements, attrs, std::move(output), max_size))};
 }
 
 } // end of namespace NdArray

--- a/NdArray/NdArray/io/_impl/NpyMmap.icpp
+++ b/NdArray/NdArray/io/_impl/NpyMmap.icpp
@@ -34,6 +34,7 @@ NdArray <T> mmapNpy(const boost::filesystem::path& path, boost::iostreams::mappe
   std::string dtype;
   size_t n_elements = 0;
   std::vector<size_t> shape;
+  std::vector<std::string> attrs;
 
   boost::iostreams::mapped_file_params map_params;
   map_params.path = path.native();
@@ -46,12 +47,16 @@ NdArray <T> mmapNpy(const boost::filesystem::path& path, boost::iostreams::mappe
   boost::iostreams::mapped_file input(map_params);
   MappedStream stream(input);
   stream.set_auto_close(false);
-  readNpyHeader(stream, dtype, shape, n_elements);
+  readNpyHeader(stream, dtype, shape, attrs, n_elements);
 
   if (dtype != NpyDtype<T>::str)
     throw Elements::Exception() << "Can not cast " << dtype << " into " << typeid(T).name();
 
-  return {shape, std::move(MappedContainer<T>(path, stream.tellg(), n_elements, {}, std::move(input), max_size))};
+  if (!attrs.empty()) {
+    n_elements *= attrs.size();
+  }
+
+  return {shape, attrs, std::move(MappedContainer<T>(path, stream.tellg(), n_elements, attrs, std::move(input), max_size))};
 }
 
 template<typename T>
@@ -59,12 +64,14 @@ NdArray <T> createMmapNpy(const boost::filesystem::path& path, const std::vector
                           const std::vector<std::string>& attrs, size_t max_size) {
   // Pre-generate header
   std::stringstream header;
-  writeNpyHeader<T>(header, shape, attrs);
+  writeNpyHeader<T>(header, appendAttrShape(shape, attrs.size()), attrs);
   auto header_str = header.str();
   auto header_size = header_str.size();
 
   // Compute file expected size
   size_t n_elements = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<size_t>());
+  if (!attrs.empty())
+    n_elements *= attrs.size();
   size_t data_size = n_elements * sizeof(T);
   size_t total_size = header_size + data_size;
 

--- a/NdArray/NdArray/io/_impl/NpyReader.icpp
+++ b/NdArray/NdArray/io/_impl/NpyReader.icpp
@@ -18,12 +18,9 @@
 
 #ifdef NPY_IMPL
 
-#include <endian.h>
 #include <cstring>
 #include <istream>
-#include <boost/endian/arithmetic.hpp>
 #include <ElementsKernel/Exception.h>
-#include "AlexandriaKernel/StringUtils.h"
 #include "NdArray/NdArray.h"
 #include "NpyCommon.h"
 
@@ -38,14 +35,19 @@ NdArray <T> readNpy(std::istream& input) {
   std::string dtype;
   size_t n_elements;
   std::vector<size_t> shape;
+  std::vector<std::string> attr_names;
 
-  readNpyHeader(input, dtype, shape, n_elements);
+  readNpyHeader(input, dtype, shape, attr_names, n_elements);
   if (dtype != NpyDtype<T>::str)
     throw Elements::Exception() << "Can not cast " << dtype << " into " << typeid(T).name();
 
+  if (!attr_names.empty()) {
+    n_elements *= attr_names.size();
+  }
+
   std::vector<T> data(n_elements);
   input.read(reinterpret_cast<char *>(&data[0]), sizeof(T) * data.size());
-  return {shape, std::move(data)};
+  return {shape, attr_names, std::move(data)};
 }
 
 } // end of namespace NdArray

--- a/NdArray/NdArray/io/_impl/NpyWriter.icpp
+++ b/NdArray/NdArray/io/_impl/NpyWriter.icpp
@@ -33,7 +33,7 @@ namespace NdArray {
  */
 template<typename T>
 void writeNpy(std::ostream& out, const NdArray<T>& array) {
-  writeNpyHeader<T>(out, array.shape());
+  writeNpyHeader<T>(out, array.shape(), array.attributes());
   // The header already has the endian type, so just dump the content of the array
   for (auto v : array) {
     out.write(reinterpret_cast<const char *>(&v), sizeof(v));

--- a/NdArray/tests/src/NdArray_test.cpp
+++ b/NdArray/tests/src/NdArray_test.cpp
@@ -160,11 +160,14 @@ BOOST_AUTO_TEST_CASE(Copy_test) {
   NdArray<int> m{std::vector<size_t>{2, 3}, values};
 
   auto copy = m.copy();
+  BOOST_CHECK_EQUAL_COLLECTIONS(values.begin(), values.end(), copy.begin(), copy.end());
   copy.at(0, 0) = 1;
   copy.at(0, 1) = 0;
 
   BOOST_CHECK_EQUAL(m.at(0, 0), values[0]);
   BOOST_CHECK_EQUAL(m.at(0, 1), values[1]);
+  BOOST_CHECK_EQUAL(copy.at(0, 0), 1);
+  BOOST_CHECK_EQUAL(copy.at(0, 1), 0);
 }
 
 BOOST_AUTO_TEST_CASE(Concatenate_test) {
@@ -191,6 +194,25 @@ BOOST_AUTO_TEST_CASE(BadConcatenate_test) {
 
   BOOST_CHECK_THROW(m.concatenate(add1), std::length_error);
   BOOST_CHECK_THROW(m.concatenate(add2), std::length_error);
+}
+
+BOOST_AUTO_TEST_CASE(AttrNames_test) {
+  const std::vector<std::string> attr_names{"ID", "SED", "PDZ"};
+  NdArray<int> named{{20}, attr_names};
+
+  BOOST_CHECK_EQUAL(named.shape().size(), 2);
+  BOOST_CHECK_EQUAL(named.shape()[0], 20);
+  BOOST_CHECK_EQUAL(named.shape()[1], 3);
+  BOOST_CHECK_EQUAL(named.size(), 60);
+
+  for (size_t i = 0; i < named.shape()[0]; ++i) {
+    named.at(i, "ID") = i;
+    named.at(i, "SED") = i * 2;
+    named.at(i, "PDZ") = i * 10 + 5;
+  }
+
+  auto attrs = named.attributes();
+  BOOST_CHECK_EQUAL_COLLECTIONS(attrs.begin(), attrs.end(), attr_names.begin(), attr_names.end());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/NdArray/tests/src/NdArray_test.cpp
+++ b/NdArray/tests/src/NdArray_test.cpp
@@ -189,8 +189,8 @@ BOOST_AUTO_TEST_CASE(BadConcatenate_test) {
   NdArray<int> add1{std::vector<size_t>{2, 4}};
   NdArray<int> add2{std::vector<size_t>{2, 3, 4}};
 
-  //BOOST_CHECK_THROW(m.concatenate(add1), std::length_error);
-  //BOOST_CHECK_THROW(m.concatenate(add2), std::length_error);
+  BOOST_CHECK_THROW(m.concatenate(add1), std::length_error);
+  BOOST_CHECK_THROW(m.concatenate(add2), std::length_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/NdArray/tests/src/NpyMmap_test.cpp
+++ b/NdArray/tests/src/NpyMmap_test.cpp
@@ -111,7 +111,7 @@ assert np.isclose(np.average(a[:,0], weights=a[:,1]),66.33333, 1e-3)
 BOOST_AUTO_TEST_CASE(MmapAppend_test) {
   Elements::TempFile file("npy_resize_mmap_%%.npy");
 
-  auto ndarray = createMmapNpy<double>(file.path(), {100, 2}, 10240);
+  auto ndarray = createMmapNpy<double>(file.path(), {100, 2}, {}, 10240);
   for (size_t i = 0; i < 100; ++i) {
     ndarray.at(i, 0) = i;
     ndarray.at(i, 1) = 2 * i;

--- a/NdArray/tests/src/NpyMmap_test.cpp
+++ b/NdArray/tests/src/NpyMmap_test.cpp
@@ -150,4 +150,119 @@ BOOST_AUTO_TEST_CASE(MmapAppend_NotEnough_test) {
   BOOST_CHECK_THROW(ndarray.concatenate(another), Elements::Exception);
 }
 
+BOOST_AUTO_TEST_CASE(MmapNamed_test) {
+  Elements::TempFile file("npy_named_mmap_%%.npy");
+  const std::vector<std::string> attr_names{"ID", "SED", "PDZ"};
+
+  // Create mmap
+  auto ndarray = createMmapNpy<uint64_t>(file.path(), {100}, attr_names);
+  BOOST_CHECK_EQUAL(ndarray.shape().size(), 2);
+  BOOST_CHECK_EQUAL(ndarray.shape()[0], 100);
+  BOOST_CHECK_EQUAL(ndarray.shape()[1], 3);
+  auto attrs = ndarray.attributes();
+  BOOST_CHECK_EQUAL_COLLECTIONS(attrs.begin(), attrs.end(), attr_names.begin(), attr_names.end());
+
+  // Fill
+  for (size_t i = 0; i < ndarray.shape()[0]; ++i) {
+    ndarray.at(i, "ID") = i;
+    ndarray.at(i, "SED") = i * 2;
+    ndarray.at(i, "PDZ") = i * 10 + 5;
+  }
+
+  // Read from Python
+  constexpr const char *PYCODE = R"EDOCYP(
+import sys
+import numpy as np
+a = np.load(sys.argv[1])
+assert a.shape == (100,)
+assert len(a.dtype) == 3
+assert set(a.dtype.names) == {'ID', 'SED', 'PDZ'}
+
+for i in range(100):
+  assert a[i]['ID'] == i
+  assert a[i]['SED'] == i * 2
+  assert a[i]['PDZ'] == i * 10 + 5
+)EDOCYP";
+
+  runPython(PYCODE, file.path());
+}
+
+BOOST_AUTO_TEST_CASE(ReadAttrNames_test) {
+  Elements::TempFile file(std::string("npy_named_mmap_%%.npy"));
+
+  std::vector<std::string> expected_attrs{"a", "b"};
+
+  // Write from Python
+  constexpr const char *PYCODE = R"EDOCYP(
+import sys
+import numpy as np
+
+a = np.array([(1, 2), (3, 4), (5, 6), (7, 8)], dtype=[('a', np.int16), ('b', np.int16)])
+np.save(sys.argv[1], a)
+)EDOCYP";
+
+  runPython(PYCODE, file.path());
+
+  // Read
+  auto array = mmapNpy<int16_t>(file.path());
+  BOOST_CHECK_EQUAL(array.shape().size(), 2);
+  BOOST_CHECK_EQUAL(array.shape()[0], 4);
+  BOOST_CHECK_EQUAL(array.shape()[1], 2);
+
+  auto attrs = array.attributes();
+  BOOST_CHECK_EQUAL_COLLECTIONS(attrs.begin(), attrs.end(), expected_attrs.begin(), expected_attrs.end());
+
+  // Check values
+  for (size_t i = 0; i < 4; ++i) {
+    BOOST_CHECK_EQUAL(array.at(i, "a"), i * 2 + 1);
+    BOOST_CHECK_EQUAL(array.at(i, "b"), i * 2 + 2);
+  }
+
+  // Modify on the fly
+  array.at(0, "a") = 42;
+  array.at(0, "b") = 88;
+  array.at(3, "a") = 78;
+
+  // The changes must be visible to another process
+  constexpr const char *PYCODE2 = R"EDOCYP(
+import sys
+import numpy as np
+
+a = np.load(sys.argv[1])
+assert a.shape == (4,)
+assert set(a.dtype.names) == {"a", "b"}
+expected = np.array([(42, 88), (3, 4), (5, 6), (78, 8)], dtype=[('a', np.int16), ('b', np.int16)])
+assert np.array_equal(expected, a), a
+)EDOCYP";
+
+  runPython(PYCODE2, file.path());
+}
+
+BOOST_AUTO_TEST_CASE(NamedAppend_test) {
+  Elements::TempFile file("npy_named_resize_mmap_%%.npy");
+  const std::vector<std::string> attr_names{"X", "Y"};
+
+  auto ndarray = createMmapNpy<double>(file.path(), {100}, attr_names, 10240);
+  for (size_t i = 0; i < 100; ++i) {
+    ndarray.at(i, "X") = i;
+    ndarray.at(i, "Y") = 2 * i;
+  }
+
+  NdArray<double> another({50}, attr_names);
+  std::fill(another.begin(), another.end(), 4.2);
+
+  ndarray.concatenate(another);
+
+  constexpr const char* PYCODE = R"EDOCYP(
+import sys
+import numpy as np
+a = np.load(sys.argv[1])
+assert a.shape == (150,), a.shape
+assert np.isclose(np.average(a[0:100]['X'], weights=a[0:100]['Y']), 66.33333, 1e-3)
+assert np.allclose(a[100:]['X'], 4.2)
+assert np.allclose(a[100:]['Y'], 4.2)
+)EDOCYP";
+  runPython(PYCODE, file.path());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/NdArray/tests/src/Npy_test.cpp
+++ b/NdArray/tests/src/Npy_test.cpp
@@ -29,7 +29,6 @@ BOOST_AUTO_TEST_SUITE(Npy_test)
 typedef boost::mpl::list<int32_t, int64_t, float, double> array_type;
 
 
-
 BOOST_AUTO_TEST_CASE_TEMPLATE(Npy1d_readwrite_test, T, array_type) {
   std::stringstream stream;
 
@@ -80,7 +79,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Npy1d_python_test, T, array_type) {
   writeNpy(file.path(), ndarray);
 
   // Read NPY
-  constexpr const char* PYCODE = R"EDOCYP(
+  constexpr const char *PYCODE = R"EDOCYP(
 import sys
 import numpy as np
 a = np.load(sys.argv[1])
@@ -105,7 +104,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Npy2d_python_test, T, array_type) {
   writeNpy(file.path(), ndarray);
 
   // Read NPY
-  constexpr const char* PYCODE = R"EDOCYP(
+  constexpr const char *PYCODE = R"EDOCYP(
 import sys
 import numpy as np
 a = np.load(sys.argv[1])
@@ -129,7 +128,7 @@ BOOST_AUTO_TEST_CASE(Npy2d_frompython_test) {
   Elements::TempFile file("npy_test_frompython_%%.npy");
 
   // Write NPY from Python
-  constexpr const char* PYCODE = R"EDOCYP(
+  constexpr const char *PYCODE = R"EDOCYP(
 import sys
 import numpy as np
 a = np.save(sys.argv[1], np.arange(0, 100, dtype='=u4').reshape(2, 5, 10))
@@ -171,6 +170,40 @@ np.save(sys.argv[1], np.arange(100, 400, dtype='>i8'))
   runPython(PYCODE, file.path());
 
   BOOST_CHECK_THROW(readNpy<int64_t>(file.path()), Elements::Exception);
+}
+
+BOOST_AUTO_TEST_CASE(AttrNames_test) {
+  Elements::TempFile file(std::string("npy_testpy_attrs_%%.npy"));
+
+  // Construct NdArray
+  const std::vector<std::string> attr_names{"ID", "SED", "PDZ"};
+  NdArray<int> named{{20}, attr_names};
+
+  for (size_t i = 0; i < named.shape()[0]; ++i) {
+    named.at(i, "ID") = i;
+    named.at(i, "SED") = i * 2;
+    named.at(i, "PDZ") = i * 10 + 5;
+  }
+
+  // Write
+  writeNpy(file.path(), named);
+
+  // Read from Python
+  constexpr const char *PYCODE = R"EDOCYP(
+import sys
+import numpy as np
+a = np.load(sys.argv[1])
+assert a.shape == (20,)
+assert len(a.dtype) == 3
+assert set(a.dtype.names) == {'ID', 'SED', 'PDZ'}
+
+for i in range(20):
+  assert a[i]['ID'] == i
+  assert a[i]['SED'] == i * 2
+  assert a[i]['PDZ'] == i * 10 + 5
+)EDOCYP";
+
+  runPython(PYCODE, file.path());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Table/tests/src/FitsWriter_test.cpp
+++ b/Table/tests/src/FitsWriter_test.cpp
@@ -44,12 +44,12 @@ struct BinaryFitsWriter_Fixture {
   std::shared_ptr<ColumnInfo> column_info {new ColumnInfo {info_list}};
   std::vector<Row::cell_type> values0{true, 1, int64_t{123}, 0.F, 0., std::string{"first"},
                                       NdArray<double>({2, 3}, {1, 2, 3, 4, 5, 6}),
-                                      NdArray<double>({1}, {41})};
+                                      NdArray<double>({1}, std::vector<double>{41.})};
   Row row0 {values0, column_info};
   std::vector<Row::cell_type> values1{false, 12345, int64_t{123456789}, 2.3e-2F, 1.12345e-18,
                                       std::string{"second with spaces on top of that"},
                                       NdArray<double>({ 2, 3 }, { 6, 5, 4, 3, 2, 1 }),
-                                      NdArray<double>({1}, {42})};
+                                      NdArray<double>({1}, std::vector<double>{42.})};
   Row row1 {values1, column_info};
   std::vector<Row> row_list {row0, row1};
   Table table {row_list};

--- a/XYDataset/tests/src/CachedProvider_test.cpp
+++ b/XYDataset/tests/src/CachedProvider_test.cpp
@@ -91,7 +91,7 @@ struct MockProvider: public XYDatasetProvider {
     return std::unique_ptr<XYDataset>{new XYDataset{i->second}};
   }
 
-  std::string getParameter(ELEMENTS_UNUSED const QualifiedName& qualified_name, const std::string& key_word){
+  std::string getParameter(ELEMENTS_UNUSED const QualifiedName& qualified_name, const std::string& key_word) override{
      return key_word;
   }
 };

--- a/XYDataset/tests/src/QualifiedName_test.cpp
+++ b/XYDataset/tests/src/QualifiedName_test.cpp
@@ -170,9 +170,9 @@ BOOST_AUTO_TEST_CASE(comparison_test) {
   Euclid::XYDataset::QualifiedName qualifiedName3 {{"bgroup"}, "bname"};
 
   // Then
-  BOOST_CHECK(qualifiedName1 < qualifiedName2 ^ qualifiedName2 < qualifiedName1);
-  BOOST_CHECK(qualifiedName2 < qualifiedName3 ^ qualifiedName3 < qualifiedName2);
-  BOOST_CHECK(qualifiedName1 < qualifiedName3 ^ qualifiedName3 < qualifiedName1);
+  BOOST_CHECK((qualifiedName1 < qualifiedName2) ^ (qualifiedName2 < qualifiedName1));
+  BOOST_CHECK((qualifiedName2 < qualifiedName3) ^ (qualifiedName3 < qualifiedName2));
+  BOOST_CHECK((qualifiedName1 < qualifiedName3) ^ (qualifiedName3 < qualifiedName1));
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
It is limited to numpy record arrays where all fields have the same type.

This new functionality is introduced so we can go back to a single index file for the reference sample, since the data model does not contemplate the possibility of having multiple index files.

Using names allow to store only what we need, and make clear what the entries are: i.e. `id, sed_file, sed_offset`.