### PR TITLE
Add .clang-format and apply

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,115 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     132
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 60
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...

--- a/AlexandriaKernel/AlexandriaKernel/InstOrRefHolder.h
+++ b/AlexandriaKernel/AlexandriaKernel/InstOrRefHolder.h
@@ -38,8 +38,7 @@ template <typename InterfaceType>
 class InstOrRefHolder {
 
 public:
-
-  template <typename InstanceType=InterfaceType, typename... Args>
+  template <typename InstanceType = InterfaceType, typename... Args>
   static std::unique_ptr<InstOrRefHolder<InterfaceType>> create(Args... args);
 
   static std::unique_ptr<InstOrRefHolder<InterfaceType>> create(InterfaceType& ref);
@@ -47,12 +46,10 @@ public:
   virtual ~InstOrRefHolder() = default;
 
   virtual InterfaceType& ref() = 0;
-
 };
 
-} // end of namespace Euclid
+}  // end of namespace Euclid
 
 #include "AlexandriaKernel/_impl/InstOrRefHolder.icpp"
 
 #endif /* _ALEXANDRIAKERNEL_INSTANCEORREFERENCEHOLDER_H */
-

--- a/AlexandriaKernel/AlexandriaKernel/StringUtils.h
+++ b/AlexandriaKernel/AlexandriaKernel/StringUtils.h
@@ -40,7 +40,7 @@ namespace Euclid {
  * @return
  *  A vector of type T.
  */
-template<typename T>
+template <typename T>
 std::vector<T> stringToVector(std::string str, const std::string& separators = std::string(", ")) {
   std::vector<std::string> parts;
   boost::trim(str);
@@ -48,13 +48,12 @@ std::vector<T> stringToVector(std::string str, const std::string& separators = s
   std::vector<T> result(parts.size());
   try {
     std::transform(parts.begin(), parts.end(), result.begin(), boost::lexical_cast<T, const std::string&>);
-  }
-  catch (const boost::bad_lexical_cast& e) {
+  } catch (const boost::bad_lexical_cast& e) {
     throw Elements::Exception(e.what());
   }
   return result;
 }
 
-}  /* namespace Euclid */
+} /* namespace Euclid */
 
 #endif /* _ALEXANDRIAKERNEL_STRINGUTILS_H */

--- a/AlexandriaKernel/AlexandriaKernel/ThreadPool.h
+++ b/AlexandriaKernel/AlexandriaKernel/ThreadPool.h
@@ -25,13 +25,13 @@
 #ifndef _ALEXANDRIAKERNEL_THREADPOOL_H
 #define _ALEXANDRIAKERNEL_THREADPOOL_H
 
-#include <vector>
-#include <thread>
-#include <mutex>
 #include <atomic>
 #include <deque>
-#include <functional>
 #include <exception>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <vector>
 
 namespace Euclid {
 
@@ -68,7 +68,6 @@ namespace Euclid {
 class ThreadPool {
 
 public:
-
   /// The type of tasks the pool can execute
   using Task = std::function<void(void)>;
 
@@ -80,8 +79,7 @@ public:
    *    The time (in milliseconds) the pool threads sleep after they try to get
    *    a task from an empty queue before they retry
    */
-  explicit ThreadPool(unsigned int thread_count = std::thread::hardware_concurrency(),
-                      unsigned int empty_queue_wait_time = 50);
+  explicit ThreadPool(unsigned int thread_count = std::thread::hardware_concurrency(), unsigned int empty_queue_wait_time = 50);
 
   /// All tasks not yet started are discarded and it blocks until all already
   /// executing tasks are finished
@@ -95,21 +93,19 @@ public:
   void block();
 
   /// Checks if any task has thrown an exception and optionally rethrows it
-  bool checkForException(bool rethrow=false);
+  bool checkForException(bool rethrow = false);
 
 private:
-
-  std::mutex m_queue_mutex;
+  std::mutex                     m_queue_mutex;
   std::vector<std::atomic<bool>> m_worker_run_flags;
   std::vector<std::atomic<bool>> m_worker_sleeping_flags;
   std::vector<std::atomic<bool>> m_worker_done_flags;
-  std::deque<Task> m_queue;
-  unsigned int m_empty_queue_wait_time;
-  std::exception_ptr m_exception_ptr;
+  std::deque<Task>               m_queue;
+  unsigned int                   m_empty_queue_wait_time;
+  std::exception_ptr             m_exception_ptr;
 
 }; /* End of ThreadPool class */
 
 } /* namespace Euclid */
-
 
 #endif

--- a/AlexandriaKernel/AlexandriaKernel/_impl/InstOrRefHolder.icpp
+++ b/AlexandriaKernel/AlexandriaKernel/_impl/InstOrRefHolder.icpp
@@ -21,8 +21,8 @@
  * @author nikoapos
  */
 
-#include <type_traits>
 #include "AlexandriaKernel/memory_tools.h"
+#include <type_traits>
 
 namespace Euclid {
 
@@ -31,28 +31,29 @@ namespace InstOrRefHolder_Impl {
 template <typename InterfaceType, typename InstanceType>
 struct InstHolder_Impl : public InstOrRefHolder<InterfaceType> {
   template <typename... Args>
-  InstHolder_Impl(Args... args) : m_instance(std::forward<Args>(args)...) { }
+  InstHolder_Impl(Args... args) : m_instance(std::forward<Args>(args)...) {}
   virtual ~InstHolder_Impl() = default;
   InterfaceType& ref() override {
     return m_instance;
   }
+
 private:
   InstanceType m_instance;
 };
 
 template <typename InterfaceType>
 struct RefHolder_Impl : public InstOrRefHolder<InterfaceType> {
-  RefHolder_Impl(InterfaceType& ref) : m_reference(ref) { }
+  RefHolder_Impl(InterfaceType& ref) : m_reference(ref) {}
   virtual ~RefHolder_Impl() = default;
   InterfaceType& ref() override {
     return m_reference.get();
   }
+
 private:
   std::reference_wrapper<InterfaceType> m_reference;
 };
 
-} // end of namespace InstOrRefHolder_Impl
-
+}  // end of namespace InstOrRefHolder_Impl
 
 template <typename InterfaceType>
 template <typename InstanceType, typename... Args>
@@ -67,5 +68,4 @@ std::unique_ptr<InstOrRefHolder<InterfaceType>> InstOrRefHolder<InterfaceType>::
   return Euclid::make_unique<InstOrRefHolder_Impl::RefHolder_Impl<InterfaceType>>(ref);
 }
 
-} // end of namespace Euclid
-
+}  // end of namespace Euclid

--- a/AlexandriaKernel/AlexandriaKernel/memory_tools.h
+++ b/AlexandriaKernel/AlexandriaKernel/memory_tools.h
@@ -38,16 +38,14 @@ namespace Euclid {
  * @return
  *    std::unique_ptr of the instance of type T
  */
-template<typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args&&... args)
-{
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args) {
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 #else
 using std::make_unique;
 #endif
 
-}
+}  // namespace Euclid
 
 #endif /* _ALEXANDRIAKERNEL_MEMORY_TOOLS_H */
-

--- a/AlexandriaKernel/AlexandriaKernel/serialization/array.h
+++ b/AlexandriaKernel/AlexandriaKernel/serialization/array.h
@@ -1,23 +1,22 @@
- 
- /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- 
+
 #ifndef ALEXANDRIA_KERNEL_SERIALIZATION_ARRAY_H
 #define ALEXANDRIA_KERNEL_SERIALIZATION_ARRAY_H
 
@@ -37,12 +36,12 @@ namespace serialization {
 template <class Archive, std::size_t ND, typename CellType>
 void serialize(Archive& archive, std::array<CellType, ND>& array, const unsigned int) {
   for (int i = 0; i < ND; ++i) {
-    archive & array[i];
+    archive& array[i];
   }
 }
 
-}
-}
+}  // namespace serialization
+}  // namespace boost
 
 #else
 
@@ -51,4 +50,3 @@ void serialize(Archive& archive, std::array<CellType, ND>& array, const unsigned
 #endif
 
 #endif /* ALEXANDRIA_KERNEL_SERIALIZATION_ARRAY_H */
-

--- a/AlexandriaKernel/src/lib/ThreadPool.cpp
+++ b/AlexandriaKernel/src/lib/ThreadPool.cpp
@@ -32,22 +32,22 @@ namespace {
 class Worker {
 
 public:
-
-  Worker(std::mutex& queue_mutex, std::deque<ThreadPool::Task>& queue,
-                  std::atomic<bool>& run_flag, std::atomic<bool>& sleeping_flag,
-                  std::atomic<bool>& done_flag, unsigned int empty_queue_wait_time,
-                  std::exception_ptr& exception_ptr)
-        : m_queue_mutex(queue_mutex), m_queue(queue), m_run_flag(run_flag),
-          m_sleeping_flag(sleeping_flag), m_done_flag(done_flag),
-          m_empty_queue_wait_time(empty_queue_wait_time),
-          m_exception_ptr(exception_ptr) {
-  }
+  Worker(std::mutex& queue_mutex, std::deque<ThreadPool::Task>& queue, std::atomic<bool>& run_flag,
+         std::atomic<bool>& sleeping_flag, std::atomic<bool>& done_flag, unsigned int empty_queue_wait_time,
+         std::exception_ptr& exception_ptr)
+      : m_queue_mutex(queue_mutex)
+      , m_queue(queue)
+      , m_run_flag(run_flag)
+      , m_sleeping_flag(sleeping_flag)
+      , m_done_flag(done_flag)
+      , m_empty_queue_wait_time(empty_queue_wait_time)
+      , m_exception_ptr(exception_ptr) {}
 
   void operator()() {
     while (m_run_flag.get() && m_exception_ptr == nullptr) {
       // Check if there is anything it the queue to be done and get it
       std::unique_ptr<ThreadPool::Task> task_ptr = nullptr;
-      std::unique_lock<std::mutex> lock {m_queue_mutex.get()};
+      std::unique_lock<std::mutex>      lock{m_queue_mutex.get()};
       if (!m_queue.get().empty()) {
         task_ptr = Euclid::make_unique<ThreadPool::Task>(m_queue.get().front());
         m_queue.get().pop_front();
@@ -58,7 +58,7 @@ public:
       if (task_ptr) {
         try {
           (*task_ptr)();
-        } catch(...) {
+        } catch (...) {
           m_exception_ptr.get() = std::current_exception();
         }
       } else {
@@ -69,32 +69,33 @@ public:
     }
     // Indicate that the worker is done
     m_sleeping_flag.get() = true;
-    m_done_flag.get() = true;
+    m_done_flag.get()     = true;
   }
 
 private:
-
-  std::reference_wrapper<std::mutex> m_queue_mutex;
+  std::reference_wrapper<std::mutex>                   m_queue_mutex;
   std::reference_wrapper<std::deque<ThreadPool::Task>> m_queue;
-  std::reference_wrapper<std::atomic<bool>> m_run_flag;
-  std::reference_wrapper<std::atomic<bool>> m_sleeping_flag;
-  std::reference_wrapper<std::atomic<bool>> m_done_flag;
-  unsigned int m_empty_queue_wait_time;
-  std::reference_wrapper<std::exception_ptr> m_exception_ptr;
-
+  std::reference_wrapper<std::atomic<bool>>            m_run_flag;
+  std::reference_wrapper<std::atomic<bool>>            m_sleeping_flag;
+  std::reference_wrapper<std::atomic<bool>>            m_done_flag;
+  unsigned int                                         m_empty_queue_wait_time;
+  std::reference_wrapper<std::exception_ptr>           m_exception_ptr;
 };
 
-} // end of anonymous namespace
+}  // end of anonymous namespace
 
 ThreadPool::ThreadPool(unsigned int thread_count, unsigned int empty_queue_wait_time)
-        : m_worker_run_flags(thread_count), m_worker_sleeping_flags(thread_count),
-          m_worker_done_flags(thread_count), m_empty_queue_wait_time(empty_queue_wait_time) {
+    : m_worker_run_flags(thread_count)
+    , m_worker_sleeping_flags(thread_count)
+    , m_worker_done_flags(thread_count)
+    , m_empty_queue_wait_time(empty_queue_wait_time) {
   for (unsigned int i = 0; i < thread_count; ++i) {
-    m_worker_run_flags.at(i) = true;
+    m_worker_run_flags.at(i)      = true;
     m_worker_sleeping_flags.at(i) = false;
-    m_worker_done_flags.at(i) = false;
-    std::thread(Worker{m_queue_mutex, m_queue, m_worker_run_flags.at(i), m_worker_sleeping_flags.at(i),
-                       m_worker_done_flags.at(i), m_empty_queue_wait_time, m_exception_ptr}).detach();
+    m_worker_done_flags.at(i)     = false;
+    std::thread(Worker{m_queue_mutex, m_queue, m_worker_run_flags.at(i), m_worker_sleeping_flags.at(i), m_worker_done_flags.at(i),
+                       m_empty_queue_wait_time, m_exception_ptr})
+        .detach();
   }
 }
 
@@ -109,7 +110,7 @@ void waitWorkers(std::vector<std::atomic<bool>>& worker_flags, unsigned int wait
   }
 }
 
-}
+}  // namespace
 
 bool ThreadPool::checkForException(bool rethrow) {
   if (m_exception_ptr) {
@@ -126,7 +127,7 @@ void ThreadPool::block() {
   // Wait for the queue to be empty
   bool queue_is_empty = false;
   while (!queue_is_empty && m_exception_ptr == nullptr) {
-    std::unique_lock<std::mutex> lock {m_queue_mutex};
+    std::unique_lock<std::mutex> lock{m_queue_mutex};
     queue_is_empty = m_queue.empty();
     lock.unlock();
     if (!queue_is_empty) {
@@ -139,7 +140,6 @@ void ThreadPool::block() {
   checkForException(true);
 }
 
-
 ThreadPool::~ThreadPool() {
   // Stop all the workers. They will stop right after they finish the task
   // they already run.
@@ -149,11 +149,8 @@ ThreadPool::~ThreadPool() {
 }
 
 void ThreadPool::submit(Task task) {
-  std::lock_guard<std::mutex> lock {m_queue_mutex};
+  std::lock_guard<std::mutex> lock{m_queue_mutex};
   m_queue.emplace_back(std::move(task));
 }
 
-} // Euclid namespace
-
-
-
+}  // namespace Euclid

--- a/AlexandriaKernel/tests/src/StringUtils_test.cpp
+++ b/AlexandriaKernel/tests/src/StringUtils_test.cpp
@@ -16,8 +16,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <boost/test/unit_test.hpp>
 #include <ElementsKernel/Exception.h>
+#include <boost/test/unit_test.hpp>
 
 #include "AlexandriaKernel/StringUtils.h"
 

--- a/Configuration/Configuration/CatalogConfig.h
+++ b/Configuration/Configuration/CatalogConfig.h
@@ -22,15 +22,15 @@
 #ifndef _CONFIGURATION_CATALOGCONFIG_H
 #define _CONFIGURATION_CATALOGCONFIG_H
 
-#include <memory>
-#include <vector>
-#include <functional>
-#include <boost/filesystem.hpp>
+#include "Configuration/Configuration.h"
+#include "SourceCatalog/AttributeFromRow.h"
+#include "SourceCatalog/Catalog.h"
 #include "Table/Table.h"
 #include "Table/TableReader.h"
-#include "SourceCatalog/Catalog.h"
-#include "SourceCatalog/AttributeFromRow.h"
-#include "Configuration/Configuration.h"
+#include <boost/filesystem.hpp>
+#include <functional>
+#include <memory>
+#include <vector>
 
 namespace Euclid {
 namespace Configuration {
@@ -66,7 +66,6 @@ namespace Configuration {
 class CatalogConfig : public Configuration {
 
 public:
-
   /// A function that converts objects of type Table::Table to objects of type
   /// SourceCatalog::Catalog
   using TableToCatalogConverter = std::function<SourceCatalog::Catalog(const Table::Table&)>;
@@ -245,13 +244,12 @@ public:
   const boost::filesystem::path& getFilename() const;
 
 private:
-
-  boost::filesystem::path m_base_dir;
-  boost::filesystem::path m_filename;
-  bool m_fits_format = true;
-  std::string m_id_column_name;
+  boost::filesystem::path                                       m_base_dir;
+  boost::filesystem::path                                       m_filename;
+  bool                                                          m_fits_format = true;
+  std::string                                                   m_id_column_name;
   std::vector<std::shared_ptr<SourceCatalog::AttributeFromRow>> m_attribute_handlers;
-  std::shared_ptr<Table::ColumnInfo> m_column_info;
+  std::shared_ptr<Table::ColumnInfo>                            m_column_info;
 
 }; /* End of CatalogConfig class */
 

--- a/Configuration/Configuration/ConfigManager.h
+++ b/Configuration/Configuration/ConfigManager.h
@@ -22,11 +22,11 @@
 #ifndef _CONFIGURATION_CONFIGMANAGER_H
 #define _CONFIGURATION_CONFIGMANAGER_H
 
-#include <map>
-#include <string>
-#include <memory>
-#include <typeindex>
 #include <boost/program_options.hpp>
+#include <map>
+#include <memory>
+#include <string>
+#include <typeindex>
 
 namespace Euclid {
 namespace Configuration {
@@ -81,7 +81,6 @@ class Configuration;
 class ConfigManager {
 
 public:
-
   /// Returns a reference to the ConfigManager with the given ID
   static ConfigManager& getInstance(long id);
 
@@ -147,7 +146,6 @@ public:
    */
   boost::program_options::options_description closeRegistration();
 
-
   /**
    * @brief
    * Initialize the manager
@@ -186,18 +184,15 @@ public:
   T& getConfiguration();
 
 private:
-
   explicit ConfigManager(long id);
 
-  enum class State {
-    REGISTRATION, WAITING_INITIALIZATION, INITIALIZED
-  };
+  enum class State { REGISTRATION, WAITING_INITIALIZATION, INITIALIZED };
 
-  long m_id;
-  State m_state = State::REGISTRATION;
-  std::unique_ptr<std::type_index> m_root_config;
+  long                                                      m_id;
+  State                                                     m_state = State::REGISTRATION;
+  std::unique_ptr<std::type_index>                          m_root_config;
   std::map<std::type_index, std::unique_ptr<Configuration>> m_config_dictionary;
-  std::map<std::type_index, std::set<std::type_index>> m_dependency_map;
+  std::map<std::type_index, std::set<std::type_index>>      m_dependency_map;
 
 }; /* End of ConfigManager class */
 

--- a/Configuration/Configuration/Configuration.h
+++ b/Configuration/Configuration/Configuration.h
@@ -22,12 +22,12 @@
 #ifndef _CONFIGURATION_CONFIGURATION_H
 #define _CONFIGURATION_CONFIGURATION_H
 
-#include <vector>
-#include <set>
+#include <boost/program_options.hpp>
 #include <map>
+#include <set>
 #include <string>
 #include <typeindex>
-#include <boost/program_options.hpp>
+#include <vector>
 
 namespace Euclid {
 namespace Configuration {
@@ -45,7 +45,6 @@ namespace Configuration {
 class Configuration {
 
 public:
-
   /// Defines the different states the configuration object can be in
   enum class State {
     /// The object has just been constructed
@@ -59,7 +58,7 @@ public:
   };
 
   using OptionDescriptionList = std::vector<boost::program_options::option_description>;
-  using UserValues = std::map<std::string, boost::program_options::variable_value>;
+  using UserValues            = std::map<std::string, boost::program_options::variable_value>;
 
   /// Constructs a new Configuration instance
   explicit Configuration(long manager_id);
@@ -139,7 +138,6 @@ public:
   State getCurrentState() const;
 
 protected:
-
   /**
    * @brief
    * Declares a Configuration as dependency
@@ -169,10 +167,9 @@ protected:
   const T& getDependency() const;
 
 private:
-
-  long m_manager_id;
+  long                      m_manager_id;
   std::set<std::type_index> m_dependencies;
-  State m_state = State::CONSTRUCTED;
+  State                     m_state = State::CONSTRUCTED;
 
 }; /* End of Configuration class */
 

--- a/Configuration/Configuration/PdfCatalogConfig.h
+++ b/Configuration/Configuration/PdfCatalogConfig.h
@@ -24,10 +24,10 @@
 #ifndef CONFIGURATION_PDFCATALOGCONFIG_H
 #define CONFIGURATION_PDFCATALOGCONFIG_H
 
+#include "Configuration/CatalogConfig.h"
+#include "Configuration/Configuration.h"
 #include "ElementsKernel/Exception.h"
 #include "SourceCatalog/SourceAttributes/PdfFromRow.h"
-#include "Configuration/Configuration.h"
-#include "Configuration/CatalogConfig.h"
 
 namespace Euclid {
 namespace Configuration {
@@ -41,7 +41,6 @@ template <typename T>
 class PdfCatalogConfig : public Configuration {
 
 public:
-
   explicit PdfCatalogConfig(long manager_id) : Configuration(manager_id) {
     declareDependency<CatalogConfig>();
   }
@@ -57,19 +56,15 @@ public:
   }
 
   void initialize(const UserValues&) override {
-    getDependency<CatalogConfig>().addAttributeHandler(
-      std::make_shared<SourceCatalog::PdfFromRow<T>>(m_keys, m_column_names));
+    getDependency<CatalogConfig>().addAttributeHandler(std::make_shared<SourceCatalog::PdfFromRow<T>>(m_keys, m_column_names));
   }
 
 private:
-
   std::map<std::string, std::vector<T>> m_keys;
-  std::map<std::string, std::string> m_column_names;
-
+  std::map<std::string, std::string>    m_column_names;
 };
 
-}
-}
+}  // namespace Configuration
+}  // namespace Euclid
 
 #endif /* CONFIGURATION_PDFCATALOGCONFIG_H */
-

--- a/Configuration/Configuration/PhotometricBandMappingConfig.h
+++ b/Configuration/Configuration/PhotometricBandMappingConfig.h
@@ -25,10 +25,10 @@
 #ifndef _CONFIGURATION_PHOTOMETRICBANDMAPPINGCONFIG_H
 #define _CONFIGURATION_PHOTOMETRICBANDMAPPINGCONFIG_H
 
+#include <boost/filesystem.hpp>
+#include <string>
 #include <utility>
 #include <vector>
-#include <string>
-#include <boost/filesystem.hpp>
 
 #include "Configuration.h"
 
@@ -45,8 +45,7 @@ namespace Configuration {
 class PhotometricBandMappingConfig : public Configuration {
 
 public:
-
-  using MappingMap = std::vector<std::pair<std::string, std::pair<std::string, std::string>>>;
+  using MappingMap             = std::vector<std::pair<std::string, std::pair<std::string, std::string>>>;
   using UpperLimitThresholdMap = std::vector<std::pair<std::string, float>>;
 
   /// Constructs a new PhotometricBandMappingConfig object
@@ -129,15 +128,13 @@ public:
   const UpperLimitThresholdMap& getUpperLimitThresholdMapping();
 
 private:
-
   boost::filesystem::path m_base_dir;
-  MappingMap m_mapping_map;
-  UpperLimitThresholdMap m_threshold_map;
+  MappingMap              m_mapping_map;
+  UpperLimitThresholdMap  m_threshold_map;
 
 }; /* End of PhotometricBandMappingConfig class */
 
 } /* namespace Configuration */
 } /* namespace Euclid */
-
 
 #endif

--- a/Configuration/Configuration/PhotometryCatalogConfig.h
+++ b/Configuration/Configuration/PhotometryCatalogConfig.h
@@ -25,10 +25,10 @@
 #ifndef _CONFIGURATION_PHOTOMETRYCATALOGCONFIG_H
 #define _CONFIGURATION_PHOTOMETRYCATALOGCONFIG_H
 
-#include <vector>
-#include <string>
-#include <boost/filesystem.hpp>
 #include "Configuration/Configuration.h"
+#include <boost/filesystem.hpp>
+#include <string>
+#include <vector>
 
 namespace Euclid {
 namespace Configuration {
@@ -42,7 +42,6 @@ namespace Configuration {
 class PhotometryCatalogConfig : public Configuration {
 
 public:
-
   /// Constructs a new PhotometryCatalogConfig object
   explicit PhotometryCatalogConfig(long manager_id);
 
@@ -89,13 +88,12 @@ public:
   bool isUpperLimitEnabled();
 
 private:
-  bool m_missing_photometry_enabled {false};
-  bool m_upper_limit_enabled {false};
+  bool m_missing_photometry_enabled{false};
+  bool m_upper_limit_enabled{false};
 
 }; /* End of PhotometryCatalogConfig class */
 
 } /* namespace Configuration */
 } /* namespace Euclid */
-
 
 #endif

--- a/Configuration/Configuration/ProgramOptionsHelper.h
+++ b/Configuration/Configuration/ProgramOptionsHelper.h
@@ -1,20 +1,20 @@
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 /**
  * @file Configuration/ProgramOptionsHelper.h
@@ -25,10 +25,10 @@
 #ifndef _CONFIGURATION_PROGRAMOPTIONSHELPER_H
 #define _CONFIGURATION_PROGRAMOPTIONSHELPER_H
 
-#include <set>
-#include <map>
-#include <string>
 #include <boost/program_options.hpp>
+#include <map>
+#include <set>
+#include <string>
 
 namespace Euclid {
 namespace Configuration {
@@ -40,15 +40,14 @@ namespace Configuration {
 class ProgramOptionsHelper {
 
 public:
-
   /**
    * @brief Destructor
    */
   virtual ~ProgramOptionsHelper() = default;
-  
+
   /**
    * @brief Creates the name to use for a wildcard program option
-   * 
+   *
    * @details
    * This method has two usages. If is is called with only the name parameter,
    * it returns the name of the option as it should be appended to the boost
@@ -56,12 +55,12 @@ public:
    * instance name, it returns the name to be used for retrieving the option
    * value from the boost variables_map. The names of the instances can be
    * retrieved by using the findWildcardNames() method.
-   * 
+   *
    * @param name The name of the wildcard option
    * @param instance The name of the instance
    * @return The wildcard option name
    */
-  static std::string wildcard(const std::string& name, const std::string& instance="*");
+  static std::string wildcard(const std::string& name, const std::string& instance = "*");
 
   /**
    * @brief Returns the instance names of wildcard options
@@ -69,18 +68,17 @@ public:
    * This method searches for all wildcard options in the option_name_list and
    * it returns the instance names to be used with the wildcard() method for
    * retrieving the option value from a boost variables_map.
-   * 
+   *
    * @param option_name_list The list of the wildcard options to search for
    * @param options The map with the values of the user
    * @return The instance names
    */
   static std::set<std::string> findWildcardNames(const std::vector<std::string>& option_name_list,
-                      const std::map<std::string, boost::program_options::variable_value>& options);
-  
+                                                 const std::map<std::string, boost::program_options::variable_value>& options);
+
 }; /* End of ProgramOptionsHelper class */
 
 } /* namespace Configuration */
 } /* namespace Euclid */
-
 
 #endif

--- a/Configuration/Configuration/SpecZCatalogConfig.h
+++ b/Configuration/Configuration/SpecZCatalogConfig.h
@@ -39,7 +39,6 @@ namespace Configuration {
 class SpecZCatalogConfig : public Configuration {
 
 public:
-
   /// Constructs a new SpecZCatalogConfig object
   explicit SpecZCatalogConfig(long manager_id);
 
@@ -101,11 +100,9 @@ public:
   void initialize(const UserValues& args) override;
 
 private:
-
 }; /* End of SpecZCatalogConfig class */
 
 } /* namespace Configuration */
 } /* namespace Euclid */
-
 
 #endif

--- a/Configuration/Configuration/Utils.h
+++ b/Configuration/Configuration/Utils.h
@@ -36,5 +36,4 @@ long getUniqueManagerId();
 } /* namespace Configuration */
 } /* namespace Euclid */
 
-
 #endif

--- a/Configuration/Configuration/_impl/ConfigManager.icpp
+++ b/Configuration/Configuration/_impl/ConfigManager.icpp
@@ -1,17 +1,17 @@
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
- * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
- * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
- * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */  
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 /**
  * @file Configuration/_impl/ConfigManager.icpp
@@ -19,16 +19,15 @@
  * @author nikoapos
  */
 
-#include "ElementsKernel/Exception.h"
 #include "Configuration/Configuration.h"
+#include "ElementsKernel/Exception.h"
 
 namespace Euclid {
 namespace Configuration {
 
 template <typename T>
 void ConfigManager::registerConfiguration() {
-  static_assert(std::is_base_of<Configuration, T>::value,
-      "T template parameter must inherit from Configuration");
+  static_assert(std::is_base_of<Configuration, T>::value, "T template parameter must inherit from Configuration");
   if (m_state != State::REGISTRATION) {
     throw Elements::Exception() << "Manager with id '" << m_id << "' is closed "
                                 << "for configuration registration";
@@ -41,10 +40,8 @@ void ConfigManager::registerConfiguration() {
 
 template <typename T1, typename T2>
 void ConfigManager::registerDependency() {
-  static_assert(std::is_base_of<Configuration, T1>::value,
-      "T1 template parameter must inherit from Configuration");
-  static_assert(std::is_base_of<Configuration, T2>::value,
-      "T2 template parameter must inherit from Configuration");
+  static_assert(std::is_base_of<Configuration, T1>::value, "T1 template parameter must inherit from Configuration");
+  static_assert(std::is_base_of<Configuration, T2>::value, "T2 template parameter must inherit from Configuration");
   if (m_state != State::REGISTRATION) {
     throw Elements::Exception() << "Manager with id '" << m_id << "' is closed "
                                 << "for dependency registration";
@@ -54,18 +51,17 @@ void ConfigManager::registerDependency() {
 
 template <typename T>
 T& ConfigManager::getConfiguration() {
-  static_assert(std::is_base_of<Configuration, T>::value,
-      "T template parameter must inherit from Configuration");
+  static_assert(std::is_base_of<Configuration, T>::value, "T template parameter must inherit from Configuration");
   if (m_state != State::INITIALIZED) {
     throw Elements::Exception() << "Method getConfiguration() cannot be called on "
                                 << "uninitialized manager with id '" << m_id << "'";
   }
   if (m_config_dictionary.find(typeid(T)) == m_config_dictionary.end()) {
-    throw Elements::Exception() << "No configuration with type " << typeid(T).name()
-                                << " has been registered (manager with id '" << m_id << "')";
+    throw Elements::Exception() << "No configuration with type " << typeid(T).name() << " has been registered (manager with id '"
+                                << m_id << "')";
   }
   return static_cast<T&>(*m_config_dictionary.at(typeid(T)));
 }
 
-} // Configuration namespace
-} // Euclid namespace
+}  // namespace Configuration
+}  // namespace Euclid

--- a/Configuration/Configuration/_impl/Configuration.icpp
+++ b/Configuration/Configuration/_impl/Configuration.icpp
@@ -1,17 +1,17 @@
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
- * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
- * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
- * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */  
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 /**
  * @file Configuration/_impl/Configuration.icpp
@@ -43,5 +43,5 @@ const T& Configuration::getDependency() const {
   return manager.getConfiguration<T>();
 }
 
-} // Configuration namespace
-} // Euclid namespace
+}  // namespace Configuration
+}  // namespace Euclid

--- a/Configuration/src/lib/ConfigManager.cpp
+++ b/Configuration/src/lib/ConfigManager.cpp
@@ -19,10 +19,10 @@
  * @author nikoapos
  */
 
+#include "Configuration/ConfigManager.h"
+#include "Configuration/Configuration.h"
 #include "ElementsKernel/Exception.h"
 #include "ElementsKernel/Logging.h"
-#include "Configuration/Configuration.h"
-#include "Configuration/ConfigManager.h"
 
 namespace po = boost::program_options;
 
@@ -32,20 +32,19 @@ namespace Configuration {
 static Elements::Logging logger = Elements::Logging::getLogger("ConfigManager");
 
 ConfigManager& ConfigManager::getInstance(long id) {
-  static std::map<long, std::unique_ptr<ConfigManager>> manager_map {};
-  auto& manager_ptr = manager_map[id];
+  static std::map<long, std::unique_ptr<ConfigManager>> manager_map{};
+  auto&                                                 manager_ptr = manager_map[id];
   if (manager_ptr == nullptr) {
     manager_ptr.reset(new ConfigManager{id});
   }
   return *manager_ptr;
 }
 
-ConfigManager::ConfigManager(long id) : m_id{id} {
-}
+ConfigManager::ConfigManager(long id) : m_id{id} {}
 
-std::vector<std::type_index> hasCircularDependencies(
-  const std::map<std::type_index, std::set<std::type_index>>& dependency_map,
-  const std::type_index& root, const std::pair<const std::type_index, std::set<std::type_index>>& config_pair) {
+std::vector<std::type_index>
+hasCircularDependencies(const std::map<std::type_index, std::set<std::type_index>>& dependency_map, const std::type_index& root,
+                        const std::pair<const std::type_index, std::set<std::type_index>>& config_pair) {
 
   if (config_pair.second.find(root) != config_pair.second.end()) {
     return {root};
@@ -53,7 +52,7 @@ std::vector<std::type_index> hasCircularDependencies(
   for (auto& config : config_pair.second) {
     auto found = hasCircularDependencies(dependency_map, root, *dependency_map.find(config));
     if (!found.empty()) {
-      std::vector<std::type_index> result {config};
+      std::vector<std::type_index> result{config};
       for (auto& type : found) {
         result.emplace_back(type);
       }
@@ -63,31 +62,29 @@ std::vector<std::type_index> hasCircularDependencies(
   return {};
 }
 
-static void cleanupNonRegisteredDependencies(std::map<std::type_index, std::set<std::type_index>>& dep_map,
+static void cleanupNonRegisteredDependencies(std::map<std::type_index, std::set<std::type_index>>&            dep_map,
                                              const std::map<std::type_index, std::unique_ptr<Configuration>>& dict) {
   logger.debug() << "Cleaning dependencies of unregistered configurations...";
-  std::vector<std::type_index> unregistered_keys {};
+  std::vector<std::type_index> unregistered_keys{};
   for (auto& pair : dep_map) {
     if (dict.find(pair.first) == dict.end()) {
       unregistered_keys.emplace_back(pair.first);
       continue;
     }
-    std::vector<std::type_index> unregistered_values {};
+    std::vector<std::type_index> unregistered_values{};
     for (auto& value : pair.second) {
       if (dict.find(value) == dict.end()) {
         unregistered_values.emplace_back(value);
       }
     }
     for (auto& to_remove : unregistered_values) {
-      logger.info() << "Removing configuration dependency " << pair.first.name()
-                    << " -> " << to_remove.name();
+      logger.info() << "Removing configuration dependency " << pair.first.name() << " -> " << to_remove.name();
       pair.second.erase(to_remove);
     }
   }
   for (auto& to_remove : unregistered_keys) {
     for (auto& value : dep_map.at(to_remove)) {
-      logger.info() << "Removing configuration dependency " << to_remove.name()
-                    << " -> " << value.name();
+      logger.info() << "Removing configuration dependency " << to_remove.name() << " -> " << value.name();
     }
     dep_map.erase(to_remove);
   }
@@ -98,8 +95,7 @@ po::options_description ConfigManager::closeRegistration() {
 
   // Populate the dependencies map
   for (auto& pair : m_config_dictionary) {
-    m_dependency_map[pair.first].insert(pair.second->getDependencies().begin(),
-                                        pair.second->getDependencies().end());
+    m_dependency_map[pair.first].insert(pair.second->getDependencies().begin(), pair.second->getDependencies().end());
   }
 
   // Cleanup any dependencies related with non register configurations
@@ -119,7 +115,7 @@ po::options_description ConfigManager::closeRegistration() {
     }
   }
 
-  std::map<std::string, po::options_description> all_options {};
+  std::map<std::string, po::options_description> all_options{};
   for (auto& config : m_config_dictionary) {
     for (auto& pair : config.second->getProgramOptions()) {
       if (all_options.find(pair.first) == all_options.end()) {
@@ -132,7 +128,7 @@ po::options_description ConfigManager::closeRegistration() {
     }
   }
 
-  po::options_description result {};
+  po::options_description result{};
   for (auto& pair : all_options) {
     result.add(pair.second);
   }
@@ -141,9 +137,8 @@ po::options_description ConfigManager::closeRegistration() {
 }
 
 static void recursiveInitialization(const std::map<std::type_index, std::unique_ptr<Configuration>>& dictionary,
-                                    const std::map<std::type_index, std::set<std::type_index>>& dependency_map,
-                                    const std::map<std::string, po::variable_value>& user_values,
-                                    const std::type_index& config) {
+                                    const std::map<std::type_index, std::set<std::type_index>>&      dependency_map,
+                                    const std::map<std::string, po::variable_value>& user_values, const std::type_index& config) {
   if (dictionary.at(config)->getCurrentState() >= Configuration::State::INITIALIZED) {
     return;
   }
@@ -159,23 +154,20 @@ static void recursiveInitialization(const std::map<std::type_index, std::unique_
 void ConfigManager::initialize(const std::map<std::string, po::variable_value>& user_values) {
   m_state = State::INITIALIZED;
   for (auto& pair : m_config_dictionary) {
-    logger.debug() << "Pre-Initializing configuration :" <<  pair.first.name();
+    logger.debug() << "Pre-Initializing configuration :" << pair.first.name();
     pair.second->preInitialize(user_values);
     pair.second->getCurrentState() = Configuration::State::PRE_INITIALIZED;
   }
   for (auto& pair : m_config_dictionary) {
-    logger.debug() << "Initializing configuration :" <<  pair.first.name();
+    logger.debug() << "Initializing configuration :" << pair.first.name();
     recursiveInitialization(m_config_dictionary, m_dependency_map, user_values, pair.first);
   }
   for (auto& pair : m_config_dictionary) {
-    logger.debug() << "Post-Initializing configuration :" <<  pair.first.name();
+    logger.debug() << "Post-Initializing configuration :" << pair.first.name();
     pair.second->postInitialize(user_values);
     pair.second->getCurrentState() = Configuration::State::FINAL;
   }
 }
 
-} // Configuration namespace
-} // Euclid namespace
-
-
-
+}  // namespace Configuration
+}  // namespace Euclid

--- a/Configuration/src/lib/Configuration.cpp
+++ b/Configuration/src/lib/Configuration.cpp
@@ -1,17 +1,17 @@
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
- * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General  
- * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied  
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to  
- * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */  
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 /**
  * @file src/lib/Configuration.cpp
@@ -24,18 +24,17 @@
 namespace Euclid {
 namespace Configuration {
 
-Configuration::Configuration(long manager_id) : m_manager_id{manager_id} {
-}
+Configuration::Configuration(long manager_id) : m_manager_id{manager_id} {}
 
 std::map<std::string, Configuration::OptionDescriptionList> Configuration::getProgramOptions() {
   return std::map<std::string, Configuration::OptionDescriptionList>{};
 }
 
-void Configuration::preInitialize(const UserValues&) { }
+void Configuration::preInitialize(const UserValues&) {}
 
-void Configuration::initialize(const UserValues&) { }
+void Configuration::initialize(const UserValues&) {}
 
-void Configuration::postInitialize(const UserValues&) { }
+void Configuration::postInitialize(const UserValues&) {}
 
 const std::set<std::type_index>& Configuration::getDependencies() {
   return m_dependencies;
@@ -48,8 +47,5 @@ Configuration::State& Configuration::getCurrentState() {
 Configuration::State Configuration::getCurrentState() const {
   return m_state;
 }
-} // Configuration namespace
-} // Euclid namespace
-
-
-
+}  // namespace Configuration
+}  // namespace Euclid

--- a/Configuration/src/lib/PhotometryCatalogConfig.cpp
+++ b/Configuration/src/lib/PhotometryCatalogConfig.cpp
@@ -22,12 +22,11 @@
  * @author nikoapos
  */
 
-#include "ElementsKernel/Logging.h"
-#include "SourceCatalog/SourceAttributes/PhotometryAttributeFromRow.h"
+#include "Configuration/PhotometryCatalogConfig.h"
 #include "Configuration/CatalogConfig.h"
 #include "Configuration/PhotometricBandMappingConfig.h"
-#include "Configuration/PhotometryCatalogConfig.h"
-
+#include "ElementsKernel/Logging.h"
+#include "SourceCatalog/SourceAttributes/PhotometryAttributeFromRow.h"
 
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
@@ -37,9 +36,9 @@ namespace Configuration {
 
 static Elements::Logging logger = Elements::Logging::getLogger("PhotometryCatalogConfig");
 
-static const std::string MISSING_PHOTOMETRY_FLAG {"missing-photometry-flag"};
-static const std::string ENABLE_UPPER_LIMIT {"enable-upper-limit"};
-static const std::string UPPER_LIMIT_USE_THRESHOLD_FLAG {"upper-limit-use-threshod-flag"};
+static const std::string MISSING_PHOTOMETRY_FLAG{"missing-photometry-flag"};
+static const std::string ENABLE_UPPER_LIMIT{"enable-upper-limit"};
+static const std::string UPPER_LIMIT_USE_THRESHOLD_FLAG{"upper-limit-use-threshod-flag"};
 
 PhotometryCatalogConfig::PhotometryCatalogConfig(long manager_id) : Configuration(manager_id) {
   declareDependency<CatalogConfig>();
@@ -47,81 +46,66 @@ PhotometryCatalogConfig::PhotometryCatalogConfig(long manager_id) : Configuratio
 }
 
 auto PhotometryCatalogConfig::getProgramOptions() -> std::map<std::string, OptionDescriptionList> {
-  return {{"Input catalog options", {
-    {MISSING_PHOTOMETRY_FLAG.c_str(), po::value<double>(),
-      "The value passed in the flux indicating that the photometry is missing, if the flag is not provided "
-      "the functionality is disabled"},
-    {ENABLE_UPPER_LIMIT.c_str(), po::value<std::string>()->default_value("NO"),
-      "Define if the catalog contains flux upper limit (YES/NO by default NO)"},
-    {UPPER_LIMIT_USE_THRESHOLD_FLAG.c_str(), po::value<double>()->default_value(-99),
-      "Define a flag (in the flux error column) telling that the sigma has to be computed from "
-      "the flux and the Upper Limit threshold defined for each filter (must be <0 to trigger upper limit "
-      "functionality, by default -99)"}
-  }}};
+  return {{"Input catalog options",
+           {{MISSING_PHOTOMETRY_FLAG.c_str(), po::value<double>(),
+             "The value passed in the flux indicating that the photometry is missing, if the flag is not provided "
+             "the functionality is disabled"},
+            {ENABLE_UPPER_LIMIT.c_str(), po::value<std::string>()->default_value("NO"),
+             "Define if the catalog contains flux upper limit (YES/NO by default NO)"},
+            {UPPER_LIMIT_USE_THRESHOLD_FLAG.c_str(), po::value<double>()->default_value(-99),
+             "Define a flag (in the flux error column) telling that the sigma has to be computed from "
+             "the flux and the Upper Limit threshold defined for each filter (must be <0 to trigger upper limit "
+             "functionality, by default -99)"}}}};
 }
 
 void PhotometryCatalogConfig::initialize(const UserValues& args) {
 
-  m_upper_limit_enabled = (args.find(ENABLE_UPPER_LIMIT) != args.end())
-                          && args.at(ENABLE_UPPER_LIMIT).as<std::string>() == "YES";
+  m_upper_limit_enabled = (args.find(ENABLE_UPPER_LIMIT) != args.end()) && args.at(ENABLE_UPPER_LIMIT).as<std::string>() == "YES";
   logger.info() << "Upper limit functionality is " << (m_upper_limit_enabled ? "ENABLED" : "DISABLED");
 
-  double upper_limit_threshold_flag =-99.;
-  if ( args.find(UPPER_LIMIT_USE_THRESHOLD_FLAG) != args.end() ) {
-     upper_limit_threshold_flag = args.at(UPPER_LIMIT_USE_THRESHOLD_FLAG).as<double>();
+  double upper_limit_threshold_flag = -99.;
+  if (args.find(UPPER_LIMIT_USE_THRESHOLD_FLAG) != args.end()) {
+    upper_limit_threshold_flag = args.at(UPPER_LIMIT_USE_THRESHOLD_FLAG).as<double>();
   }
   if (m_upper_limit_enabled) {
     logger.info() << "Upper limit threshold flag is " << upper_limit_threshold_flag;
   }
 
-
-  double missing_photo_flag =-99.;
-  if ( args.find(MISSING_PHOTOMETRY_FLAG) != args.end() ) {
-    m_missing_photometry_enabled=true;
-    missing_photo_flag = args.at(MISSING_PHOTOMETRY_FLAG).as<double>();
+  double missing_photo_flag = -99.;
+  if (args.find(MISSING_PHOTOMETRY_FLAG) != args.end()) {
+    m_missing_photometry_enabled = true;
+    missing_photo_flag           = args.at(MISSING_PHOTOMETRY_FLAG).as<double>();
   }
   logger.info() << "Missing photometry functionality is " << (m_missing_photometry_enabled ? "ENABLED" : "DISABLED");
 
   auto filter_name_mapping = getDependency<PhotometricBandMappingConfig>().getPhotometricBandMapping();
-  auto threshold_mapping = getDependency<PhotometricBandMappingConfig>().getUpperLimitThresholdMapping();
-  auto column_info = getDependency<CatalogConfig>().getColumnInfo();
+  auto threshold_mapping   = getDependency<PhotometricBandMappingConfig>().getUpperLimitThresholdMapping();
+  auto column_info         = getDependency<CatalogConfig>().getColumnInfo();
 
   // Add the row handler to parse the photometries
-  std::shared_ptr<SourceCatalog::AttributeFromRow> handler_ptr {
-    new SourceCatalog::PhotometryAttributeFromRow {column_info,
-                                                   std::move(filter_name_mapping),
-                                                   m_missing_photometry_enabled,
-                                                   missing_photo_flag,
-                                                   m_upper_limit_enabled,
-                                                   threshold_mapping,
-                                                   upper_limit_threshold_flag
-                                                  }
-  };
+  std::shared_ptr<SourceCatalog::AttributeFromRow> handler_ptr{new SourceCatalog::PhotometryAttributeFromRow{
+      column_info, std::move(filter_name_mapping), m_missing_photometry_enabled, missing_photo_flag, m_upper_limit_enabled,
+      threshold_mapping, upper_limit_threshold_flag}};
   getDependency<CatalogConfig>().addAttributeHandler(std::move(handler_ptr));
 }
 
-
-bool PhotometryCatalogConfig::isMissingPhotometryEnabled(){
+bool PhotometryCatalogConfig::isMissingPhotometryEnabled() {
 
   if (getCurrentState() < State::INITIALIZED) {
-     throw Elements::Exception() << "isMissingPhotometryEnabled() call to uninitialized PhotometryCatalogConfig";
-   }
+    throw Elements::Exception() << "isMissingPhotometryEnabled() call to uninitialized PhotometryCatalogConfig";
+  }
 
   return m_missing_photometry_enabled;
-
 }
 
-bool PhotometryCatalogConfig::isUpperLimitEnabled(){
+bool PhotometryCatalogConfig::isUpperLimitEnabled() {
 
   if (getCurrentState() < State::INITIALIZED) {
-     throw Elements::Exception() << "isUpperLimitEnabled() call to uninitialized PhotometryCatalogConfig";
+    throw Elements::Exception() << "isUpperLimitEnabled() call to uninitialized PhotometryCatalogConfig";
   }
 
   return m_upper_limit_enabled;
 }
 
-} // Configuration namespace
-} // Euclid namespace
-
-
-
+}  // namespace Configuration
+}  // namespace Euclid

--- a/Configuration/src/lib/ProgramOptionsHelper.cpp
+++ b/Configuration/src/lib/ProgramOptionsHelper.cpp
@@ -1,20 +1,20 @@
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 /**
  * @file src/lib/ProgramOptionsHelper.cpp
@@ -22,8 +22,8 @@
  * @author nikoapos
  */
 
-#include <boost/algorithm/string/predicate.hpp>
 #include "Configuration/ProgramOptionsHelper.h"
+#include <boost/algorithm/string/predicate.hpp>
 
 namespace Euclid {
 namespace Configuration {
@@ -32,9 +32,9 @@ std::string ProgramOptionsHelper::wildcard(const std::string& name, const std::s
   return name + "-" + instance;
 }
 
-std::set<std::string> ProgramOptionsHelper::findWildcardNames(
-        const std::vector<std::string>& option_name_list,
-        const std::map<std::string, boost::program_options::variable_value>& options) {
+std::set<std::string>
+ProgramOptionsHelper::findWildcardNames(const std::vector<std::string>&                                      option_name_list,
+                                        const std::map<std::string, boost::program_options::variable_value>& options) {
   std::set<std::string> result;
   for (auto& option_name : option_name_list) {
     for (auto& pair : options) {
@@ -50,9 +50,5 @@ std::set<std::string> ProgramOptionsHelper::findWildcardNames(
   return result;
 }
 
-
-} // Configuration namespace
-} // Euclid namespace
-
-
-
+}  // namespace Configuration
+}  // namespace Euclid

--- a/Configuration/src/lib/SpecZCatalogConfig.cpp
+++ b/Configuration/src/lib/SpecZCatalogConfig.cpp
@@ -1,20 +1,20 @@
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 /**
  * @file src/lib/SpecZCatalogConfig.cpp
@@ -22,124 +22,107 @@
  * @author nikoapos
  */
 
-#include "ElementsKernel/Exception.h"
-#include "SourceCatalog/SourceAttributes/SpectroscopicRedshiftAttributeFromRow.h"
 #include "Configuration/SpecZCatalogConfig.h"
 #include "Configuration/CatalogConfig.h"
+#include "ElementsKernel/Exception.h"
+#include "SourceCatalog/SourceAttributes/SpectroscopicRedshiftAttributeFromRow.h"
 
 namespace po = boost::program_options;
 
 namespace Euclid {
 namespace Configuration {
 
-static const std::string SPECZ_COLUMN_NAME {"spec-z-column-name"};
-static const std::string SPECZ_COLUMN_INDEX {"spec-z-column-index"};
-static const std::string SPECZ_ERR_COLUMN_NAME {"spec-z-err-column-name"};
-static const std::string SPECZ_ERR_COLUMN_INDEX {"spec-z-err-column-index"};
+static const std::string SPECZ_COLUMN_NAME{"spec-z-column-name"};
+static const std::string SPECZ_COLUMN_INDEX{"spec-z-column-index"};
+static const std::string SPECZ_ERR_COLUMN_NAME{"spec-z-err-column-name"};
+static const std::string SPECZ_ERR_COLUMN_INDEX{"spec-z-err-column-index"};
 
 SpecZCatalogConfig::SpecZCatalogConfig(long manager_id) : Configuration(manager_id) {
   declareDependency<CatalogConfig>();
 }
 
 auto SpecZCatalogConfig::getProgramOptions() -> std::map<std::string, OptionDescriptionList> {
-  return {{"Input catalog options", {
-    {SPECZ_COLUMN_NAME.c_str(), po::value<std::string>(),
-        "The name of the column representing the spectroscopic redshift"},
-    {SPECZ_COLUMN_INDEX.c_str(), po::value<int>(),
-        "The 1-based index of the column representing the spectroscopic redshift"},
-    {SPECZ_ERR_COLUMN_NAME.c_str(), po::value<std::string>(),
-        "The name of the column representing spectroscopic redshift error"},
-    {SPECZ_ERR_COLUMN_INDEX.c_str(), po::value<int>(),
-        "The 1-based index of the column representing the spectroscopic redshift error"}
-  }}};
+  return {
+      {"Input catalog options",
+       {{SPECZ_COLUMN_NAME.c_str(), po::value<std::string>(), "The name of the column representing the spectroscopic redshift"},
+        {SPECZ_COLUMN_INDEX.c_str(), po::value<int>(), "The 1-based index of the column representing the spectroscopic redshift"},
+        {SPECZ_ERR_COLUMN_NAME.c_str(), po::value<std::string>(),
+         "The name of the column representing spectroscopic redshift error"},
+        {SPECZ_ERR_COLUMN_INDEX.c_str(), po::value<int>(),
+         "The 1-based index of the column representing the spectroscopic redshift error"}}}};
 }
 
 void SpecZCatalogConfig::preInitialize(const UserValues& args) {
-  if (args.find(SPECZ_COLUMN_NAME) != args.end() 
-      && args.find(SPECZ_COLUMN_INDEX) != args.end()) {
-    throw Elements::Exception() << "Options " << SPECZ_COLUMN_NAME << " and "
-         << SPECZ_COLUMN_INDEX << " are mutually exclusive";
+  if (args.find(SPECZ_COLUMN_NAME) != args.end() && args.find(SPECZ_COLUMN_INDEX) != args.end()) {
+    throw Elements::Exception() << "Options " << SPECZ_COLUMN_NAME << " and " << SPECZ_COLUMN_INDEX << " are mutually exclusive";
   }
-  if (args.find(SPECZ_COLUMN_NAME) == args.end()
-      && args.find(SPECZ_COLUMN_INDEX) == args.end()) {
-     throw Elements::Exception() << "One of the options " << SPECZ_COLUMN_NAME
-         << " and " << SPECZ_COLUMN_INDEX << " must be given";
+  if (args.find(SPECZ_COLUMN_NAME) == args.end() && args.find(SPECZ_COLUMN_INDEX) == args.end()) {
+    throw Elements::Exception() << "One of the options " << SPECZ_COLUMN_NAME << " and " << SPECZ_COLUMN_INDEX << " must be given";
   }
-  if (args.find(SPECZ_COLUMN_INDEX) != args.end()
-      && args.at(SPECZ_COLUMN_INDEX).as<int>() < 1) {
+  if (args.find(SPECZ_COLUMN_INDEX) != args.end() && args.at(SPECZ_COLUMN_INDEX).as<int>() < 1) {
     throw Elements::Exception() << SPECZ_COLUMN_INDEX << " must be a one-based "
-        << "index but was " << args.at(SPECZ_COLUMN_INDEX).as<int>();
+                                << "index but was " << args.at(SPECZ_COLUMN_INDEX).as<int>();
   }
-  if (args.find(SPECZ_ERR_COLUMN_NAME) != args.end() 
-      && args.find(SPECZ_ERR_COLUMN_INDEX) != args.end()) {
-    throw Elements::Exception() << "Options " << SPECZ_ERR_COLUMN_NAME << " and "
-         << SPECZ_ERR_COLUMN_INDEX << " are mutually exclusive";
+  if (args.find(SPECZ_ERR_COLUMN_NAME) != args.end() && args.find(SPECZ_ERR_COLUMN_INDEX) != args.end()) {
+    throw Elements::Exception() << "Options " << SPECZ_ERR_COLUMN_NAME << " and " << SPECZ_ERR_COLUMN_INDEX
+                                << " are mutually exclusive";
   }
-  if (args.find(SPECZ_ERR_COLUMN_INDEX) != args.end()
-      && args.at(SPECZ_ERR_COLUMN_INDEX).as<int>() < 1) {
+  if (args.find(SPECZ_ERR_COLUMN_INDEX) != args.end() && args.at(SPECZ_ERR_COLUMN_INDEX).as<int>() < 1) {
     throw Elements::Exception() << SPECZ_ERR_COLUMN_INDEX << " must be a one-based "
-        << "index but was " << args.at(SPECZ_ERR_COLUMN_INDEX).as<int>();
+                                << "index but was " << args.at(SPECZ_ERR_COLUMN_INDEX).as<int>();
   }
 }
 
-static std::string getFluxColumnFromOptions(const Configuration::UserValues& args,
-                                            const Table::ColumnInfo& column_info) {
+static std::string getFluxColumnFromOptions(const Configuration::UserValues& args, const Table::ColumnInfo& column_info) {
   if (args.find(SPECZ_COLUMN_NAME) != args.end()) {
-    std::string name  = args.at(SPECZ_COLUMN_NAME).as<std::string>();
+    std::string name = args.at(SPECZ_COLUMN_NAME).as<std::string>();
     if (column_info.find(name) == nullptr) {
       throw Elements::Exception() << "Input catalog file does not contain the "
-          << " SpecZ column with name " << name;
+                                  << " SpecZ column with name " << name;
     }
     return name;
   } else {
     std::size_t index = args.at(SPECZ_COLUMN_INDEX).as<int>();
     if (index > column_info.size()) {
-      throw Elements::Exception() << SPECZ_COLUMN_INDEX << " (" << index
-          << ") is out of range (" << column_info.size() << ")";
+      throw Elements::Exception() << SPECZ_COLUMN_INDEX << " (" << index << ") is out of range (" << column_info.size() << ")";
     }
-    return column_info.getDescription(index-1).name;
+    return column_info.getDescription(index - 1).name;
   }
 }
 
-static std::string getErrColumnFromOptions(const Configuration::UserValues& args,
-                                            const Table::ColumnInfo& column_info) {
+static std::string getErrColumnFromOptions(const Configuration::UserValues& args, const Table::ColumnInfo& column_info) {
   if (args.find(SPECZ_ERR_COLUMN_NAME) != args.end()) {
-    std::string name  = args.at(SPECZ_ERR_COLUMN_NAME).as<std::string>();
+    std::string name = args.at(SPECZ_ERR_COLUMN_NAME).as<std::string>();
     if (column_info.find(name) == nullptr) {
       throw Elements::Exception() << "Input catalog file does not contain the "
-          << " SpecZ error column with name " << name;
+                                  << " SpecZ error column with name " << name;
     }
     return name;
   } else {
     std::size_t index = args.at(SPECZ_ERR_COLUMN_INDEX).as<int>();
     if (index > column_info.size()) {
-      throw Elements::Exception() << SPECZ_ERR_COLUMN_INDEX << " (" << index
-          << ") is out of range (" << column_info.size() << ")";
+      throw Elements::Exception() << SPECZ_ERR_COLUMN_INDEX << " (" << index << ") is out of range (" << column_info.size() << ")";
     }
-    return column_info.getDescription(index-1).name;
+    return column_info.getDescription(index - 1).name;
   }
 }
 
 void SpecZCatalogConfig::initialize(const UserValues& args) {
   auto column_info = getDependency<CatalogConfig>().getColumnInfo();
-  
+
   std::string flux_column = getFluxColumnFromOptions(args, *column_info);
-  
-  std::shared_ptr<SourceCatalog::AttributeFromRow> handler_ptr {};
-  
-  if (args.find(SPECZ_ERR_COLUMN_NAME) == args.end()
-      && args.find(SPECZ_ERR_COLUMN_INDEX) == args.end()) {
-    handler_ptr.reset(new SourceCatalog::SpectroscopicRedshiftAttributeFromRow {column_info, flux_column});
+
+  std::shared_ptr<SourceCatalog::AttributeFromRow> handler_ptr{};
+
+  if (args.find(SPECZ_ERR_COLUMN_NAME) == args.end() && args.find(SPECZ_ERR_COLUMN_INDEX) == args.end()) {
+    handler_ptr.reset(new SourceCatalog::SpectroscopicRedshiftAttributeFromRow{column_info, flux_column});
   } else {
     std::string err_column = getErrColumnFromOptions(args, *column_info);
-    handler_ptr.reset(new SourceCatalog::SpectroscopicRedshiftAttributeFromRow {column_info, flux_column, err_column});
+    handler_ptr.reset(new SourceCatalog::SpectroscopicRedshiftAttributeFromRow{column_info, flux_column, err_column});
   }
-  
+
   getDependency<CatalogConfig>().addAttributeHandler(handler_ptr);
 }
 
-} // Configuration namespace
-} // Euclid namespace
-
-
-
+}  // namespace Configuration
+}  // namespace Euclid

--- a/Configuration/src/lib/Utils.cpp
+++ b/Configuration/src/lib/Utils.cpp
@@ -22,8 +22,8 @@
  * @author nikoapos
  */
 
-#include <chrono>
 #include "Configuration/Utils.h"
+#include <chrono>
 
 namespace Euclid {
 namespace Configuration {
@@ -33,15 +33,11 @@ static long last_manager_id = 0;
 long getUniqueManagerId() {
   long id = last_manager_id;
   while (id == last_manager_id) {
-    id = std::chrono::duration_cast<std::chrono::microseconds>(
-      std::chrono::system_clock::now().time_since_epoch()).count();
+    id = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
   }
   last_manager_id = id;
   return id;
 }
 
-} // Configuration namespace
-} // Euclid namespace
-
-
-
+}  // namespace Configuration
+}  // namespace Euclid

--- a/Configuration/tests/src/ConfigManager_fixture.h
+++ b/Configuration/tests/src/ConfigManager_fixture.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file ConfigManager_fixture.h
  * @date Nov 9, 2015
  * @author Nikolaos Apostolakos
@@ -25,19 +25,15 @@
 #ifndef _PHZCONFIGURATION_CONFIGMANAGER_FIXTURE
 #define _PHZCONFIGURATION_CONFIGMANAGER_FIXTURE
 
-#include <chrono>
 #include "Configuration/ConfigManager.h"
 #include "Configuration/Utils.h"
-
+#include <chrono>
 
 struct ConfigManager_fixture {
-  
+
   long timestamp = Euclid::Configuration::getUniqueManagerId();
-  
-  Euclid::Configuration::ConfigManager& config_manager = 
-                      Euclid::Configuration::ConfigManager::getInstance(timestamp);
- 
+
+  Euclid::Configuration::ConfigManager& config_manager = Euclid::Configuration::ConfigManager::getInstance(timestamp);
 };
 
-#endif // _PHZCONFIGURATION_CONFIGMANAGER_FIXTURE
-
+#endif  // _PHZCONFIGURATION_CONFIGMANAGER_FIXTURE

--- a/Configuration/tests/src/ConfigManager_test.cpp
+++ b/Configuration/tests/src/ConfigManager_test.cpp
@@ -21,8 +21,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include "Configuration/ConfigManager.h"
 #include "ConfigManager_fixture.h"
+#include "Configuration/ConfigManager.h"
 
 using namespace Euclid::Configuration;
 namespace po = boost::program_options;
@@ -31,10 +31,10 @@ class Config1 : public Configuration {
 public:
   explicit Config1(long id) : Configuration(id) {}
   std::map<std::string, OptionDescriptionList> getProgramOptions() override {
-    return {{"Test",{{"par-1", po::value<int>(), ""}}}};
+    return {{"Test", {{"par-1", po::value<int>(), ""}}}};
   }
-  bool pre_initialized = false;
-  bool initialized = false;
+  bool pre_initialized  = false;
+  bool initialized      = false;
   bool post_initialized = false;
   void preInitialize(const UserValues&) override {
     BOOST_CHECK(!pre_initialized);
@@ -60,10 +60,10 @@ class Config2 : public Configuration {
 public:
   explicit Config2(long id) : Configuration(id) {}
   std::map<std::string, OptionDescriptionList> getProgramOptions() override {
-    return {{"Test",{{"par-2", po::value<int>(), ""}}}};
+    return {{"Test", {{"par-2", po::value<int>(), ""}}}};
   }
-  bool pre_initialized = false;
-  bool initialized = false;
+  bool pre_initialized  = false;
+  bool initialized      = false;
   bool post_initialized = false;
   void preInitialize(const UserValues&) override {
     BOOST_CHECK(!pre_initialized);
@@ -92,10 +92,10 @@ public:
     declareDependency<Config2>();
   }
   std::map<std::string, OptionDescriptionList> getProgramOptions() override {
-    return {{"Test",{{"par-3", po::value<int>(), ""}}}};
+    return {{"Test", {{"par-3", po::value<int>(), ""}}}};
   }
-  bool pre_initialized = false;
-  bool initialized = false;
+  bool pre_initialized  = false;
+  bool initialized      = false;
   bool post_initialized = false;
   void preInitialize(const UserValues&) override {
     BOOST_CHECK(!pre_initialized);
@@ -121,7 +121,7 @@ public:
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (ConfigManager_test)
+BOOST_AUTO_TEST_SUITE(ConfigManager_test)
 
 //-----------------------------------------------------------------------------
 
@@ -138,7 +138,6 @@ BOOST_FIXTURE_TEST_CASE(registerConfiguration, ConfigManager_fixture) {
   BOOST_CHECK_NO_THROW(config_manager.getConfiguration<Config1>());
   BOOST_CHECK_NO_THROW(config_manager.getConfiguration<Config2>());
   BOOST_CHECK_NO_THROW(config_manager.getConfiguration<Config3>());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -150,7 +149,6 @@ BOOST_FIXTURE_TEST_CASE(registerConfigurationWhenClosed, ConfigManager_fixture) 
 
   // Then
   BOOST_CHECK_THROW(config_manager.registerConfiguration<Config1>(), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -165,7 +163,6 @@ BOOST_FIXTURE_TEST_CASE(circularDependency, ConfigManager_fixture) {
 
   // Then
   BOOST_CHECK_THROW(config_manager.closeRegistration(), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -182,7 +179,6 @@ BOOST_FIXTURE_TEST_CASE(getProgramOptions, ConfigManager_fixture) {
   BOOST_CHECK_NO_THROW(options.find("par-1", false));
   BOOST_CHECK_NO_THROW(options.find("par-2", false));
   BOOST_CHECK_NO_THROW(options.find("par-3", false));
-
 }
 
 //-----------------------------------------------------------------------------
@@ -212,7 +208,6 @@ BOOST_FIXTURE_TEST_CASE(initialize, ConfigManager_fixture) {
   BOOST_CHECK(conf3.initialized);
   BOOST_CHECK(conf3.post_initialized);
   BOOST_CHECK(conf3.getCurrentState() == Configuration::State::FINAL);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -227,7 +222,6 @@ BOOST_FIXTURE_TEST_CASE(getConfigurationNotInitialized, ConfigManager_fixture) {
 
   // Then
   BOOST_CHECK_THROW(config_manager.getConfiguration<Config1>(), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -243,11 +237,8 @@ BOOST_FIXTURE_TEST_CASE(getConfigurationNotRegistered, ConfigManager_fixture) {
 
   // Then
   BOOST_CHECK_THROW(config_manager.getConfiguration<Config2>(), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/Configuration/tests/src/Configuration_test.cpp
+++ b/Configuration/tests/src/Configuration_test.cpp
@@ -21,8 +21,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include "Configuration/Configuration.h"
 #include "ConfigManager_fixture.h"
+#include "Configuration/Configuration.h"
 
 using namespace Euclid::Configuration;
 
@@ -46,14 +46,14 @@ public:
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (Configuration_test)
+BOOST_AUTO_TEST_SUITE(Configuration_test)
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(state_test, ConfigManager_fixture) {
 
   // When
-  Config1 config {timestamp};
+  Config1 config{timestamp};
 
   // Then
   BOOST_CHECK(config.getCurrentState() == Configuration::State::CONSTRUCTED);
@@ -81,7 +81,6 @@ BOOST_FIXTURE_TEST_CASE(state_test, ConfigManager_fixture) {
 
   // Then
   BOOST_CHECK(config.getCurrentState() == Configuration::State::FINAL);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -89,7 +88,7 @@ BOOST_FIXTURE_TEST_CASE(state_test, ConfigManager_fixture) {
 BOOST_FIXTURE_TEST_CASE(dependencies_test, ConfigManager_fixture) {
 
   // When
-  Config3 config {timestamp};
+  Config3 config{timestamp};
 
   // Given
   auto& dependencies = config.getDependencies();
@@ -98,11 +97,8 @@ BOOST_FIXTURE_TEST_CASE(dependencies_test, ConfigManager_fixture) {
   BOOST_CHECK_EQUAL(dependencies.size(), 2);
   BOOST_CHECK_EQUAL(dependencies.count(typeid(Config1)), 1);
   BOOST_CHECK_EQUAL(dependencies.count(typeid(Config2)), 1);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/Configuration/tests/src/PhotometricBandMappingConfig_test.cpp
+++ b/Configuration/tests/src/PhotometricBandMappingConfig_test.cpp
@@ -22,14 +22,14 @@
  * @author nikoapos
  */
 
-#include <fstream>
-#include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <fstream>
 
 #include "ElementsKernel/Temporary.h"
 
-#include "Configuration/PhotometricBandMappingConfig.h"
 #include "ConfigManager_fixture.h"
+#include "Configuration/PhotometricBandMappingConfig.h"
 
 using namespace Euclid::Configuration;
 namespace po = boost::program_options;
@@ -46,72 +46,65 @@ struct BaseDirConfig : public Configuration {
 
 struct PhotometricBandMappingConfig_fixture : public ConfigManager_fixture {
 
-  const std::string FILTER_MAPPING_FILE {"filter-mapping-file"};
-  const std::string EXCLUDE_FILTER {"exclude-filter"};
+  const std::string FILTER_MAPPING_FILE{"filter-mapping-file"};
+  const std::string EXCLUDE_FILTER{"exclude-filter"};
 
   Elements::TempDir temp_dir;
-  std::string filter_mapping_filename {"mapping.txt"};
-  std::string faulty_filter_mapping_filename {"faulty_mapping.txt"};
-  fs::path relative_filename {fs::path{"relative"} / filter_mapping_filename};
-  fs::path absolute_filename {temp_dir.path() / "absolute" / filter_mapping_filename};
-  std::string wrong_format_filename {"wrong.txt"};
+  std::string       filter_mapping_filename{"mapping.txt"};
+  std::string       faulty_filter_mapping_filename{"faulty_mapping.txt"};
+  fs::path          relative_filename{fs::path{"relative"} / filter_mapping_filename};
+  fs::path          absolute_filename{temp_dir.path() / "absolute" / filter_mapping_filename};
+  std::string       wrong_format_filename{"wrong.txt"};
 
-  std::map<std::string, po::variable_value> options_map {};
+  std::map<std::string, po::variable_value> options_map{};
 
   PhotometricBandMappingConfig_fixture() {
 
-    std::string mapping {
-      "#Comment\n"
-      "Filter1 F1 F1_ERR 3\n"
-      "Filter2 F2 F2_ERR\n"
-      "Filter3 F3 F3_ERR 5\n"
-    };
+    std::string mapping{"#Comment\n"
+                        "Filter1 F1 F1_ERR 3\n"
+                        "Filter2 F2 F2_ERR\n"
+                        "Filter3 F3 F3_ERR 5\n"};
 
-    std::string faulty_mapping {
-      "#Comment\n"
-      "Filter3 F3 F3_ERR a5a.1.2\n"
-    };
+    std::string faulty_mapping{"#Comment\n"
+                               "Filter3 F3 F3_ERR a5a.1.2\n"};
 
     {
-      std::ofstream out {(temp_dir.path()/filter_mapping_filename).string()};
+      std::ofstream out{(temp_dir.path() / filter_mapping_filename).string()};
       out << mapping;
     }
 
-
     {
-      std::ofstream out {(temp_dir.path()/faulty_filter_mapping_filename).string()};
+      std::ofstream out{(temp_dir.path() / faulty_filter_mapping_filename).string()};
       out << faulty_mapping;
     }
 
     {
-      fs::create_directories((temp_dir.path()/relative_filename).parent_path());
-      std::ofstream out {(temp_dir.path()/relative_filename).string()};
+      fs::create_directories((temp_dir.path() / relative_filename).parent_path());
+      std::ofstream out{(temp_dir.path() / relative_filename).string()};
       out << mapping;
     }
     {
       fs::create_directories(absolute_filename.parent_path());
-      std::ofstream out {absolute_filename.string()};
+      std::ofstream out{absolute_filename.string()};
       out << mapping;
     }
     {
-      std::ofstream out {(temp_dir.path()/wrong_format_filename).string()};
+      std::ofstream out{(temp_dir.path() / wrong_format_filename).string()};
       out << "Filter1 F1 F1_ERR\n"
           << "Filter2 F2\n";
     }
 
     config_manager.registerConfiguration<BaseDirConfig>();
 
-    options_map["test-base-dir"].value() = boost::any(temp_dir.path().string());
+    options_map["test-base-dir"].value()     = boost::any(temp_dir.path().string());
     options_map[FILTER_MAPPING_FILE].value() = boost::any(filter_mapping_filename);
-    options_map[EXCLUDE_FILTER].value() = boost::any(std::vector<std::string>{});
-
+    options_map[EXCLUDE_FILTER].value()      = boost::any(std::vector<std::string>{});
   }
-
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (PhotometricBandMappingConfig_test)
+BOOST_AUTO_TEST_SUITE(PhotometricBandMappingConfig_test)
 
 //-----------------------------------------------------------------------------
 
@@ -126,7 +119,6 @@ BOOST_FIXTURE_TEST_CASE(getProgramOptions_test, PhotometricBandMappingConfig_fix
   // Then
   BOOST_CHECK_NO_THROW(options.find(FILTER_MAPPING_FILE, false));
   BOOST_CHECK_NO_THROW(options.find(EXCLUDE_FILTER, false));
-
 }
 
 //-----------------------------------------------------------------------------
@@ -152,7 +144,6 @@ BOOST_FIXTURE_TEST_CASE(nominalBandList_test, PhotometricBandMappingConfig_fixtu
   BOOST_CHECK_EQUAL(result[2].first, "Filter3");
   BOOST_CHECK_EQUAL(result[2].second.first, "F3");
   BOOST_CHECK_EQUAL(result[2].second.second, "F3_ERR");
-
 }
 
 BOOST_FIXTURE_TEST_CASE(nominalThresholdList_test, PhotometricBandMappingConfig_fixture) {
@@ -173,7 +164,6 @@ BOOST_FIXTURE_TEST_CASE(nominalThresholdList_test, PhotometricBandMappingConfig_
   BOOST_CHECK_EQUAL(result[1].second, 3);
   BOOST_CHECK_EQUAL(result[2].first, "Filter3");
   BOOST_CHECK_EQUAL(result[2].second, 5);
-
 }
 
 BOOST_FIXTURE_TEST_CASE(FaultyList_test, PhotometricBandMappingConfig_fixture) {
@@ -211,7 +201,6 @@ BOOST_FIXTURE_TEST_CASE(relativePath_test, PhotometricBandMappingConfig_fixture)
   BOOST_CHECK_EQUAL(result[2].first, "Filter3");
   BOOST_CHECK_EQUAL(result[2].second.first, "F3");
   BOOST_CHECK_EQUAL(result[2].second.second, "F3_ERR");
-
 }
 
 //-----------------------------------------------------------------------------
@@ -238,7 +227,6 @@ BOOST_FIXTURE_TEST_CASE(absolutePath_test, PhotometricBandMappingConfig_fixture)
   BOOST_CHECK_EQUAL(result[2].first, "Filter3");
   BOOST_CHECK_EQUAL(result[2].second.first, "F3");
   BOOST_CHECK_EQUAL(result[2].second.second, "F3_ERR");
-
 }
 
 //-----------------------------------------------------------------------------
@@ -254,7 +242,6 @@ BOOST_FIXTURE_TEST_CASE(missingFile_test, PhotometricBandMappingConfig_fixture) 
 
   // Then
   BOOST_CHECK_THROW(config_manager.initialize(options_map), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -270,7 +257,6 @@ BOOST_FIXTURE_TEST_CASE(fileFormatError_test, PhotometricBandMappingConfig_fixtu
 
   // Then
   BOOST_CHECK_THROW(config_manager.initialize(options_map), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -294,7 +280,6 @@ BOOST_FIXTURE_TEST_CASE(excludeFilter_test, PhotometricBandMappingConfig_fixture
   BOOST_CHECK_EQUAL(result[1].first, "Filter3");
   BOOST_CHECK_EQUAL(result[1].second.first, "F3");
   BOOST_CHECK_EQUAL(result[1].second.second, "F3_ERR");
-
 }
 
 BOOST_FIXTURE_TEST_CASE(excludeFilterThreshold_test, PhotometricBandMappingConfig_fixture) {
@@ -314,10 +299,7 @@ BOOST_FIXTURE_TEST_CASE(excludeFilterThreshold_test, PhotometricBandMappingConfi
   BOOST_CHECK_EQUAL(result[0].second, 3);
   BOOST_CHECK_EQUAL(result[1].first, "Filter3");
   BOOST_CHECK_EQUAL(result[1].second, 5);
-
 }
-
-
 
 //-----------------------------------------------------------------------------
 
@@ -333,11 +315,8 @@ BOOST_FIXTURE_TEST_CASE(wrongExcludeFilter_test, PhotometricBandMappingConfig_fi
 
   // Then
   BOOST_CHECK_THROW(config_manager.initialize(options_map), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/Configuration/tests/src/PhotometryCatalogConfig_test.cpp
+++ b/Configuration/tests/src/PhotometryCatalogConfig_test.cpp
@@ -22,18 +22,18 @@
  * @author nikoapos
  */
 
-#include <fstream>
-#include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <fstream>
 
 #include "ElementsKernel/Temporary.h"
-#include "Table/AsciiWriter.h"
 #include "SourceCatalog/SourceAttributes/Photometry.h"
+#include "Table/AsciiWriter.h"
 
-#include "Configuration/CatalogConfig.h"
-#include "Configuration/PhotometryCatalogConfig.h"
 #include "ConfigManager_fixture.h"
+#include "Configuration/CatalogConfig.h"
 #include "Configuration/PhotometricBandMappingConfig.h"
+#include "Configuration/PhotometryCatalogConfig.h"
 
 using namespace Euclid::Table;
 using namespace Euclid::Configuration;
@@ -42,22 +42,17 @@ namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
 static Table createTestTable() {
-  std::vector<ColumnInfo::info_type> info_list {
-    ColumnInfo::info_type {"ID", typeid(std::int64_t)},
-    ColumnInfo::info_type {"F1", typeid(double)},
-    ColumnInfo::info_type {"F1_ERR", typeid(double)},
-    ColumnInfo::info_type {"F2", typeid(double)},
-    ColumnInfo::info_type {"F2_ERR", typeid(double)}
-  };
+  std::vector<ColumnInfo::info_type> info_list{
+      ColumnInfo::info_type{"ID", typeid(std::int64_t)}, ColumnInfo::info_type{"F1", typeid(double)},
+      ColumnInfo::info_type{"F1_ERR", typeid(double)}, ColumnInfo::info_type{"F2", typeid(double)},
+      ColumnInfo::info_type{"F2_ERR", typeid(double)}};
   auto column_info = std::make_shared<ColumnInfo>(std::move(info_list));
 
-  std::vector<Row> row_list {
-    {{std::int64_t{1}, 1.1, 2.1, 3.1, 4.1}, column_info},
-    {{std::int64_t{2}, 1.2, 2.2, 3.2, 4.2}, column_info},
-    {{std::int64_t{3}, 1.3, 2.3, 3.3, 4.3}, column_info}
-  };
+  std::vector<Row> row_list{{{std::int64_t{1}, 1.1, 2.1, 3.1, 4.1}, column_info},
+                            {{std::int64_t{2}, 1.2, 2.2, 3.2, 4.2}, column_info},
+                            {{std::int64_t{3}, 1.3, 2.3, 3.3, 4.3}, column_info}};
 
-  return Table {std::move(row_list)};
+  return Table{std::move(row_list)};
 }
 
 struct BaseDirConfig : public Configuration {
@@ -73,49 +68,44 @@ struct BaseDirConfig : public Configuration {
 
 struct PhotometryCatalogConfig_fixture : public ConfigManager_fixture {
 
-  const std::string MISSING_PHOTOMETRY_FLAG {"missing-photometry-flag"};
-  const std::string ENABLE_UPPER_LIMIT {"enable-upper-limit"};
+  const std::string MISSING_PHOTOMETRY_FLAG{"missing-photometry-flag"};
+  const std::string ENABLE_UPPER_LIMIT{"enable-upper-limit"};
 
   Table table = createTestTable();
 
   Elements::TempDir temp_dir;
-  fs::path catalog_filename = temp_dir.path()/"catalog.txt";
-  fs::path filter_mapping_filename = temp_dir.path()/"mapping.txt";
+  fs::path          catalog_filename        = temp_dir.path() / "catalog.txt";
+  fs::path          filter_mapping_filename = temp_dir.path() / "mapping.txt";
 
-  std::map<std::string, po::variable_value> options_map {};
+  std::map<std::string, po::variable_value> options_map{};
 
   PhotometryCatalogConfig_fixture() {
 
     {
-      std::ofstream out {catalog_filename.string()};
+      std::ofstream out{catalog_filename.string()};
       AsciiWriter(out).addData(table);
     }
-    std::string mapping {
-      "#Comment\n"
-      "Filter1 F1 F1_ERR\n"
-      "Filter2 F2 F2_ERR\n"
-    };
+    std::string mapping{"#Comment\n"
+                        "Filter1 F1 F1_ERR\n"
+                        "Filter2 F2 F2_ERR\n"};
     {
-      std::ofstream out {filter_mapping_filename.string()};
+      std::ofstream out{filter_mapping_filename.string()};
       out << mapping;
     }
 
     config_manager.registerConfiguration<BaseDirConfig>();
 
-    options_map["test-base-dir"].value() = boost::any(temp_dir.path().string());
-    options_map["input-catalog-file"].value() = boost::any(catalog_filename.string());
+    options_map["test-base-dir"].value()        = boost::any(temp_dir.path().string());
+    options_map["input-catalog-file"].value()   = boost::any(catalog_filename.string());
     options_map["input-catalog-format"].value() = boost::any(std::string{"AUTO"});
-    options_map["filter-mapping-file"].value() = boost::any(filter_mapping_filename.string());
-    options_map["exclude-filter"].value() = boost::any(std::vector<std::string>{});
-
-
+    options_map["filter-mapping-file"].value()  = boost::any(filter_mapping_filename.string());
+    options_map["exclude-filter"].value()       = boost::any(std::vector<std::string>{});
   }
-
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (PhotometryCatalogConfig_test)
+BOOST_AUTO_TEST_SUITE(PhotometryCatalogConfig_test)
 
 //-----------------------------------------------------------------------------
 
@@ -133,7 +123,6 @@ BOOST_FIXTURE_TEST_CASE(getProgramOptions_test, PhotometryCatalogConfig_fixture)
   BOOST_CHECK_NO_THROW(options.find(MISSING_PHOTOMETRY_FLAG, false));
 }
 
-
 BOOST_FIXTURE_TEST_CASE(getFlagsfalse_test, PhotometryCatalogConfig_fixture) {
 
   // Given
@@ -146,7 +135,6 @@ BOOST_FIXTURE_TEST_CASE(getFlagsfalse_test, PhotometryCatalogConfig_fixture) {
   config_manager.initialize(options_map);
   BOOST_CHECK(!config_manager.getConfiguration<PhotometryCatalogConfig>().isMissingPhotometryEnabled());
   BOOST_CHECK(!config_manager.getConfiguration<PhotometryCatalogConfig>().isUpperLimitEnabled());
-
 }
 
 BOOST_FIXTURE_TEST_CASE(getFlagstrue_test, PhotometryCatalogConfig_fixture) {
@@ -158,13 +146,12 @@ BOOST_FIXTURE_TEST_CASE(getFlagstrue_test, PhotometryCatalogConfig_fixture) {
   auto options = config_manager.closeRegistration();
 
   options_map[MISSING_PHOTOMETRY_FLAG].value() = boost::any(-99.);
-  options_map[ENABLE_UPPER_LIMIT].value() = boost::any(std::string{"YES"});
+  options_map[ENABLE_UPPER_LIMIT].value()      = boost::any(std::string{"YES"});
 
   // Then
   config_manager.initialize(options_map);
   BOOST_CHECK(config_manager.getConfiguration<PhotometryCatalogConfig>().isMissingPhotometryEnabled());
   BOOST_CHECK(config_manager.getConfiguration<PhotometryCatalogConfig>().isUpperLimitEnabled());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -181,25 +168,24 @@ BOOST_FIXTURE_TEST_CASE(nominal_test, PhotometryCatalogConfig_fixture) {
 
   // Then
   BOOST_CHECK_EQUAL(result.size(), 3);
-  BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter1")->flux,  1.1);
+  BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter1")->flux, 1.1);
   BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter1")->error, 2.1);
   BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter1")->missing_photometry_flag, false);
-  BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter2")->flux,  3.1);
+  BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter2")->flux, 3.1);
   BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter2")->error, 4.1);
   BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter2")->missing_photometry_flag, false);
-  BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter1")->flux,  1.2);
+  BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter1")->flux, 1.2);
   BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter1")->error, 2.2);
   BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter1")->missing_photometry_flag, false);
-  BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter2")->flux,  3.2);
+  BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter2")->flux, 3.2);
   BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter2")->error, 4.2);
   BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter2")->missing_photometry_flag, false);
-  BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter1")->flux,  1.3);
+  BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter1")->flux, 1.3);
   BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter1")->error, 2.3);
   BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter1")->missing_photometry_flag, false);
-  BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter2")->flux,  3.3);
+  BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter2")->flux, 3.3);
   BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter2")->error, 4.3);
   BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter2")->missing_photometry_flag, false);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -217,31 +203,28 @@ BOOST_FIXTURE_TEST_CASE(missingPhotometryFlag_test, PhotometryCatalogConfig_fixt
 
   // Then
   BOOST_CHECK_EQUAL(result.size(), 3);
-  BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter1")->flux,  1.1);
+  BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter1")->flux, 1.1);
   BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter1")->error, 2.1);
   BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter1")->missing_photometry_flag, false);
-  BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter2")->flux,  3.1);
+  BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter2")->flux, 3.1);
   BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter2")->error, 4.1);
   BOOST_CHECK_EQUAL(result.find(1)->getAttribute<Photometry>()->find("Filter2")->missing_photometry_flag, false);
 
-  BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter1")->flux,  1.2);
+  BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter1")->flux, 1.2);
   BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter1")->error, 0);
   BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter1")->missing_photometry_flag, true);
 
-  BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter2")->flux,  3.2);
+  BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter2")->flux, 3.2);
   BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter2")->error, 4.2);
   BOOST_CHECK_EQUAL(result.find(2)->getAttribute<Photometry>()->find("Filter2")->missing_photometry_flag, false);
-  BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter1")->flux,  1.3);
+  BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter1")->flux, 1.3);
   BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter1")->error, 2.3);
   BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter1")->missing_photometry_flag, false);
-  BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter2")->flux,  3.3);
+  BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter2")->flux, 3.3);
   BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter2")->error, 4.3);
   BOOST_CHECK_EQUAL(result.find(3)->getAttribute<Photometry>()->find("Filter2")->missing_photometry_flag, false);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/Configuration/tests/src/ProgramOptionsHelper_test.cpp
+++ b/Configuration/tests/src/ProgramOptionsHelper_test.cpp
@@ -1,20 +1,20 @@
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 /**
  * @file tests/src/ProgramOptionsHelper_test.cpp
@@ -30,7 +30,7 @@ using poh = Euclid::Configuration::ProgramOptionsHelper;
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (ProgramOptionsHelper_test)
+BOOST_AUTO_TEST_SUITE(ProgramOptionsHelper_test)
 
 //-----------------------------------------------------------------------------
 
@@ -38,13 +38,12 @@ BOOST_AUTO_TEST_CASE(wildcard_only_name_test) {
 
   // Given
   std::string name = "option";
-  
+
   // When
   auto result = poh::wildcard(name);
 
   // Then
-  BOOST_CHECK_EQUAL(result, name+"-*");
-  
+  BOOST_CHECK_EQUAL(result, name + "-*");
 }
 
 //-----------------------------------------------------------------------------
@@ -52,15 +51,14 @@ BOOST_AUTO_TEST_CASE(wildcard_only_name_test) {
 BOOST_AUTO_TEST_CASE(wildcard_with_instance_test) {
 
   // Given
-  std::string name = "option";
+  std::string name     = "option";
   std::string instance = "instance";
-  
+
   // When
   auto result = poh::wildcard(name, instance);
 
   // Then
-  BOOST_CHECK_EQUAL(result, name+"-"+instance);
-  
+  BOOST_CHECK_EQUAL(result, name + "-" + instance);
 }
 
 //-----------------------------------------------------------------------------
@@ -68,19 +66,17 @@ BOOST_AUTO_TEST_CASE(wildcard_with_instance_test) {
 BOOST_AUTO_TEST_CASE(findWildcardNames_test) {
 
   // Given
-  std::string name1 = "option1";
-  std::string name2 = "option2";
+  std::string name1     = "option1";
+  std::string name2     = "option2";
   std::string instance1 = "instance1";
   std::string instance2 = "instance2";
   std::string instance3 = "instance3";
-  
-  std::map<std::string, boost::program_options::variable_value> options {
-    {poh::wildcard(name1, instance1), {}},
-    {poh::wildcard(name1, instance2), {}},
-    {poh::wildcard(name2, instance2), {}},
-    {poh::wildcard(name2, instance3), {}}
-  };
-  
+
+  std::map<std::string, boost::program_options::variable_value> options{{poh::wildcard(name1, instance1), {}},
+                                                                        {poh::wildcard(name1, instance2), {}},
+                                                                        {poh::wildcard(name2, instance2), {}},
+                                                                        {poh::wildcard(name2, instance3), {}}};
+
   // When
   auto result = poh::findWildcardNames({name1, name2}, options);
 
@@ -89,11 +85,8 @@ BOOST_AUTO_TEST_CASE(findWildcardNames_test) {
   BOOST_CHECK_EQUAL(result.count(instance1), 1);
   BOOST_CHECK_EQUAL(result.count(instance2), 1);
   BOOST_CHECK_EQUAL(result.count(instance3), 1);
-  
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/Configuration/tests/src/SpecZCatalogConfig_test.cpp
+++ b/Configuration/tests/src/SpecZCatalogConfig_test.cpp
@@ -1,20 +1,20 @@
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 /**
  * @file tests/src/SpecZCatalogConfig_test.cpp
@@ -22,17 +22,17 @@
  * @author nikoapos
  */
 
-#include <fstream>
-#include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <fstream>
 
 #include "ElementsKernel/Temporary.h"
-#include "Table/AsciiWriter.h"
 #include "SourceCatalog/SourceAttributes/SpectroscopicRedshift.h"
+#include "Table/AsciiWriter.h"
 
+#include "ConfigManager_fixture.h"
 #include "Configuration/CatalogConfig.h"
 #include "Configuration/SpecZCatalogConfig.h"
-#include "ConfigManager_fixture.h"
 
 using namespace Euclid::Table;
 using namespace Euclid::Configuration;
@@ -41,20 +41,16 @@ namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
 static Table createTestTable() {
-  std::vector<ColumnInfo::info_type> info_list {
-    ColumnInfo::info_type {"ID", typeid(std::int64_t)},
-    ColumnInfo::info_type {"SPECZ", typeid(double)},
-    ColumnInfo::info_type {"ERR", typeid(double)}
-  };
-  auto column_info = std::make_shared<ColumnInfo>(std::move(info_list));
-  
-  std::vector<Row> row_list {
-    {{std::int64_t{1}, 1.1, 0.1}, column_info},
-    {{std::int64_t{2}, 1.2, 0.2}, column_info},
-    {{std::int64_t{3}, 1.3, 0.3}, column_info}
-  };
-  
-  return Table {std::move(row_list)};
+  std::vector<ColumnInfo::info_type> info_list{ColumnInfo::info_type{"ID", typeid(std::int64_t)},
+                                               ColumnInfo::info_type{"SPECZ", typeid(double)},
+                                               ColumnInfo::info_type{"ERR", typeid(double)}};
+  auto                               column_info = std::make_shared<ColumnInfo>(std::move(info_list));
+
+  std::vector<Row> row_list{{{std::int64_t{1}, 1.1, 0.1}, column_info},
+                            {{std::int64_t{2}, 1.2, 0.2}, column_info},
+                            {{std::int64_t{3}, 1.3, 0.3}, column_info}};
+
+  return Table{std::move(row_list)};
 }
 
 struct BaseDirConfig : public Configuration {
@@ -67,41 +63,39 @@ struct BaseDirConfig : public Configuration {
 };
 
 struct SpecZCatalogConfig_fixture : public ConfigManager_fixture {
-  
-  const std::string SPECZ_COLUMN_NAME {"spec-z-column-name"};
-  const std::string SPECZ_COLUMN_INDEX {"spec-z-column-index"};
-  const std::string SPECZ_ERR_COLUMN_NAME {"spec-z-err-column-name"};
-  const std::string SPECZ_ERR_COLUMN_INDEX {"spec-z-err-column-index"};
-  
+
+  const std::string SPECZ_COLUMN_NAME{"spec-z-column-name"};
+  const std::string SPECZ_COLUMN_INDEX{"spec-z-column-index"};
+  const std::string SPECZ_ERR_COLUMN_NAME{"spec-z-err-column-name"};
+  const std::string SPECZ_ERR_COLUMN_INDEX{"spec-z-err-column-index"};
+
   Table table = createTestTable();
-  
+
   Elements::TempDir temp_dir;
-  std::string filename {"catalog.txt"};
-  
-  std::map<std::string, po::variable_value> options_map {};
-  
+  std::string       filename{"catalog.txt"};
+
+  std::map<std::string, po::variable_value> options_map{};
+
   SpecZCatalogConfig_fixture() {
-    
+
     {
-      std::ofstream out {(temp_dir.path()/filename).string()};
+      std::ofstream out{(temp_dir.path() / filename).string()};
       AsciiWriter(out).addData(table);
     }
-    
+
     config_manager.registerConfiguration<BaseDirConfig>();
-    
-    options_map["test-base-dir"].value() = boost::any(temp_dir.path().string());
-    options_map["input-catalog-file"].value() = boost::any(filename);
+
+    options_map["test-base-dir"].value()        = boost::any(temp_dir.path().string());
+    options_map["input-catalog-file"].value()   = boost::any(filename);
     options_map["input-catalog-format"].value() = boost::any(std::string{"AUTO"});
-    options_map[SPECZ_COLUMN_NAME].value() = boost::any(std::string{"SPECZ"});
-    options_map[SPECZ_ERR_COLUMN_NAME].value() = boost::any(std::string{"ERR"});
-    
+    options_map[SPECZ_COLUMN_NAME].value()      = boost::any(std::string{"SPECZ"});
+    options_map[SPECZ_ERR_COLUMN_NAME].value()  = boost::any(std::string{"ERR"});
   }
-  
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (SpecZCatalogConfig_test)
+BOOST_AUTO_TEST_SUITE(SpecZCatalogConfig_test)
 
 //-----------------------------------------------------------------------------
 
@@ -109,116 +103,110 @@ BOOST_FIXTURE_TEST_CASE(getProgramOptions_test, SpecZCatalogConfig_fixture) {
 
   // Given
   config_manager.registerConfiguration<SpecZCatalogConfig>();
-  
+
   // When
   auto options = config_manager.closeRegistration();
-  
+
   // Then
   BOOST_CHECK_NO_THROW(options.find(SPECZ_COLUMN_NAME, false));
   BOOST_CHECK_NO_THROW(options.find(SPECZ_COLUMN_INDEX, false));
   BOOST_CHECK_NO_THROW(options.find(SPECZ_ERR_COLUMN_NAME, false));
   BOOST_CHECK_NO_THROW(options.find(SPECZ_ERR_COLUMN_INDEX, false));
-
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(bothSpeczNameIndex_test, SpecZCatalogConfig_fixture) {
-  
+
   // Given
-  options_map[SPECZ_COLUMN_NAME].value() = boost::any(std::string{"SPECZ"});
+  options_map[SPECZ_COLUMN_NAME].value()  = boost::any(std::string{"SPECZ"});
   options_map[SPECZ_COLUMN_INDEX].value() = boost::any(2);
-  
+
   // When
   config_manager.registerConfiguration<SpecZCatalogConfig>();
   config_manager.closeRegistration();
-  
-  //Then
+
+  // Then
   BOOST_CHECK_THROW(config_manager.initialize(options_map), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(noneOfSpeczNameIndex_test, SpecZCatalogConfig_fixture) {
-  
+
   // Given
   options_map.erase(SPECZ_COLUMN_NAME);
   options_map.erase(SPECZ_COLUMN_INDEX);
-  
+
   // When
   config_manager.registerConfiguration<SpecZCatalogConfig>();
   config_manager.closeRegistration();
-  
-  //Then
+
+  // Then
   BOOST_CHECK_THROW(config_manager.initialize(options_map), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(invalidSpeczIndex_test, SpecZCatalogConfig_fixture) {
-  
+
   // Given
   options_map.erase(SPECZ_COLUMN_NAME);
   options_map[SPECZ_COLUMN_INDEX].value() = boost::any(0);
-  
+
   // When
   config_manager.registerConfiguration<SpecZCatalogConfig>();
   config_manager.closeRegistration();
-  
-  //Then
+
+  // Then
   BOOST_CHECK_THROW(config_manager.initialize(options_map), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(bothErrNameIndex_test, SpecZCatalogConfig_fixture) {
-  
+
   // Given
-  options_map[SPECZ_ERR_COLUMN_NAME].value() = boost::any(std::string{"ERR"});
+  options_map[SPECZ_ERR_COLUMN_NAME].value()  = boost::any(std::string{"ERR"});
   options_map[SPECZ_ERR_COLUMN_INDEX].value() = boost::any(3);
-  
+
   // When
   config_manager.registerConfiguration<SpecZCatalogConfig>();
   config_manager.closeRegistration();
-  
-  //Then
+
+  // Then
   BOOST_CHECK_THROW(config_manager.initialize(options_map), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(invalidErrIndex_test, SpecZCatalogConfig_fixture) {
-  
+
   // Given
   options_map.erase(SPECZ_ERR_COLUMN_NAME);
   options_map[SPECZ_ERR_COLUMN_INDEX].value() = boost::any(0);
-  
+
   // When
   config_manager.registerConfiguration<SpecZCatalogConfig>();
   config_manager.closeRegistration();
-  
-  //Then
+
+  // Then
   BOOST_CHECK_THROW(config_manager.initialize(options_map), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(nominal_test, SpecZCatalogConfig_fixture) {
-  
+
   // Given
   config_manager.registerConfiguration<SpecZCatalogConfig>();
   config_manager.closeRegistration();
-  
+
   // When
   config_manager.initialize(options_map);
   auto result = config_manager.getConfiguration<CatalogConfig>().readAsCatalog();
-  
-  //Then
+
+  // Then
   BOOST_CHECK_EQUAL(result.size(), 3);
   BOOST_CHECK_EQUAL(result.find(1)->getAttribute<SpectroscopicRedshift>()->getValue(), 1.1);
   BOOST_CHECK_EQUAL(result.find(1)->getAttribute<SpectroscopicRedshift>()->getError(), 0.1);
@@ -226,24 +214,23 @@ BOOST_FIXTURE_TEST_CASE(nominal_test, SpecZCatalogConfig_fixture) {
   BOOST_CHECK_EQUAL(result.find(2)->getAttribute<SpectroscopicRedshift>()->getError(), 0.2);
   BOOST_CHECK_EQUAL(result.find(3)->getAttribute<SpectroscopicRedshift>()->getValue(), 1.3);
   BOOST_CHECK_EQUAL(result.find(3)->getAttribute<SpectroscopicRedshift>()->getError(), 0.3);
-  
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(noError_test, SpecZCatalogConfig_fixture) {
-  
+
   // Given
   config_manager.registerConfiguration<SpecZCatalogConfig>();
   config_manager.closeRegistration();
   options_map.erase(SPECZ_ERR_COLUMN_INDEX);
   options_map.erase(SPECZ_ERR_COLUMN_NAME);
-  
+
   // When
   config_manager.initialize(options_map);
   auto result = config_manager.getConfiguration<CatalogConfig>().readAsCatalog();
-  
-  //Then
+
+  // Then
   BOOST_CHECK_EQUAL(result.size(), 3);
   BOOST_CHECK_EQUAL(result.find(1)->getAttribute<SpectroscopicRedshift>()->getValue(), 1.1);
   BOOST_CHECK_EQUAL(result.find(1)->getAttribute<SpectroscopicRedshift>()->getError(), 0.);
@@ -251,79 +238,72 @@ BOOST_FIXTURE_TEST_CASE(noError_test, SpecZCatalogConfig_fixture) {
   BOOST_CHECK_EQUAL(result.find(2)->getAttribute<SpectroscopicRedshift>()->getError(), 0.);
   BOOST_CHECK_EQUAL(result.find(3)->getAttribute<SpectroscopicRedshift>()->getValue(), 1.3);
   BOOST_CHECK_EQUAL(result.find(3)->getAttribute<SpectroscopicRedshift>()->getError(), 0.);
-  
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(unknownSpeczName_test, SpecZCatalogConfig_fixture) {
-  
+
   // Given
   options_map[SPECZ_COLUMN_NAME].value() = boost::any(std::string{"Unknown"});
   options_map.erase(SPECZ_COLUMN_INDEX);
-  
+
   // When
   config_manager.registerConfiguration<SpecZCatalogConfig>();
   config_manager.closeRegistration();
-  
-  //Then
+
+  // Then
   BOOST_CHECK_THROW(config_manager.initialize(options_map), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(outOfBoundsSpeczIndex_test, SpecZCatalogConfig_fixture) {
-  
+
   // Given
   options_map.erase(SPECZ_COLUMN_NAME);
   options_map[SPECZ_COLUMN_INDEX].value() = boost::any(10);
-  
+
   // When
   config_manager.registerConfiguration<SpecZCatalogConfig>();
   config_manager.closeRegistration();
-  
-  //Then
+
+  // Then
   BOOST_CHECK_THROW(config_manager.initialize(options_map), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(unknownErrName_test, SpecZCatalogConfig_fixture) {
-  
+
   // Given
   options_map[SPECZ_ERR_COLUMN_NAME].value() = boost::any(std::string{"Unknown"});
   options_map.erase(SPECZ_ERR_COLUMN_INDEX);
-  
+
   // When
   config_manager.registerConfiguration<SpecZCatalogConfig>();
   config_manager.closeRegistration();
-  
-  //Then
+
+  // Then
   BOOST_CHECK_THROW(config_manager.initialize(options_map), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(outOfBoundsErrIndex_test, SpecZCatalogConfig_fixture) {
-  
+
   // Given
   options_map.erase(SPECZ_ERR_COLUMN_NAME);
   options_map[SPECZ_ERR_COLUMN_INDEX].value() = boost::any(10);
-  
+
   // When
   config_manager.registerConfiguration<SpecZCatalogConfig>();
   config_manager.closeRegistration();
-  
-  //Then
+
+  // Then
   BOOST_CHECK_THROW(config_manager.initialize(options_map), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/GridContainer/GridContainer/GridAxis.h
+++ b/GridContainer/GridContainer/GridAxis.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file GridContainer/GridAxis.h
  * @date May 12, 2014
  * @author Nikolaos Apostolakos
@@ -45,11 +45,10 @@ namespace GridContainer {
  *
  * @tparam T the type of the axis values
  */
-template<typename T>
+template <typename T>
 class GridAxis {
 
 public:
-
   /// The type of the axis values
   typedef T data_type;
 
@@ -97,15 +96,13 @@ public:
   bool operator!=(const GridAxis<U>& other) const;
 
 private:
-
-  std::string m_name;
+  std::string    m_name;
   std::vector<T> m_values;
-
 };
 
-} // end of namespace GridContainer
-} // end of namespace Euclid
+}  // end of namespace GridContainer
+}  // end of namespace Euclid
 
 #include "GridContainer/_impl/GridAxis.icpp"
 
-#endif  /* GRIDCONTAINER_GRIDAXIS_H */
+#endif /* GRIDCONTAINER_GRIDAXIS_H */

--- a/GridContainer/GridContainer/GridCellManagerTraits.h
+++ b/GridContainer/GridContainer/GridCellManagerTraits.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file GridContainer/GridCellManagerTraits.h
  * @date May 13, 2014
  * @author Nikolaos Apostolakos
@@ -25,8 +25,8 @@
 #ifndef GRIDCONTAINER_GRIDCELLMANAGERTRAITS_H
 #define GRIDCONTAINER_GRIDCELLMANAGERTRAITS_H
 
-#include <vector>
 #include <memory>
+#include <vector>
 
 namespace Euclid {
 namespace GridContainer {
@@ -46,7 +46,7 @@ namespace GridContainer {
  *
  * @tparam GridCellManager the manager which keeps the GridContainer data
  */
-template<typename GridCellManager>
+template <typename GridCellManager>
 struct GridCellManagerTraits {
 
   /// The type of the data kept by the GridCellManager
@@ -100,8 +100,7 @@ struct GridCellManagerTraits {
   /// this flag set to false cannot be serialized.
   static const bool enable_boost_serialize = false;
 
-}; // end of GridCellManagerTraits
-
+};  // end of GridCellManagerTraits
 
 /**
  * Specialization of the GridCellManagerTraits for vector CellManagers. It uses
@@ -111,7 +110,7 @@ struct GridCellManagerTraits {
  *
  * @tparam T the type of the data kept by the vector
  */
-template<typename T>
+template <typename T>
 struct GridCellManagerTraits<std::vector<T>> {
 
   /// The type of the data kept by the GridCellManager
@@ -136,11 +135,11 @@ struct GridCellManagerTraits<std::vector<T>> {
   /// Enables boost serialization of Grids using vector%s as GridCellManager%s
   static const bool enable_boost_serialize = true;
 
-}; // end of GridCellManagerTraits vector specialization
+};  // end of GridCellManagerTraits vector specialization
 
-} // end of namespace GridContainer
-} // end of namespace Euclid
+}  // end of namespace GridContainer
+}  // end of namespace Euclid
 
 #include "GridContainer/_impl/GridCellManagerTraits.icpp"
 
-#endif  /* GRIDCONTAINER_GRIDCELLMANAGERTRAITS_H */
+#endif /* GRIDCONTAINER_GRIDCELLMANAGERTRAITS_H */

--- a/GridContainer/GridContainer/GridContainer.h
+++ b/GridContainer/GridContainer/GridContainer.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file GridContainer/GridContainer.h
  * @date May 13, 2014
  * @author Nikolaos Apostolakos
@@ -25,14 +25,14 @@
 #ifndef GRIDCONTAINER_GRIDCONTAINER_H
 #define GRIDCONTAINER_GRIDCONTAINER_H
 
-#include <memory>
-#include <tuple>
-#include <iterator>
-#include <map>
-#include <type_traits>
 #include "GridContainer/GridCellManagerTraits.h"
 #include "GridContainer/GridIndexHelper.h"
 #include "GridContainer/_impl/GridConstructionHelper.h"
+#include <iterator>
+#include <map>
+#include <memory>
+#include <tuple>
+#include <type_traits>
 
 namespace Euclid {
 namespace GridContainer {
@@ -93,14 +93,13 @@ namespace GridContainer {
  *                     delegated
  * @tparam AxesTypes The types of the grid axes
  */
-template<typename GridCellManager, typename... AxesTypes>
+template <typename GridCellManager, typename... AxesTypes>
 class GridContainer {
 
   // The following aliases are used to simplify the definitions inside the class
   typedef typename GridCellManagerTraits<GridCellManager>::iterator cell_manager_iter_type;
 
 public:
-
   /// The type of the values stored in the grid cells
   typedef typename GridCellManagerTraits<GridCellManager>::data_type cell_type;
 
@@ -108,14 +107,14 @@ public:
   typedef std::tuple<GridAxis<AxesTypes>...> AxesTuple;
 
   // The following is a shortcut to retrieve the type of each axis
-  template<int I>
+  template <int I>
   using axis_type = typename std::tuple_element<I, std::tuple<AxesTypes...>>::type;
 
   // The iterator type of the GridContainer. See at the end of the file for its declaration
-  template<typename CellType>
+  template <typename CellType>
   class iter;
 
-  typedef iter<cell_type> iterator;
+  typedef iter<cell_type>       iterator;
   typedef iter<cell_type const> const_iterator;
 
   /**
@@ -142,7 +141,6 @@ public:
   GridContainer(GridContainer<GridCellManager, AxesTypes...>&&) = default;
   GridContainer& operator=(GridContainer<GridCellManager, AxesTypes...>&&) = default;
 
-
   // Do not allow copying of GridContainer objects. This is done because these
   // objects will most of the time be very big and copying them will be a
   // bottleneck. To avoid unvoluntary copy constructor calls, this constructor
@@ -161,7 +159,7 @@ public:
    * @tparam I The (zero based) index of the axis
    * @return the axis information
    */
-  template<int I>
+  template <int I>
   const GridAxis<axis_type<I>>& getAxis() const;
 
   /// Returns a tuple containing the information of all the grid axes.
@@ -333,23 +331,19 @@ public:
   const GridContainer<GridCellManager, AxesTypes...> fixAxisByValue(const axis_type<I>& value) const;
 
 private:
-
   /// A tuple containing the axes of the grid
   std::tuple<GridAxis<AxesTypes>...> m_axes;
   /// A helper class used for calculations of the axes indices
-  GridIndexHelper<AxesTypes...> m_index_helper {m_axes};
+  GridIndexHelper<AxesTypes...> m_index_helper{m_axes};
   /// a tuple containing the original axes of the full grid, if this grid is a slice
-  std::tuple<GridAxis<AxesTypes>...> m_axes_fixed {m_axes};
+  std::tuple<GridAxis<AxesTypes>...> m_axes_fixed{m_axes};
   /// a helper class for calculations of the original axes indices
-  GridIndexHelper<AxesTypes...> m_index_helper_fixed {m_axes_fixed};
+  GridIndexHelper<AxesTypes...> m_index_helper_fixed{m_axes_fixed};
   /// A map containing the axes which have been fixed, if this grid is a slice
-  std::map<size_t, size_t> m_fixed_indices {};
+  std::map<size_t, size_t> m_fixed_indices{};
   /// A pointer to the data of the grid
-  std::shared_ptr<GridCellManager> m_cell_manager {
-          GridCellManagerTraits<GridCellManager>::factory(
-                  GridConstructionHelper<AxesTypes...>::getAxisIndexFactor(
-                          m_axes, TemplateLoopCounter<sizeof...(AxesTypes)-1>{}))
-  };
+  std::shared_ptr<GridCellManager> m_cell_manager{GridCellManagerTraits<GridCellManager>::factory(
+      GridConstructionHelper<AxesTypes...>::getAxisIndexFactor(m_axes, TemplateLoopCounter<sizeof...(AxesTypes) - 1>{}))};
 
   /**
    * @brief Slice constructor
@@ -366,11 +360,10 @@ private:
   /// Returns the original axis. This behaves the same like the getAxis() with
   /// exception the case that the grid is a slice. In that case, it will return
   /// the original axes and not the single value fixed ones.
-  template<int I>
+  template <int I>
   const GridAxis<axis_type<I>>& getOriginalAxis() const;
 
-}; // end of class GridContainer
-
+};  // end of class GridContainer
 
 /**
  * @class GridContainer::iter
@@ -385,11 +378,10 @@ private:
  * information. Slicing can be achieved by using the fixAxisByIndex() and
  * fixAxisByValue() methods.
  */
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
 class GridContainer<GridCellManager, AxesTypes...>::iter : public std::iterator<std::forward_iterator_tag, CellType> {
 public:
-
   /**
    * @brief Constructs a new iterator for the given grid
    * @details
@@ -399,8 +391,7 @@ public:
    * @param owner The grid to iterate through
    * @param data_iter The GridCellManager iterator indicating the cell position
    */
-  iter(const GridContainer<GridCellManager, AxesTypes...>& owner,
-           const cell_manager_iter_type& data_iter);
+  iter(const GridContainer<GridCellManager, AxesTypes...>& owner, const cell_manager_iter_type& data_iter);
 
   /// Copy constructor
   iter(const iter<CellType>&) = default;
@@ -436,12 +427,12 @@ public:
 
   /// Returns the index (coordinate) of the axis with index I, for the cell
   /// the iterator points
-  template<int I>
+  template <int I>
   size_t axisIndex() const;
 
   /// Returns the value of the axis with index I, for the cell the iterator
   /// points
-  template<int I>
+  template <int I>
   const axis_type<I>& axisValue() const;
 
   /**
@@ -457,7 +448,7 @@ public:
    * @throws Elements::Exception
    *    if the axis has already been fixed for this iterator
    */
-  template<int I>
+  template <int I>
   iter& fixAxisByIndex(size_t index);
 
   /**
@@ -477,7 +468,7 @@ public:
    * @throws Elements::Exception
    *    if the axis has already been fixed for this iterator
    */
-  template<int I>
+  template <int I>
   iter& fixAxisByValue(const axis_type<I>& value);
 
   /**
@@ -489,23 +480,21 @@ public:
    * @param other The iterator to get the axes values from
    * @return the iterator with all its axes fixed
    */
-  template<typename OtherIter>
+  template <typename OtherIter>
   iter& fixAllAxes(const OtherIter& other);
 
 private:
-
   const GridContainer<GridCellManager, AxesTypes...>& m_owner;
-  cell_manager_iter_type m_data_iter;
-  std::map<size_t, size_t> m_fixed_indices;
-  void forwardToIndex(size_t axis, size_t fixed_index);
+  cell_manager_iter_type                              m_data_iter;
+  std::map<size_t, size_t>                            m_fixed_indices;
+  void                                                forwardToIndex(size_t axis, size_t fixed_index);
 
-}; // end of class iter
+};  // end of class iter
 
-} // end of namespace GridContainer
-} // end of namespace Euclid
+}  // end of namespace GridContainer
+}  // end of namespace Euclid
 
 #include "GridContainer/_impl/GridContainer.icpp"
 #include "GridContainer/_impl/GridIterator.icpp"
 
-#endif  /* GRIDCONTAINER_GRIDCONTAINER_H */
-
+#endif /* GRIDCONTAINER_GRIDCONTAINER_H */

--- a/GridContainer/GridContainer/GridContainerToTable.h
+++ b/GridContainer/GridContainer/GridContainerToTable.h
@@ -19,10 +19,10 @@
 #ifndef GRIDCONTAINER_GRIDCONTAINERTOTABLE_H
 #define GRIDCONTAINER_GRIDCONTAINERTOTABLE_H
 
-#include <vector>
 #include "GridContainer/GridContainer.h"
 #include "Table/Table.h"
 #include "XYDataset/QualifiedName.h"
+#include <vector>
 
 namespace Euclid {
 namespace GridContainer {
@@ -33,7 +33,7 @@ namespace GridContainer {
  * @tparam T
  *  Type to be mapped
  */
-template<typename T>
+template <typename T>
 struct GridAxisToTable {
   typedef T table_cell_t;
 
@@ -45,7 +45,7 @@ struct GridAxisToTable {
 /**
  * Specialization for mapping a qualified name into a string
  */
-template<>
+template <>
 struct GridAxisToTable<Euclid::XYDataset::QualifiedName> {
   typedef std::string table_cell_t;
 
@@ -59,7 +59,7 @@ struct GridAxisToTable<Euclid::XYDataset::QualifiedName> {
  * @tparam T
  *  Type to be mapped
  */
-template<typename T, typename Enable=void>
+template <typename T, typename Enable = void>
 struct GridCellToTable {
   static_assert(!std::is_same<T, T>::value, "Specialization of GridCellToTable required");
 
@@ -86,7 +86,7 @@ struct GridCellToTable {
 /**
  * Specialization for scalar types
  */
-template<typename T>
+template <typename T>
 struct GridCellToTable<T, typename std::enable_if<std::is_arithmetic<T>::value>::type> {
 
   static void addColumnDescriptions(const T&, std::vector<Table::ColumnDescription>& columns) {
@@ -102,12 +102,12 @@ struct GridCellToTable<T, typename std::enable_if<std::is_arithmetic<T>::value>:
  * Transform a GridContainer into a Table, with an entry for each
  * cell. The content will be unfolded, so the knot values will be repeated.
  */
-template<typename GridCellManager, typename ...AxesTypes>
+template <typename GridCellManager, typename... AxesTypes>
 Table::Table gridContainerToTable(const GridContainer<GridCellManager, AxesTypes...>& grid);
 
-} // end of namespace GridContainer
-} // end of namespace Euclid
+}  // end of namespace GridContainer
+}  // end of namespace Euclid
 
 #include "GridContainer/_impl/GridContainerToTable.icpp"
 
-#endif // GRIDCONTAINER_GRIDCONTAINERTOTABLE_H
+#endif  // GRIDCONTAINER_GRIDCONTAINERTOTABLE_H

--- a/GridContainer/GridContainer/GridIndexHelper.h
+++ b/GridContainer/GridContainer/GridIndexHelper.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file GridContainer/GridIndexHelper.h
  * @date May 15, 2014
  * @author Nikolaos Apostolakos
@@ -25,10 +25,10 @@
 #ifndef GRIDCONTAINER_GRIDINDEXHELPER_H
 #define GRIDCONTAINER_GRIDINDEXHELPER_H
 
-#include <vector>
-#include <tuple>
 #include "GridContainer/GridAxis.h"
 #include "GridContainer/_impl/GridConstructionHelper.h"
+#include <tuple>
+#include <vector>
 
 namespace Euclid {
 namespace GridContainer {
@@ -50,11 +50,10 @@ namespace GridContainer {
  *
  * @tparam AxesTypes The types of the GridContainer axes
  */
-template<typename... AxesTypes>
+template <typename... AxesTypes>
 class GridIndexHelper {
 
 public:
-
   /**
    * Constructs a new GridIndexHelper instance for making conversions for
    * a GridContainer with the given axes. For avoiding the long template syntax
@@ -108,11 +107,10 @@ public:
 
   /// Checks if any of the given coordinates is fixed and not zero
   template <typename Coord, typename... RestCoords>
-  void checkAllFixedAreZero(const std::map<size_t, size_t>& fixed_indices,
-                            Coord coord, RestCoords... rest_coords) const;
+  void checkAllFixedAreZero(const std::map<size_t, size_t>& fixed_indices, Coord coord, RestCoords... rest_coords) const;
 
-  std::vector<size_t> m_axes_sizes;
-  std::vector<size_t> m_axes_index_factors;
+  std::vector<size_t>      m_axes_sizes;
+  std::vector<size_t>      m_axes_index_factors;
   std::vector<std::string> m_axes_names;
 };
 
@@ -125,15 +123,14 @@ public:
  * @param axes_tuple the information of the GridContainer axes
  * @return The GridIndexHelper instance
  */
-template<typename... AxesTypes>
+template <typename... AxesTypes>
 GridIndexHelper<AxesTypes...> makeGridIndexHelper(const std::tuple<GridAxis<AxesTypes>...>& axes_tuple) {
   return GridIndexHelper<AxesTypes...>(axes_tuple);
 }
 
-} // end of namespace GridContainer
-} // end of namespace Euclid
+}  // end of namespace GridContainer
+}  // end of namespace Euclid
 
 #include "GridContainer/_impl/GridIndexHelper.icpp"
 
-#endif  /* GRIDCONTAINER_GRIDINDEXHELPER_H */
-
+#endif /* GRIDCONTAINER_GRIDINDEXHELPER_H */

--- a/GridContainer/GridContainer/_impl/FitsSerialize.icpp
+++ b/GridContainer/GridContainer/_impl/FitsSerialize.icpp
@@ -1,43 +1,42 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
 
-/* 
+/*
  * @file FitsSerialize.icpp
  * @author nikoapos
  */
 
-#include <valarray>
-#include <type_traits>
-#include <boost/filesystem.hpp>
-#include <CCfits/CCfits>
-#include "XYDataset/QualifiedName.h"
-#include "Table/Table.h"
-#include "Table/FitsWriter.h"
-#include "GridContainer/GridContainer.h"
 #include "GridConstructionHelper.h"
+#include "GridContainer/GridContainer.h"
+#include "Table/FitsWriter.h"
+#include "Table/Table.h"
+#include "XYDataset/QualifiedName.h"
+#include <CCfits/CCfits>
+#include <boost/filesystem.hpp>
+#include <type_traits>
+#include <valarray>
 
 namespace Euclid {
 namespace GridContainer {
 
 template <typename T>
 struct FitsBpixTraits {
-  static_assert(!std::is_same<T,T>::value, "FITS arrays of type T are not supported");
+  static_assert(!std::is_same<T, T>::value, "FITS arrays of type T are not supported");
 };
 
 template <>
@@ -70,7 +69,7 @@ struct FitsBpixTraits<double> {
   static constexpr int BPIX = DOUBLE_IMG;
 };
 
-template<typename T>
+template <typename T>
 struct GridAxisValueFitsHelper {
   using FitsType = T;
   static FitsType axisToFits(const T& value) {
@@ -81,7 +80,7 @@ struct GridAxisValueFitsHelper {
   }
 };
 
-template<>
+template <>
 struct GridAxisValueFitsHelper<XYDataset::QualifiedName> {
   using FitsType = std::string;
   static FitsType axisToFits(const XYDataset::QualifiedName& value) {
@@ -92,156 +91,145 @@ struct GridAxisValueFitsHelper<XYDataset::QualifiedName> {
   }
 };
 
-template<typename... AxesTypes>
+template <typename... AxesTypes>
 struct GridAxesToFitsHelper {
-  
-  template<int I>
-  static void addGridAxesToFitsFile(const boost::filesystem::path& filename,
-                                    const std::string& array_hdu_name,
-                                    const std::tuple<GridAxis<AxesTypes>...>& axes_tuple,
-                                    const TemplateLoopCounter<I>&) {
-    addGridAxesToFitsFile(filename, array_hdu_name, axes_tuple, TemplateLoopCounter<I-1>{});
-    
-    auto& axis = std::get<I-1>(axes_tuple);
+
+  template <int I>
+  static void addGridAxesToFitsFile(const boost::filesystem::path& filename, const std::string& array_hdu_name,
+                                    const std::tuple<GridAxis<AxesTypes>...>& axes_tuple, const TemplateLoopCounter<I>&) {
+    addGridAxesToFitsFile(filename, array_hdu_name, axes_tuple, TemplateLoopCounter<I - 1>{});
+
+    auto& axis     = std::get<I - 1>(axes_tuple);
     using AxisType = typename std::remove_reference<decltype(axis)>::type::data_type;
     using FitsType = typename GridAxisValueFitsHelper<AxisType>::FitsType;
-  
-    std::vector<Table::ColumnInfo::info_type> info_list {
-      Table::ColumnInfo::info_type {"Index", typeid(int32_t)},
-      Table::ColumnInfo::info_type {"Value", typeid(FitsType)}
-    };
-    std::shared_ptr<Table::ColumnInfo> column_info {new Table::ColumnInfo {std::move(info_list)}};
 
-    std::vector<Table::Row> row_list {};
-    for (size_t i=0; i<axis.size(); ++i) {
+    std::vector<Table::ColumnInfo::info_type> info_list{Table::ColumnInfo::info_type{"Index", typeid(int32_t)},
+                                                        Table::ColumnInfo::info_type{"Value", typeid(FitsType)}};
+    std::shared_ptr<Table::ColumnInfo>        column_info{new Table::ColumnInfo{std::move(info_list)}};
+
+    std::vector<Table::Row> row_list{};
+    for (size_t i = 0; i < axis.size(); ++i) {
       auto fits_value = GridAxisValueFitsHelper<AxisType>::axisToFits(axis[i]);
       row_list.push_back(Table::Row{{(int)i, fits_value}, column_info});
     }
-    Table::Table table {row_list};
+    Table::Table table{row_list};
 
     Table::FitsWriter{filename.string(), false}
-            .setFormat(Table::FitsWriter::Format::BINARY)
-            .setHduName(axis.name()+"_"+array_hdu_name)
-            .addData(table);
+        .setFormat(Table::FitsWriter::Format::BINARY)
+        .setHduName(axis.name() + "_" + array_hdu_name)
+        .addData(table);
   }
-  
-  static void addGridAxesToFitsFile(const boost::filesystem::path&,
-                                    const std::string&,
-                                    const std::tuple<GridAxis<AxesTypes>...>&,
-                                    const TemplateLoopCounter<0>&) {
-  }
-  
+
+  static void addGridAxesToFitsFile(const boost::filesystem::path&, const std::string&, const std::tuple<GridAxis<AxesTypes>...>&,
+                                    const TemplateLoopCounter<0>&) {}
 };
 
-template<typename GridCellManager, typename... AxesTypes>
-void gridFitsExport(const boost::filesystem::path& filename,
-                    const std::string& hdu_name,
+template <typename GridCellManager, typename... AxesTypes>
+void gridFitsExport(const boost::filesystem::path& filename, const std::string& hdu_name,
                     const GridContainer<GridCellManager, AxesTypes...>& grid) {
   auto& axes = grid.getAxesTuple();
 
   // Create the first HDU with the array. We do that in a scope so the file is
   // created and the data are flushed into it before we continue.
   {
-    CCfits::FITS fits (filename.string(), CCfits::Write);
+    CCfits::FITS fits(filename.string(), CCfits::Write);
 
-    auto ext_ax_size_t = GridConstructionHelper<AxesTypes...>::createAxesSizesVector(
-                                      axes, TemplateLoopCounter<sizeof...(AxesTypes)>{});
-    std::vector<long> ext_ax {ext_ax_size_t.begin(), ext_ax_size_t.end()};
+    auto ext_ax_size_t =
+        GridConstructionHelper<AxesTypes...>::createAxesSizesVector(axes, TemplateLoopCounter<sizeof...(AxesTypes)>{});
+    std::vector<long> ext_ax{ext_ax_size_t.begin(), ext_ax_size_t.end()};
 
     using cell_type = typename GridCellManagerTraits<GridCellManager>::data_type;
-    auto bpix = FitsBpixTraits<cell_type>::BPIX;
+    auto bpix       = FitsBpixTraits<cell_type>::BPIX;
     fits.addImage(hdu_name, bpix, ext_ax);
-    std::valarray<cell_type> data (grid.size());
-    int i = 0;
+    std::valarray<cell_type> data(grid.size());
+    int                      i = 0;
     for (auto value : grid) {
       data[i] = value;
       ++i;
     }
     fits.currentExtension().write(1, grid.size(), data);
   }
-  
-  GridAxesToFitsHelper<AxesTypes...>::addGridAxesToFitsFile(filename, hdu_name,
-                              axes, TemplateLoopCounter<sizeof...(AxesTypes)>{});
+
+  GridAxesToFitsHelper<AxesTypes...>::addGridAxesToFitsFile(filename, hdu_name, axes, TemplateLoopCounter<sizeof...(AxesTypes)>{});
 }
 
 template <typename GridType>
 class GridAxisFitsReader {
-  
+
   template <int I>
   using AxisType = typename std::remove_reference<decltype(std::declval<GridType>().template getAxis<I>())>::type;
-  
-  template <int I, typename=void>
+
+  template <int I, typename = void>
   struct AxesTupleType {
-    using previous = typename AxesTupleType<I-1>::type;
-    using type = decltype(std::tuple_cat(std::declval<previous>(), std::declval<std::tuple<AxisType<I>>>()));
+    using previous = typename AxesTupleType<I - 1>::type;
+    using type     = decltype(std::tuple_cat(std::declval<previous>(), std::declval<std::tuple<AxisType<I>>>()));
   };
-  
+
   template <int I>
   struct AxesTupleType<I, typename std::enable_if<I == -1>::type> {
     using type = std::tuple<>;
   };
-  
+
   template <int I>
   using GridAxisType = typename std::remove_reference<decltype(std::declval<GridType>().template getAxis<I>())>::type;
-  
+
   template <int I>
   static GridAxisType<I> readAxis(const std::string& grid_name, CCfits::ExtHDU& hdu) {
     using KnotType = typename GridAxisType<I>::data_type;
     using FitsType = typename GridAxisValueFitsHelper<KnotType>::FitsType;
 
-    auto axis_name = hdu.name().substr(0, hdu.name().size() - grid_name.size() - 1);
-    std::vector<FitsType> data {};
+    auto                  axis_name = hdu.name().substr(0, hdu.name().size() - grid_name.size() - 1);
+    std::vector<FitsType> data{};
     try {
       auto& column = hdu.column("Value");
       column.read(data, 1, column.rows());
     } catch (CCfits::FitsException e) {
       throw Elements::Exception() << e.message();
     }
-    std::vector<KnotType> knots {};
+    std::vector<KnotType> knots{};
     for (std::size_t i = 0; i < data.size(); ++i) {
       knots.emplace_back(GridAxisValueFitsHelper<KnotType>::FitsToAxis(data[i]));
     }
     return {std::move(axis_name), std::move(knots)};
   }
-  
+
   template <int I>
-  static typename AxesTupleType<I>::type readAxesTuple(CCfits::FITS& fits, const std::string& grid_name, int hdu_index, const TemplateLoopCounter<I>&) {
-    auto axis = readAxis<I>(grid_name, fits.extension(hdu_index));
-    auto previous = readAxesTuple(fits, grid_name, hdu_index-1, TemplateLoopCounter<I-1>{});
+  static typename AxesTupleType<I>::type readAxesTuple(CCfits::FITS& fits, const std::string& grid_name, int hdu_index,
+                                                       const TemplateLoopCounter<I>&) {
+    auto axis     = readAxis<I>(grid_name, fits.extension(hdu_index));
+    auto previous = readAxesTuple(fits, grid_name, hdu_index - 1, TemplateLoopCounter<I - 1>{});
     return std::tuple_cat(std::move(previous), std::tuple<decltype(axis)>{std::move(axis)});
   }
-  
+
   static std::tuple<> readAxesTuple(CCfits::FITS&, const std::string&, int, const TemplateLoopCounter<-1>&) {
     return {};
   }
-  
+
 public:
-  
-  static typename AxesTupleType<GridType::axisNumber()-1>::type readAllAxes(CCfits::FITS& fits, int hdu_index) {
+  static typename AxesTupleType<GridType::axisNumber() - 1>::type readAllAxes(CCfits::FITS& fits, int hdu_index) {
     auto name = fits.extension(hdu_index).name();
-    return readAxesTuple(fits, name, hdu_index + GridType::axisNumber(), TemplateLoopCounter<GridType::axisNumber()-1>{});
+    return readAxesTuple(fits, name, hdu_index + GridType::axisNumber(), TemplateLoopCounter<GridType::axisNumber() - 1>{});
   }
-  
 };
 
-template<typename GridType>
+template <typename GridType>
 GridType gridFitsImport(const boost::filesystem::path& filename, int hdu_index) {
-  CCfits::FITS fits (filename.string(), CCfits::Read);
-  
+  CCfits::FITS fits(filename.string(), CCfits::Read);
+
   auto axes = GridAxisFitsReader<GridType>::readAllAxes(fits, hdu_index);
-  
-  GridType grid {std::move(axes)};
-  
-  std::valarray<typename GridType::cell_type> data {};
+
+  GridType grid{std::move(axes)};
+
+  std::valarray<typename GridType::cell_type> data{};
   fits.extension(hdu_index).read(data);
-  
+
   int i = 0;
   for (auto iter = grid.begin(); iter != grid.end(); ++iter, ++i) {
     *iter = data[i];
   }
-  
+
   return grid;
 }
 
-} // end of namespace GridContainer
-} // end of namespace Euclid
+}  // end of namespace GridContainer
+}  // end of namespace Euclid

--- a/GridContainer/GridContainer/_impl/GridAxis.icpp
+++ b/GridContainer/GridContainer/_impl/GridAxis.icpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file GridContainer/_impl/GridAxis.icpp
  * @date May 12, 2014
  * @author Nikolaos Apostolakos
@@ -27,38 +27,36 @@
 namespace Euclid {
 namespace GridContainer {
 
-template<typename T>
-GridAxis<T>::GridAxis(std::string name, std::vector<T> values)
-        : m_name(std::move(name)), m_values(std::move(values)) {
-}
+template <typename T>
+GridAxis<T>::GridAxis(std::string name, std::vector<T> values) : m_name(std::move(name)), m_values(std::move(values)) {}
 
-template<typename T>
+template <typename T>
 size_t GridAxis<T>::size() const {
   return m_values.size();
 }
 
-template<typename T>
+template <typename T>
 const std::string& GridAxis<T>::name() const {
   return m_name;
 }
 
-template<typename T>
+template <typename T>
 const T& GridAxis<T>::operator[](size_t index) const {
   return m_values[index];
 }
 
-template<typename T>
+template <typename T>
 auto GridAxis<T>::begin() const -> const_iterator {
   return m_values.cbegin();
 }
 
-template<typename T>
+template <typename T>
 auto GridAxis<T>::end() const -> const_iterator {
   return m_values.end();
 }
 
-template<typename T>
-template<typename U>
+template <typename T>
+template <typename U>
 bool GridAxis<T>::operator==(const GridAxis<U>& other) const {
   bool same = false;
   if (this->size() == other.size()) {
@@ -67,11 +65,11 @@ bool GridAxis<T>::operator==(const GridAxis<U>& other) const {
   return same;
 }
 
-template<typename T>
-template<typename U>
+template <typename T>
+template <typename U>
 bool GridAxis<T>::operator!=(const GridAxis<U>& other) const {
   return !this->operator==(other);
 }
 
-} // end of namespace GridContainer
-} // end of namespace Euclid
+}  // end of namespace GridContainer
+}  // end of namespace Euclid

--- a/GridContainer/GridContainer/_impl/GridCellManagerTraits.icpp
+++ b/GridContainer/GridContainer/_impl/GridCellManagerTraits.icpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file GridContainer/_impl/GridCellManagerTraits.icpp
  * @date May 13, 2014
  * @author Nikolaos Apostolakos
@@ -25,45 +25,45 @@
 namespace Euclid {
 namespace GridContainer {
 
-template<typename GridCellManager>
+template <typename GridCellManager>
 std::unique_ptr<GridCellManager> GridCellManagerTraits<GridCellManager>::factory(size_t size) {
-  return std::unique_ptr<GridCellManager> {new GridCellManager(size)};
+  return std::unique_ptr<GridCellManager>{new GridCellManager(size)};
 }
 
-template<typename GridCellManager>
+template <typename GridCellManager>
 size_t GridCellManagerTraits<GridCellManager>::size(const GridCellManager& cell_manager) {
   return cell_manager.size();
 }
 
-template<typename GridCellManager>
+template <typename GridCellManager>
 auto GridCellManagerTraits<GridCellManager>::begin(GridCellManager& cell_manager) -> iterator {
   return cell_manager.begin();
 }
 
-template<typename GridCellManager>
+template <typename GridCellManager>
 auto GridCellManagerTraits<GridCellManager>::end(GridCellManager& cell_manager) -> iterator {
   return cell_manager.end();
 }
 
-template<typename T>
+template <typename T>
 std::unique_ptr<std::vector<T>> GridCellManagerTraits<std::vector<T>>::factory(size_t size) {
-  return std::unique_ptr<std::vector<T>> {new std::vector<T>(size)};
+  return std::unique_ptr<std::vector<T>>{new std::vector<T>(size)};
 }
 
-template<typename T>
+template <typename T>
 size_t GridCellManagerTraits<std::vector<T>>::size(const std::vector<T>& vector) {
   return vector.size();
 }
 
-template<typename T>
+template <typename T>
 auto GridCellManagerTraits<std::vector<T>>::begin(std::vector<T>& vector) -> iterator {
   return vector.begin();
 }
 
-template<typename T>
+template <typename T>
 auto GridCellManagerTraits<std::vector<T>>::end(std::vector<T>& vector) -> iterator {
   return vector.end();
 }
 
-} // end of namespace GridContainer
-} // end of namespace Euclid
+}  // end of namespace GridContainer
+}  // end of namespace Euclid

--- a/GridContainer/GridContainer/_impl/GridConstructionHelper.h
+++ b/GridContainer/GridContainer/_impl/GridConstructionHelper.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file GridContainer/_impl/GridConstructionHelper.h
  * @date May 13, 2014
  * @author Nikolaos Apostolakos
@@ -25,12 +25,12 @@
 #ifndef GRIDCONTAINER_GRIDCONSTRUCTIONHELPER_H
 #define GRIDCONTAINER_GRIDCONSTRUCTIONHELPER_H
 
-#include <vector>
-#include <tuple>
-#include <map>
-#include <type_traits>
 #include "GridContainer/GridAxis.h"
 #include "TemplateLoopCounter.h"
+#include <map>
+#include <tuple>
+#include <type_traits>
+#include <vector>
 
 namespace Euclid {
 namespace GridContainer {
@@ -49,10 +49,9 @@ namespace GridContainer {
  *
  * @tparam Axes the types of the axes
  */
-template<typename... Axes>
+template <typename... Axes>
 class GridConstructionHelper {
 public:
-
   /**
    * @brief
    * Creates a vector which contains the sizes of the given axes
@@ -65,17 +64,15 @@ public:
    * @param axes A tuple containing the GridAxis objects describing the axes
    * @return A vector containing the sizes of the axes
    */
-  template<int I>
-  static std::vector<size_t> createAxesSizesVector(const std::tuple<GridAxis<Axes>...>& axes,
-                                                     const TemplateLoopCounter<I>&) {
-    std::vector<size_t> result {createAxesSizesVector(axes, TemplateLoopCounter<I-1>{})};
-    result.push_back(std::get<I-1>(axes).size());
+  template <int I>
+  static std::vector<size_t> createAxesSizesVector(const std::tuple<GridAxis<Axes>...>& axes, const TemplateLoopCounter<I>&) {
+    std::vector<size_t> result{createAxesSizesVector(axes, TemplateLoopCounter<I - 1>{})};
+    result.push_back(std::get<I - 1>(axes).size());
     return result;
   }
 
   /// Method which terminates the iteration when creating the axes sizes vector
-  static std::vector<size_t> createAxesSizesVector(const std::tuple<GridAxis<Axes>...>&,
-                                                     const TemplateLoopCounter<0>&) {
+  static std::vector<size_t> createAxesSizesVector(const std::tuple<GridAxis<Axes>...>&, const TemplateLoopCounter<0>&) {
     return std::vector<size_t>{};
   }
 
@@ -91,17 +88,15 @@ public:
    * @param axes A tuple containing the GridAxis objects describing the axes
    * @return A vector containing the names of the axes
    */
-  template<int I>
-  static std::vector<std::string> createAxesNamesVector(const std::tuple<GridAxis<Axes>...>& axes,
-                                                      const TemplateLoopCounter<I>&) {
-    std::vector<std::string> result {createAxesNamesVector(axes, TemplateLoopCounter<I-1>{})};
-    result.push_back(std::get<I-1>(axes).name());
+  template <int I>
+  static std::vector<std::string> createAxesNamesVector(const std::tuple<GridAxis<Axes>...>& axes, const TemplateLoopCounter<I>&) {
+    std::vector<std::string> result{createAxesNamesVector(axes, TemplateLoopCounter<I - 1>{})};
+    result.push_back(std::get<I - 1>(axes).name());
     return result;
   }
 
   /// Method which terminates the iteration when creating the axes names vector
-  static std::vector<std::string> createAxesNamesVector(const std::tuple<GridAxis<Axes>...>&,
-                                                     const TemplateLoopCounter<0>&) {
+  static std::vector<std::string> createAxesNamesVector(const std::tuple<GridAxis<Axes>...>&, const TemplateLoopCounter<0>&) {
     return std::vector<std::string>{};
   }
 
@@ -119,15 +114,13 @@ public:
    * @param axes The axes to use for the calculation
    * @return The index factor of the Ith axis
    */
-  template<int I>
-  static size_t getAxisIndexFactor(const std::tuple<GridAxis<Axes>...>& axes,
-                                    const TemplateLoopCounter<I>&) {
-    return std::get<I>(axes).size() * getAxisIndexFactor(axes, TemplateLoopCounter<I-1>{});
+  template <int I>
+  static size_t getAxisIndexFactor(const std::tuple<GridAxis<Axes>...>& axes, const TemplateLoopCounter<I>&) {
+    return std::get<I>(axes).size() * getAxisIndexFactor(axes, TemplateLoopCounter<I - 1>{});
   }
 
   /// Method which terminates the iteration when calculating the axis index factors
-  static size_t getAxisIndexFactor(const std::tuple<GridAxis<Axes>...>&,
-                                    const TemplateLoopCounter<-1>&) {
+  static size_t getAxisIndexFactor(const std::tuple<GridAxis<Axes>...>&, const TemplateLoopCounter<-1>&) {
     return 1;
   }
 
@@ -147,57 +140,49 @@ public:
    * @param axes A tuple containing the GridAxis objects describing the axes
    * @return A vector containing the index factors of the axes
    */
-  template<int I>
-  static std::vector<size_t> createAxisIndexFactorVector(
-            const std::tuple<GridAxis<Axes>...>& axes,const TemplateLoopCounter<I>&) {
-    std::vector<size_t> result {createAxisIndexFactorVector(axes, TemplateLoopCounter<I-1>{})};
-    result.push_back(getAxisIndexFactor(axes, TemplateLoopCounter<I-1>{}));
+  template <int I>
+  static std::vector<size_t> createAxisIndexFactorVector(const std::tuple<GridAxis<Axes>...>& axes, const TemplateLoopCounter<I>&) {
+    std::vector<size_t> result{createAxisIndexFactorVector(axes, TemplateLoopCounter<I - 1>{})};
+    result.push_back(getAxisIndexFactor(axes, TemplateLoopCounter<I - 1>{}));
     return result;
   }
 
   /// Method which terminates the iteration when creating the axes index factors
-  static std::vector<size_t> createAxisIndexFactorVector(
-            const std::tuple<GridAxis<Axes>...>&,const TemplateLoopCounter<0>&) {
-    return std::vector<size_t> {1};
+  static std::vector<size_t> createAxisIndexFactorVector(const std::tuple<GridAxis<Axes>...>&, const TemplateLoopCounter<0>&) {
+    return std::vector<size_t>{1};
   }
 
-  template<int I>
-  static void findAndFixAxis(std::tuple<GridAxis<Axes>...>& axes_tuple, size_t axis,
-                             size_t index, const TemplateLoopCounter<I>&) {
+  template <int I>
+  static void findAndFixAxis(std::tuple<GridAxis<Axes>...>& axes_tuple, size_t axis, size_t index, const TemplateLoopCounter<I>&) {
     if (axis == I) {
-      auto& old_axis = std::get<I>(axes_tuple);
-      typename std::remove_reference<decltype(old_axis)>::type new_axis {old_axis.name(), {old_axis[index]}};
+      auto&                                                    old_axis = std::get<I>(axes_tuple);
+      typename std::remove_reference<decltype(old_axis)>::type new_axis{old_axis.name(), {old_axis[index]}};
       std::get<I>(axes_tuple) = std::move(new_axis);
       return;
     }
-    findAndFixAxis(axes_tuple, axis, index, TemplateLoopCounter<I+1>{});
+    findAndFixAxis(axes_tuple, axis, index, TemplateLoopCounter<I + 1>{});
   }
 
-  static void findAndFixAxis(std::tuple<GridAxis<Axes>...>&, size_t,
-                             size_t, const TemplateLoopCounter<sizeof...(Axes)>&) {
+  static void findAndFixAxis(std::tuple<GridAxis<Axes>...>&, size_t, size_t, const TemplateLoopCounter<sizeof...(Axes)>&) {
     // does nothing
   }
 
-  template<typename IterType, int I>
-  static void fixIteratorAxes(IterType& iter, std::map<size_t, size_t> fix_indices,
-                              const TemplateLoopCounter<I>&) {
+  template <typename IterType, int I>
+  static void fixIteratorAxes(IterType& iter, std::map<size_t, size_t> fix_indices, const TemplateLoopCounter<I>&) {
     auto fix_pair = fix_indices.find(I);
     if (fix_pair != fix_indices.end()) {
       iter.template fixAxisByIndex<I>(fix_pair->second);
     }
-    fixIteratorAxes(iter, fix_indices, TemplateLoopCounter<I+1>{});
+    fixIteratorAxes(iter, fix_indices, TemplateLoopCounter<I + 1>{});
   }
 
-  template<typename IterType>
-  static void fixIteratorAxes(IterType&, std::map<size_t, size_t>,
-                              const TemplateLoopCounter<sizeof...(Axes)>&) {
+  template <typename IterType>
+  static void fixIteratorAxes(IterType&, std::map<size_t, size_t>, const TemplateLoopCounter<sizeof...(Axes)>&) {
     // does nothing
   }
-
 };
 
-} // end of namespace GridContainer
-} // end of namespace Euclid
+}  // end of namespace GridContainer
+}  // end of namespace Euclid
 
-#endif  /* GRIDCONTAINER_GRIDCONSTRUCTIONHELPER_H */
-
+#endif /* GRIDCONTAINER_GRIDCONSTRUCTIONHELPER_H */

--- a/GridContainer/GridContainer/_impl/GridContainer.icpp
+++ b/GridContainer/GridContainer/_impl/GridContainer.icpp
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file GridContainer/_impl/GridContainer.icpp
  * @date May 13, 2014
  * @author Nikolaos Apostolakos
@@ -28,27 +28,27 @@
 namespace Euclid {
 namespace GridContainer {
 
-template<typename GridCellManager, typename... AxesTypes>
-GridContainer<GridCellManager, AxesTypes...>::GridContainer(GridAxis<AxesTypes>... axes)
-      : m_axes{std::move(axes)...} { }
+template <typename GridCellManager, typename... AxesTypes>
+GridContainer<GridCellManager, AxesTypes...>::GridContainer(GridAxis<AxesTypes>... axes) : m_axes{std::move(axes)...} {}
 
-template<typename GridCellManager, typename... AxesTypes>
+template <typename GridCellManager, typename... AxesTypes>
 GridContainer<GridCellManager, AxesTypes...>::GridContainer(std::tuple<GridAxis<AxesTypes>...> axes_tuple)
-      : m_axes{std::move(axes_tuple)} { }
+    : m_axes{std::move(axes_tuple)} {}
 
-template<typename... AxesTypes>
+template <typename... AxesTypes>
 std::tuple<GridAxis<AxesTypes>...> fixAxis(const std::tuple<GridAxis<AxesTypes>...>& original, size_t axis, size_t index) {
-  std::tuple<GridAxis<AxesTypes>...> result {original};
-    GridConstructionHelper<AxesTypes...>::template findAndFixAxis(result, axis, index, TemplateLoopCounter<0>{});
+  std::tuple<GridAxis<AxesTypes>...> result{original};
+  GridConstructionHelper<AxesTypes...>::template findAndFixAxis(result, axis, index, TemplateLoopCounter<0>{});
   return result;
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-GridContainer<GridCellManager, AxesTypes...>::GridContainer(
-                      const GridContainer<GridCellManager, AxesTypes...>& other,
-                      size_t axis, size_t index)
-      : m_axes{other.m_axes}, m_axes_fixed{fixAxis(other.m_axes, axis, index)},
-        m_fixed_indices{other.m_fixed_indices}, m_cell_manager{other.m_cell_manager} {
+template <typename GridCellManager, typename... AxesTypes>
+GridContainer<GridCellManager, AxesTypes...>::GridContainer(const GridContainer<GridCellManager, AxesTypes...>& other, size_t axis,
+                                                            size_t index)
+    : m_axes{other.m_axes}
+    , m_axes_fixed{fixAxis(other.m_axes, axis, index)}
+    , m_fixed_indices{other.m_fixed_indices}
+    , m_cell_manager{other.m_cell_manager} {
   // Update the fixed indices
   if (m_fixed_indices.find(axis) != m_fixed_indices.end()) {
     throw Elements::Exception() << "Axis " << axis << " is already fixed";
@@ -56,71 +56,72 @@ GridContainer<GridCellManager, AxesTypes...>::GridContainer(
   m_fixed_indices[axis] = index;
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<int I>
+template <typename GridCellManager, typename... AxesTypes>
+template <int I>
 auto GridContainer<GridCellManager, AxesTypes...>::getOriginalAxis() const -> const GridAxis<axis_type<I>>& {
-    return std::get<I>(m_axes);
+  return std::get<I>(m_axes);
 }
 
-template<typename GridCellManager, typename... AxesTypes>
+template <typename GridCellManager, typename... AxesTypes>
 constexpr size_t GridContainer<GridCellManager, AxesTypes...>::axisNumber() {
   return std::tuple_size<decltype(m_axes_fixed)>::value;
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<int I>
+template <typename GridCellManager, typename... AxesTypes>
+template <int I>
 auto GridContainer<GridCellManager, AxesTypes...>::getAxis() const -> const GridAxis<axis_type<I>>& {
-    return std::get<I>(m_axes_fixed);
+  return std::get<I>(m_axes_fixed);
 }
 
-template<typename GridCellManager, typename... AxesTypes>
+template <typename GridCellManager, typename... AxesTypes>
 const std::tuple<GridAxis<AxesTypes>...>& GridContainer<GridCellManager, AxesTypes...>::getAxesTuple() const {
   return m_axes_fixed;
 }
 
-template<typename GridCellManager, typename... AxesTypes>
+template <typename GridCellManager, typename... AxesTypes>
 auto GridContainer<GridCellManager, AxesTypes...>::begin() -> iterator {
-  iterator result {*this, GridCellManagerTraits<GridCellManager>::begin(*m_cell_manager)};
+  iterator result{*this, GridCellManagerTraits<GridCellManager>::begin(*m_cell_manager)};
   GridConstructionHelper<AxesTypes...>::fixIteratorAxes(result, m_fixed_indices, TemplateLoopCounter<0>{});
   return result;
 }
 
-template<typename GridCellManager, typename... AxesTypes>
+template <typename GridCellManager, typename... AxesTypes>
 auto GridContainer<GridCellManager, AxesTypes...>::begin() const -> const_iterator {
-  const_iterator result {*this, GridCellManagerTraits<GridCellManager>::begin(*m_cell_manager)};
+  const_iterator result{*this, GridCellManagerTraits<GridCellManager>::begin(*m_cell_manager)};
   GridConstructionHelper<AxesTypes...>::fixIteratorAxes(result, m_fixed_indices, TemplateLoopCounter<0>{});
   return result;
 }
 
-template<typename GridCellManager, typename... AxesTypes>
+template <typename GridCellManager, typename... AxesTypes>
 auto GridContainer<GridCellManager, AxesTypes...>::cbegin() -> const_iterator {
-  const_iterator result {*this, GridCellManagerTraits<GridCellManager>::begin(*m_cell_manager)};
+  const_iterator result{*this, GridCellManagerTraits<GridCellManager>::begin(*m_cell_manager)};
   GridConstructionHelper<AxesTypes...>::fixIteratorAxes(result, m_fixed_indices, TemplateLoopCounter<0>{});
   return result;
 }
 
-template<typename GridCellManager, typename... AxesTypes>
+template <typename GridCellManager, typename... AxesTypes>
 auto GridContainer<GridCellManager, AxesTypes...>::end() -> iterator {
   return iterator{*this, GridCellManagerTraits<GridCellManager>::end(*m_cell_manager)};
 }
 
-template<typename GridCellManager, typename... AxesTypes>
+template <typename GridCellManager, typename... AxesTypes>
 auto GridContainer<GridCellManager, AxesTypes...>::end() const -> const_iterator {
   return const_iterator{*this, GridCellManagerTraits<GridCellManager>::end(*m_cell_manager)};
 }
 
-template<typename GridCellManager, typename... AxesTypes>
+template <typename GridCellManager, typename... AxesTypes>
 auto GridContainer<GridCellManager, AxesTypes...>::cend() -> const_iterator {
   return const_iterator{*this, GridCellManagerTraits<GridCellManager>::end(*m_cell_manager)};
 }
 
-template<typename GridCellManager, typename... AxesTypes>
+template <typename GridCellManager, typename... AxesTypes>
 size_t GridContainer<GridCellManager, AxesTypes...>::size() const {
   return m_index_helper_fixed.m_axes_index_factors.back();
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-auto GridContainer<GridCellManager, AxesTypes...>::operator()(decltype(std::declval<GridAxis<AxesTypes>>().size())... indices) const -> const cell_type& {
+template <typename GridCellManager, typename... AxesTypes>
+auto GridContainer<GridCellManager, AxesTypes...>::operator()(decltype(std::declval<GridAxis<AxesTypes>>().size())... indices) const
+    -> const cell_type& {
   size_t total_index = m_index_helper.totalIndex(indices...);
   // If we have fixed axes we need to move the index accordingly
   for (auto& pair : m_fixed_indices) {
@@ -129,13 +130,15 @@ auto GridContainer<GridCellManager, AxesTypes...>::operator()(decltype(std::decl
   return (*m_cell_manager)[total_index];
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-auto GridContainer<GridCellManager, AxesTypes...>::operator()(decltype(std::declval<GridAxis<AxesTypes>>().size())... indices) -> cell_type& {
+template <typename GridCellManager, typename... AxesTypes>
+auto GridContainer<GridCellManager, AxesTypes...>::operator()(decltype(std::declval<GridAxis<AxesTypes>>().size())... indices)
+    -> cell_type& {
   return const_cast<cell_type&>(static_cast<const GridContainer&>(*this)(indices...));
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-auto GridContainer<GridCellManager, AxesTypes...>::at(decltype(std::declval<GridAxis<AxesTypes>>().size())... indices) const -> const cell_type& {
+template <typename GridCellManager, typename... AxesTypes>
+auto GridContainer<GridCellManager, AxesTypes...>::at(decltype(std::declval<GridAxis<AxesTypes>>().size())... indices) const
+    -> const cell_type& {
   // First make a check that all the fixed axes are zero
   m_index_helper.checkAllFixedAreZero(m_fixed_indices, indices...);
   size_t total_index = m_index_helper.totalIndexChecked(indices...);
@@ -146,45 +149,47 @@ auto GridContainer<GridCellManager, AxesTypes...>::at(decltype(std::declval<Grid
   return (*m_cell_manager)[total_index];
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-auto GridContainer<GridCellManager, AxesTypes...>::at(decltype(std::declval<GridAxis<AxesTypes>>().size())... indices) -> cell_type& {
+template <typename GridCellManager, typename... AxesTypes>
+auto GridContainer<GridCellManager, AxesTypes...>::at(decltype(std::declval<GridAxis<AxesTypes>>().size())... indices)
+    -> cell_type& {
   return const_cast<cell_type&>(static_cast<const GridContainer&>(*this).at(indices...));
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<int I>
-GridContainer<GridCellManager, AxesTypes...>  GridContainer<GridCellManager, AxesTypes...>::fixAxisByIndex(size_t index) {
+template <typename GridCellManager, typename... AxesTypes>
+template <int I>
+GridContainer<GridCellManager, AxesTypes...> GridContainer<GridCellManager, AxesTypes...>::fixAxisByIndex(size_t index) {
   if (index >= getOriginalAxis<I>().size()) {
-    throw Elements::Exception() << "Index (" << index << ") out of axis "
-                              << getOriginalAxis<I>().name() << " size ("
-                              << getOriginalAxis<I>().size() << ")";
+    throw Elements::Exception() << "Index (" << index << ") out of axis " << getOriginalAxis<I>().name() << " size ("
+                                << getOriginalAxis<I>().size() << ")";
   }
   return GridContainer<GridCellManager, AxesTypes...>(*this, I, index);
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<int I>
-const GridContainer<GridCellManager, AxesTypes...> GridContainer<GridCellManager, AxesTypes...>::fixAxisByIndex(size_t index) const {
+template <typename GridCellManager, typename... AxesTypes>
+template <int I>
+const GridContainer<GridCellManager, AxesTypes...>
+GridContainer<GridCellManager, AxesTypes...>::fixAxisByIndex(size_t index) const {
   return const_cast<GridContainer<GridCellManager, AxesTypes...>*>(this)->fixAxisByIndex<I>(index);
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<int I>
-GridContainer<GridCellManager, AxesTypes...>  GridContainer<GridCellManager, AxesTypes...>::fixAxisByValue(const axis_type<I>& value) {
-  auto& axis = getOriginalAxis<I>();
-  auto found_axis = std::find(axis.begin(), axis.end(), value);
+template <typename GridCellManager, typename... AxesTypes>
+template <int I>
+GridContainer<GridCellManager, AxesTypes...>
+GridContainer<GridCellManager, AxesTypes...>::fixAxisByValue(const axis_type<I>& value) {
+  auto& axis       = getOriginalAxis<I>();
+  auto  found_axis = std::find(axis.begin(), axis.end(), value);
   if (found_axis == axis.end()) {
-    throw Elements::Exception() << "Failed to fix axis " << getOriginalAxis<I>().name()
-                              << " (given value not found)";
+    throw Elements::Exception() << "Failed to fix axis " << getOriginalAxis<I>().name() << " (given value not found)";
   }
-  return GridContainer<GridCellManager, AxesTypes...>(*this, I, found_axis-axis.begin());
+  return GridContainer<GridCellManager, AxesTypes...>(*this, I, found_axis - axis.begin());
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<int I>
-const GridContainer<GridCellManager, AxesTypes...> GridContainer<GridCellManager, AxesTypes...>::fixAxisByValue(const axis_type<I>& value) const {
+template <typename GridCellManager, typename... AxesTypes>
+template <int I>
+const GridContainer<GridCellManager, AxesTypes...>
+GridContainer<GridCellManager, AxesTypes...>::fixAxisByValue(const axis_type<I>& value) const {
   return const_cast<GridContainer<GridCellManager, AxesTypes...>*>(this)->fixAxisByValue<I>(value);
 }
 
-} // end of namespace GridContainer
-} // end of namespace Euclid
+}  // end of namespace GridContainer
+}  // end of namespace Euclid

--- a/GridContainer/GridContainer/_impl/GridContainerToTable.icpp
+++ b/GridContainer/GridContainer/_impl/GridContainerToTable.icpp
@@ -16,9 +16,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <boost/algorithm/string.hpp>
 #include <type_traits>
 #include <vector>
-#include <boost/algorithm/string.hpp>
 
 namespace Euclid {
 namespace GridContainer {
@@ -28,7 +28,7 @@ namespace GridContainer {
  * @tparam I
  *  Handle the axis stored on the (I-1)th position on the GridContainer::AxesTuple
  */
-template<size_t I, typename GridCellManager, typename ...Axes>
+template <size_t I, typename GridCellManager, typename... Axes>
 struct GridToFitsHelper {
 
   /**
@@ -40,10 +40,10 @@ struct GridToFitsHelper {
    *    A vector where to emplace the description
    */
   static void addColumnDescriptions(const GridContainer<GridCellManager, Axes...>& grid,
-                                    std::vector<Table::ColumnDescription>& description) {
-    auto& axis = grid.template getAxis<I - 1>();
+                                    std::vector<Table::ColumnDescription>&         description) {
+    auto& axis   = grid.template getAxis<I - 1>();
     using knot_t = typename std::remove_reference<decltype(axis)>::type::data_type;
-    auto name = axis.name();
+    auto name    = axis.name();
     boost::replace_all(name, " ", "_");
     description.emplace_back(name, typeid(typename GridAxisToTable<knot_t>::table_cell_t));
 
@@ -63,23 +63,20 @@ struct GridToFitsHelper {
    * @param axes
    *    Used to keep track of the values of the knots of the previous axis
    */
-  template<typename ...Args>
-  static void
-  unfold(const GridContainer<GridCellManager, Axes...>& grid, const std::shared_ptr<Table::ColumnInfo>& column_info,
-         std::vector<Table::Row>& rows, std::pair<size_t, Args>... axes) {
+  template <typename... Args>
+  static void unfold(const GridContainer<GridCellManager, Axes...>& grid, const std::shared_ptr<Table::ColumnInfo>& column_info,
+                     std::vector<Table::Row>& rows, std::pair<size_t, Args>... axes) {
     auto& axis = grid.template getAxis<I - 1>();
     for (size_t i = 0; i < axis.size(); ++i) {
-      GridToFitsHelper<I - 1, GridCellManager, Axes...>::unfold(grid, column_info, rows, std::make_pair(i, axis[i]),
-                                                              axes...);
+      GridToFitsHelper<I - 1, GridCellManager, Axes...>::unfold(grid, column_info, rows, std::make_pair(i, axis[i]), axes...);
     }
   }
 
   /**
    * Same as before, but without the book-keeping data, since this is the entry point
    */
-  static void
-  unfold(const GridContainer<GridCellManager, Axes...>& grid, const std::shared_ptr<Table::ColumnInfo>& column_info,
-         std::vector<Table::Row>& rows) {
+  static void unfold(const GridContainer<GridCellManager, Axes...>& grid, const std::shared_ptr<Table::ColumnInfo>& column_info,
+                     std::vector<Table::Row>& rows) {
     auto& axis = grid.template getAxis<I - 1>();
     for (size_t i = 0; i < axis.size(); ++i) {
       GridToFitsHelper<I - 1, GridCellManager, Axes...>::unfold(grid, column_info, rows, std::make_pair(i, axis[i]));
@@ -90,21 +87,19 @@ struct GridToFitsHelper {
 /**
  * Base class for the recursive traversal of the grid
  */
-template<typename GridCellManager, typename ...Axes>
+template <typename GridCellManager, typename... Axes>
 struct GridToFitsHelper<0, GridCellManager, Axes...> {
   /**
    * There are no more axis, so do nothing for the columns
    */
-  static void addColumnDescriptions(const GridContainer<GridCellManager, Axes...>&,
-                                    std::vector<Table::ColumnDescription>&) {}
+  static void addColumnDescriptions(const GridContainer<GridCellManager, Axes...>&, std::vector<Table::ColumnDescription>&) {}
 
   /**
    * Insert into the row vector the cell value plus the axes values that brought us here
    */
-  template<typename ...Args>
-  static void
-  unfold(const GridContainer<GridCellManager, Axes...>& grid, const std::shared_ptr<Table::ColumnInfo>& column_info,
-         std::vector<Table::Row>& rows, std::pair<size_t, Args> ...axes) {
+  template <typename... Args>
+  static void unfold(const GridContainer<GridCellManager, Axes...>& grid, const std::shared_ptr<Table::ColumnInfo>& column_info,
+                     std::vector<Table::Row>& rows, std::pair<size_t, Args>... axes) {
     using GridType = GridContainer<GridCellManager, Axes...>;
 
     std::vector<Table::Row::cell_type> row_content{GridAxisToTable<Args>::serialize(axes.second)...};
@@ -121,10 +116,10 @@ struct GridToFitsHelper<0, GridCellManager, Axes...> {
  * Transform a GridContainer into a Table, with an entry for each
  * cell. The content will be unfolded, so the knot values will be repeated.
  */
-template<typename GridCellManager, typename ...AxesTypes>
+template <typename GridCellManager, typename... AxesTypes>
 Table::Table gridContainerToTable(const GridContainer<GridCellManager, AxesTypes...>& grid) {
   using GridType = GridContainer<GridCellManager, AxesTypes...>;
-  using Helper = GridToFitsHelper<std::tuple_size<typename GridType::AxesTuple>::value, GridCellManager, AxesTypes...>;
+  using Helper   = GridToFitsHelper<std::tuple_size<typename GridType::AxesTuple>::value, GridCellManager, AxesTypes...>;
 
   std::vector<Table::ColumnDescription> columns;
   Helper::addColumnDescriptions(GridContainer<GridCellManager, AxesTypes...>{grid.getAxesTuple()}, columns);
@@ -142,5 +137,5 @@ Table::Table gridContainerToTable(const GridContainer<GridCellManager, AxesTypes
   return Table::Table{std::move(rows)};
 }
 
-} // end of namespace GridContainer
-} // end of namespace Euclid
+}  // end of namespace GridContainer
+}  // end of namespace Euclid

--- a/GridContainer/GridContainer/_impl/GridIndexHelper.icpp
+++ b/GridContainer/GridContainer/_impl/GridIndexHelper.icpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file GridContainer/_impl/GridIndexHelper.icpp
  * @date July 4, 2014
  * @author Nikolaos Apostolakos
@@ -27,23 +27,19 @@
 namespace Euclid {
 namespace GridContainer {
 
-template<typename... AxesTypes>
+template <typename... AxesTypes>
 GridIndexHelper<AxesTypes...>::GridIndexHelper(const std::tuple<GridAxis<AxesTypes>...>& axes_tuple)
-          : m_axes_sizes { 
-                GridConstructionHelper<AxesTypes...>::createAxesSizesVector(
-                        axes_tuple, TemplateLoopCounter<sizeof...(AxesTypes)>{})
-          }, m_axes_index_factors {
-                GridConstructionHelper<AxesTypes...>::createAxisIndexFactorVector(
-                     axes_tuple, TemplateLoopCounter<sizeof...(AxesTypes)>{})
-          }, m_axes_names { 
-                GridConstructionHelper<AxesTypes...>::createAxesNamesVector(
-                        axes_tuple, TemplateLoopCounter<sizeof...(AxesTypes)>{})
-          } { }
+    : m_axes_sizes{GridConstructionHelper<AxesTypes...>::createAxesSizesVector(axes_tuple,
+                                                                               TemplateLoopCounter<sizeof...(AxesTypes)>{})}
+    , m_axes_index_factors{GridConstructionHelper<AxesTypes...>::createAxisIndexFactorVector(
+          axes_tuple, TemplateLoopCounter<sizeof...(AxesTypes)>{})}
+    , m_axes_names{
+          GridConstructionHelper<AxesTypes...>::createAxesNamesVector(axes_tuple, TemplateLoopCounter<sizeof...(AxesTypes)>{})} {}
 
-template<typename... AxesTypes>
+template <typename... AxesTypes>
 size_t GridIndexHelper<AxesTypes...>::axisIndex(size_t axis, size_t array_index) const {
   size_t index = array_index % m_axes_index_factors[axis + 1];
-  index = index / m_axes_index_factors[axis];
+  index        = index / m_axes_index_factors[axis];
   return index;
 }
 
@@ -54,67 +50,63 @@ size_t calculateTotalIndex(const std::vector<size_t>& factors, Coord coord) {
 
 template <typename Coord, typename... RestCoords>
 size_t calculateTotalIndex(const std::vector<size_t>& factors, Coord coord, RestCoords... rest_coords) {
-  return coord * factors[factors.size()-sizeof...(RestCoords)-2] + calculateTotalIndex(factors, rest_coords...);
+  return coord * factors[factors.size() - sizeof...(RestCoords) - 2] + calculateTotalIndex(factors, rest_coords...);
 }
 
-template<typename... AxesTypes>
+template <typename... AxesTypes>
 size_t GridIndexHelper<AxesTypes...>::totalIndex(decltype(std::declval<GridAxis<AxesTypes>>().size())... coords) const {
   return calculateTotalIndex(m_axes_index_factors, coords...);
 }
 
 template <typename Coord>
-void checkBounds(const std::vector<std::string>& axes_names,
-                 const std::vector<size_t>& axes_sizes, Coord coord) {
-  if (coord >= axes_sizes[axes_sizes.size()-1]) {
-    throw Elements::Exception() << "Coordinate " << coord << " for axis "
-                              << axes_names[axes_sizes.size()-1] << " (size " 
-                              << axes_sizes[axes_sizes.size()-1]
-                              << ") is out of bound";
+void checkBounds(const std::vector<std::string>& axes_names, const std::vector<size_t>& axes_sizes, Coord coord) {
+  if (coord >= axes_sizes[axes_sizes.size() - 1]) {
+    throw Elements::Exception() << "Coordinate " << coord << " for axis " << axes_names[axes_sizes.size() - 1] << " (size "
+                                << axes_sizes[axes_sizes.size() - 1] << ") is out of bound";
   }
 }
 
 template <typename Coord, typename... RestCoords>
-void checkBounds(const std::vector<std::string>& axes_names,
-                 const std::vector<size_t>& axes_sizes, Coord coord, RestCoords... rest_coords) {
-  if (coord >= axes_sizes[axes_sizes.size()-sizeof...(RestCoords)-1]) {
+void checkBounds(const std::vector<std::string>& axes_names, const std::vector<size_t>& axes_sizes, Coord coord,
+                 RestCoords... rest_coords) {
+  if (coord >= axes_sizes[axes_sizes.size() - sizeof...(RestCoords) - 1]) {
     throw Elements::Exception() << "Coordinate " << coord << " for axis "
-                              << axes_names[axes_sizes.size()-sizeof...(RestCoords)-1] << " (size " 
-                              << axes_sizes[axes_sizes.size()-sizeof...(RestCoords)-1]
-                              << ") is out of bound";
+                                << axes_names[axes_sizes.size() - sizeof...(RestCoords) - 1] << " (size "
+                                << axes_sizes[axes_sizes.size() - sizeof...(RestCoords) - 1] << ") is out of bound";
   }
   checkBounds(axes_names, axes_sizes, rest_coords...);
 }
 
-template<typename... AxesTypes>
+template <typename... AxesTypes>
 size_t GridIndexHelper<AxesTypes...>::totalIndexChecked(decltype(std::declval<GridAxis<AxesTypes>>().size())... coords) const {
   checkBounds(m_axes_names, m_axes_sizes, coords...);
   return calculateTotalIndex(m_axes_index_factors, coords...);
 }
 
-template<typename... AxesTypes>
+template <typename... AxesTypes>
 template <typename Coord>
 void GridIndexHelper<AxesTypes...>::checkAllFixedAreZero(const std::map<size_t, size_t>& fixed_indices, Coord coord) const {
   if (coord != 0) {
-    if (fixed_indices.find(m_axes_sizes.size()-1) != fixed_indices.end()) {
-      throw Elements::Exception() << "Coordinate " << coord << " for axis "
-                              << m_axes_names[m_axes_sizes.size()-1] << " (size 1) is out of bound";
+    if (fixed_indices.find(m_axes_sizes.size() - 1) != fixed_indices.end()) {
+      throw Elements::Exception() << "Coordinate " << coord << " for axis " << m_axes_names[m_axes_sizes.size() - 1]
+                                  << " (size 1) is out of bound";
     }
   }
 }
 
-template<typename... AxesTypes>
+template <typename... AxesTypes>
 template <typename Coord, typename... RestCoords>
-void GridIndexHelper<AxesTypes...>::checkAllFixedAreZero(const std::map<size_t, size_t>& fixed_indices,
-                          Coord coord, RestCoords... rest_coords) const {
+void GridIndexHelper<AxesTypes...>::checkAllFixedAreZero(const std::map<size_t, size_t>& fixed_indices, Coord coord,
+                                                         RestCoords... rest_coords) const {
   if (coord != 0) {
     size_t axis_index = m_axes_sizes.size() - sizeof...(RestCoords) - 1;
     if (fixed_indices.find(axis_index) != fixed_indices.end()) {
-      throw Elements::Exception() << "Coordinate " << coord << " for axis "
-                              << m_axes_names[axis_index] << " (size 1) is out of bound";
+      throw Elements::Exception() << "Coordinate " << coord << " for axis " << m_axes_names[axis_index]
+                                  << " (size 1) is out of bound";
     }
   }
   checkAllFixedAreZero(fixed_indices, rest_coords...);
 }
 
-}
-} // end of namespace Euclid
+}  // namespace GridContainer
+}  // end of namespace Euclid

--- a/GridContainer/GridContainer/_impl/GridIterator.icpp
+++ b/GridContainer/GridContainer/_impl/GridIterator.icpp
@@ -1,56 +1,55 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file GridContainer/_impl/GridIterator.icpp
  * @date May 14, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <algorithm>
 #include "ElementsKernel/Exception.h"
 #include "TemplateLoopCounter.h"
+#include <algorithm>
 
 namespace Euclid {
 namespace GridContainer {
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
-GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::iter(
-                                const GridContainer<GridCellManager, AxesTypes...>& owner,
-                                const cell_manager_iter_type& data_iter)
-        : m_owner(owner), m_data_iter {data_iter} { }
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
+GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::iter(const GridContainer<GridCellManager, AxesTypes...>& owner,
+                                                                   const cell_manager_iter_type&                       data_iter)
+    : m_owner(owner), m_data_iter{data_iter} {}
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
 auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator=(const iter& other) -> iter& {
-  m_data_iter = other.m_data_iter;
+  m_data_iter     = other.m_data_iter;
   m_fixed_indices = other.m_fixed_indices;
   return *this;
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
 auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator++() -> iter& {
   ++m_data_iter;
   if (!m_fixed_indices.empty()) {
     for (auto& fixed_index_pair : m_fixed_indices) {
-      size_t axis = fixed_index_pair.first;
+      size_t axis        = fixed_index_pair.first;
       size_t fixed_index = fixed_index_pair.second;
       forwardToIndex(axis, fixed_index);
     }
@@ -64,122 +63,117 @@ auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator++() 
   return *this;
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
 auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator*() -> CellType& {
   return *m_data_iter;
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
 auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator*() const -> typename std::add_const<CellType>::type& {
   return *m_data_iter;
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
 auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator->() -> CellType* {
   return &(*m_data_iter);
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
 auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator->() const -> typename std::add_const<CellType>::type* {
   return &(*m_data_iter);
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
 bool GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator==(const iter& other) const {
   return m_data_iter == other.m_data_iter;
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
 bool GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator!=(const iter& other) const {
   return m_data_iter != other.m_data_iter;
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
-template<int I>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
+template <int I>
 size_t GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::axisIndex() const {
   size_t index = m_data_iter - GridCellManagerTraits<GridCellManager>::begin(*(m_owner.m_cell_manager));
   return m_owner.m_index_helper.axisIndex(I, index);
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
-template<int I>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
+template <int I>
 auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::axisValue() const -> const axis_type<I>& {
   size_t index = axisIndex<I>();
   return std::get<I>(m_owner.m_axes)[index];
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
-template<int I>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
+template <int I>
 auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::fixAxisByIndex(size_t index) -> iter& {
   auto fixed_index = m_fixed_indices.find(I);
   if (fixed_index != m_fixed_indices.end() && fixed_index->second != index) {
-    throw Elements::Exception() << "Axis " <<m_owner.getOriginalAxis<I>().name()
-                                << " is already fixed";
+    throw Elements::Exception() << "Axis " << m_owner.getOriginalAxis<I>().name() << " is already fixed";
   }
   if (index >= m_owner.getOriginalAxis<I>().size()) {
-    throw Elements::Exception() << "Index (" << index << ") out of axis " 
-                              << m_owner.getOriginalAxis<I>().name() << " size ("
-                              << m_owner.getOriginalAxis<I>().size() << ")";
+    throw Elements::Exception() << "Index (" << index << ") out of axis " << m_owner.getOriginalAxis<I>().name() << " size ("
+                                << m_owner.getOriginalAxis<I>().size() << ")";
   }
   m_fixed_indices[I] = index;
   forwardToIndex(I, index);
   return *this;
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
-template<int I>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
+template <int I>
 auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::fixAxisByValue(const axis_type<I>& value) -> iter& {
-  auto& axis = m_owner.getOriginalAxis<I>();
-  auto found_axis = std::find(axis.begin(), axis.end(), value);
+  auto& axis       = m_owner.getOriginalAxis<I>();
+  auto  found_axis = std::find(axis.begin(), axis.end(), value);
   if (found_axis == axis.end()) {
-    throw Elements::Exception() << "Failed to fix axis " << m_owner.getOriginalAxis<I>().name()
-                              << " (given value not found)";
+    throw Elements::Exception() << "Failed to fix axis " << m_owner.getOriginalAxis<I>().name() << " (given value not found)";
   }
   size_t index = found_axis - axis.begin();
   return fixAxisByIndex<I>(index);
 }
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
 void GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::forwardToIndex(size_t axis, size_t fixed_index) {
-  size_t current_size = m_data_iter - GridCellManagerTraits<GridCellManager>::begin(*(m_owner.m_cell_manager));
+  size_t current_size  = m_data_iter - GridCellManagerTraits<GridCellManager>::begin(*(m_owner.m_cell_manager));
   size_t current_index = m_owner.m_index_helper.axisIndex(axis, current_size);
   if (fixed_index != current_index) {
     size_t axis_factor = m_owner.m_index_helper.m_axes_index_factors[axis];
-    size_t distance = (fixed_index > current_index)
-          ? fixed_index - current_index
-          : m_owner.m_index_helper.m_axes_sizes[axis] + fixed_index - current_index;
+    size_t distance    = (fixed_index > current_index) ? fixed_index - current_index
+                                                    : m_owner.m_index_helper.m_axes_sizes[axis] + fixed_index - current_index;
     m_data_iter += distance * axis_factor;
   }
 }
 
-template<typename IterFrom, typename IterTo, int I>
+template <typename IterFrom, typename IterTo, int I>
 static void fixSameAxes(IterFrom& from, IterTo& to, const TemplateLoopCounter<I>&) {
   to.template fixAxisByValue<I>(from.template axisValue<I>());
-  fixSameAxes(from, to, TemplateLoopCounter<I-1>{});
+  fixSameAxes(from, to, TemplateLoopCounter<I - 1>{});
 }
 
-template<typename IterFrom, typename IterTo>
-static void fixSameAxes(IterFrom&, IterTo&, const TemplateLoopCounter<-1>&) {
-}
+template <typename IterFrom, typename IterTo>
+static void fixSameAxes(IterFrom&, IterTo&, const TemplateLoopCounter<-1>&) {}
 
-template<typename GridCellManager, typename... AxesTypes>
-template<typename CellType>
-template<typename OtherIter>
+template <typename GridCellManager, typename... AxesTypes>
+template <typename CellType>
+template <typename OtherIter>
 auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::fixAllAxes(const OtherIter& other) -> iter& {
-  fixSameAxes(other, *this, TemplateLoopCounter<sizeof...(AxesTypes)-1>{});
+  fixSameAxes(other, *this, TemplateLoopCounter<sizeof...(AxesTypes) - 1>{});
   return *this;
 }
 
-} // end of GridContainer namespace
-} // end of namespace Euclid
+}  // namespace GridContainer
+}  // end of namespace Euclid

--- a/GridContainer/GridContainer/_impl/TemplateLoopCounter.h
+++ b/GridContainer/GridContainer/_impl/TemplateLoopCounter.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file GridContainer/_impl/TemplateLoopCounter.h
  * @date May 13, 2014
  * @author Nikolaos Apostolakos
@@ -30,11 +30,10 @@ namespace GridContainer {
 
 /// This is a dummy class with a integer template parameter, which is used
 /// as a counter for the template recursions.
-template<int>
-struct TemplateLoopCounter { };
+template <int>
+struct TemplateLoopCounter {};
 
-}
-} // end of namespace Euclid
+}  // namespace GridContainer
+}  // end of namespace Euclid
 
-#endif  /* GRIDCONTAINER_TEMPLATELOOPCOUNTER_H */
-
+#endif /* GRIDCONTAINER_TEMPLATELOOPCOUNTER_H */

--- a/GridContainer/GridContainer/serialization/GridAxis.h
+++ b/GridContainer/GridContainer/serialization/GridAxis.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file GridContainer/serialization/GridAxis.h
  * @date May 16, 2014
  * @author Nikolaos Apostolakos
@@ -25,17 +25,17 @@
 #ifndef GRIDCONTAINER_SERIALIZATION_GRIDAXIS_H
 #define GRIDCONTAINER_SERIALIZATION_GRIDAXIS_H
 
-#include <type_traits>
-#include <memory>
-#include <boost/serialization/utility.hpp>
 #include "GridContainer/GridAxis.h"
+#include <boost/serialization/utility.hpp>
+#include <memory>
+#include <type_traits>
 
 namespace boost {
 namespace serialization {
 
 /// Method which saves/loads an GridAxis instance to/from an archive. It
 /// does nothing as everything is done with the data passed to the constructor.
-template<typename Archive, typename T>
+template <typename Archive, typename T>
 void serialize(Archive&, Euclid::GridContainer::GridAxis<T>&, const unsigned int) {
   // Nothing here as everything is done with the data passed to the constructor
 }
@@ -43,7 +43,7 @@ void serialize(Archive&, Euclid::GridContainer::GridAxis<T>&, const unsigned int
 /// Version of the saveType method for types which do have default constructors.
 /// It saves the object t to the archive. The boost::serialization::serialize
 /// method must be implemented for the type T.
-template<typename Archive, typename T>
+template <typename Archive, typename T>
 void saveType(Archive& ar, const T& t, typename std::enable_if<std::is_default_constructible<T>::value>::type* = 0) {
   ar << t;
 }
@@ -53,7 +53,7 @@ void saveType(Archive& ar, const T& t, typename std::enable_if<std::is_default_c
 /// boost serialization for non-default constructor types is enabled. The
 /// method boost::serialization::save_construct_data must be implemented for
 /// the type T.
-template<typename Archive, typename T>
+template <typename Archive, typename T>
 void saveType(Archive& ar, const T& t, typename std::enable_if<!std::is_default_constructible<T>::value>::type* = 0) {
   const T* ptr = &t;
   ar << ptr;
@@ -65,14 +65,13 @@ void saveType(Archive& ar, const T& t, typename std::enable_if<!std::is_default_
 /// value of each knot. The knot values must be boost serializable.
 /// NOTE: Any changes in this method should be reflected in the
 /// load_construct_data method.
-template<typename Archive, typename T>
-void save_construct_data(Archive& ar, const Euclid::GridContainer::GridAxis<T>* t,
-                                const unsigned int) {
+template <typename Archive, typename T>
+void save_construct_data(Archive& ar, const Euclid::GridContainer::GridAxis<T>* t, const unsigned int) {
   std::string name = t->name();
   ar << name;
   size_t size = t->size();
   ar << size;
-  for (size_t i=0; i<size; ++i) {
+  for (size_t i = 0; i < size; ++i) {
     saveType(ar, (*t)[i]);
   }
 }
@@ -80,7 +79,7 @@ void save_construct_data(Archive& ar, const Euclid::GridContainer::GridAxis<T>* 
 /// Version of the loadType method for types which do have default constructors.
 /// It loads the object t from the archive. The boost::serialization::serialize
 /// method must be implemented for the type T.
-template<typename Archive, typename T>
+template <typename Archive, typename T>
 T loadType(Archive& ar, typename std::enable_if<std::is_default_constructible<T>::value>::type* = 0) {
   T value;
   ar >> value;
@@ -92,13 +91,13 @@ T loadType(Archive& ar, typename std::enable_if<std::is_default_constructible<T>
 /// it uses it to create the returned value. The method
 /// boost::serialization::load_construct_data must be implemented for the type
 /// T, which must also have a copy constructor.
-template<typename Archive, typename T>
+template <typename Archive, typename T>
 T loadType(Archive& ar, typename std::enable_if<!std::is_default_constructible<T>::value>::type* = 0) {
   T* ptr;
   ar >> ptr;
   // We use a unique_ptr to guarantee deletion of the pointer
-  std::unique_ptr<T> deleter {ptr};
-  T value {*deleter};
+  std::unique_ptr<T> deleter{ptr};
+  T                  value{*deleter};
   return value;
 }
 
@@ -108,23 +107,21 @@ T loadType(Archive& ar, typename std::enable_if<!std::is_default_constructible<T
 /// followed by the value of each knot.
 /// NOTE: Any changes in this method should be reflected in the
 /// save_construct_data method.
-template<typename Archive, typename T>
-void load_construct_data(Archive& ar, Euclid::GridContainer::GridAxis<T>* t,
-                                const unsigned int) {
+template <typename Archive, typename T>
+void load_construct_data(Archive& ar, Euclid::GridContainer::GridAxis<T>* t, const unsigned int) {
   std::string name;
   ar >> name;
   size_t size;
   ar >> size;
   std::vector<T> values;
-  for (size_t i=0; i<size; ++i) {
+  for (size_t i = 0; i < size; ++i) {
     T value = loadType<Archive, T>(ar);
     values.push_back(value);
   }
-  ::new(t) Euclid::GridContainer::GridAxis<T>(name, values);
+  ::new (t) Euclid::GridContainer::GridAxis<T>(name, values);
 }
 
 } /* end of namespace serialization */
 } /* end of namespace boost */
 
-#endif  /* GRIDCONTAINER_SERIALIZATION_GRIDAXIS_H */
-
+#endif /* GRIDCONTAINER_SERIALIZATION_GRIDAXIS_H */

--- a/GridContainer/GridContainer/serialization/GridContainer.h
+++ b/GridContainer/GridContainer/serialization/GridContainer.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  *
  * @file GridContainer/serialization/GridContainer.h
  * @date May 17, 2014
@@ -26,25 +26,24 @@
 #ifndef GRIDCONTAINER_SERIALIZATION_GRIDCONTAINER_H
 #define GRIDCONTAINER_SERIALIZATION_GRIDCONTAINER_H
 
-#include <type_traits>
-#include <memory>
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/split_free.hpp>
 #include "GridContainer/GridAxis.h"
 #include "GridContainer/GridContainer.h"
-#include "GridContainer/serialization/tuple.h"
 #include "GridContainer/serialization/GridAxis.h"
+#include "GridContainer/serialization/tuple.h"
+#include <boost/serialization/split_free.hpp>
+#include <boost/serialization/vector.hpp>
+#include <memory>
+#include <type_traits>
 
 namespace boost {
 namespace serialization {
 
 /// Method which saves a GridContainer instance to an archive. This version handles
 /// default constructible cell values.
-template<class Archive, typename GridCellManager, typename... AxesTypes>
-void save(Archive& ar, const Euclid::GridContainer::GridContainer<GridCellManager,AxesTypes...>& grid, const unsigned int,
+template <class Archive, typename GridCellManager, typename... AxesTypes>
+void save(Archive& ar, const Euclid::GridContainer::GridContainer<GridCellManager, AxesTypes...>& grid, const unsigned int,
           typename std::enable_if<std::is_default_constructible<
-            typename Euclid::GridContainer::GridCellManagerTraits<GridCellManager>::data_type
-          >::value>::type * = 0) {
+              typename Euclid::GridContainer::GridCellManagerTraits<GridCellManager>::data_type>::value>::type* = 0) {
   for (auto& cell : grid) {
     ar << cell;
   }
@@ -52,11 +51,10 @@ void save(Archive& ar, const Euclid::GridContainer::GridContainer<GridCellManage
 
 /// Method which saves a GridContainer instance to an archive. This version handles
 /// non-default constructible cell values.
-template<class Archive, typename GridCellManager, typename... AxesTypes>
-void save(Archive& ar, const Euclid::GridContainer::GridContainer<GridCellManager,AxesTypes...>& grid, const unsigned int,
+template <class Archive, typename GridCellManager, typename... AxesTypes>
+void save(Archive& ar, const Euclid::GridContainer::GridContainer<GridCellManager, AxesTypes...>& grid, const unsigned int,
           typename std::enable_if<!std::is_default_constructible<
-            typename Euclid::GridContainer::GridCellManagerTraits<GridCellManager>::data_type
-          >::value>::type * = 0) {
+              typename Euclid::GridContainer::GridCellManagerTraits<GridCellManager>::data_type>::value>::type* = 0) {
   for (auto& cell : grid) {
     // Do NOT delete this pointer! It points to the cell of the grid and the
     // grid will take care of the memory management
@@ -67,11 +65,10 @@ void save(Archive& ar, const Euclid::GridContainer::GridContainer<GridCellManage
 
 /// Method which loads a GridContainer instance from an archive. This version handles
 /// default constructible cell values.
-template<class Archive, typename GridCellManager, typename... AxesTypes>
-void load(Archive& ar, Euclid::GridContainer::GridContainer<GridCellManager,AxesTypes...>& grid, const unsigned int,
+template <class Archive, typename GridCellManager, typename... AxesTypes>
+void load(Archive& ar, Euclid::GridContainer::GridContainer<GridCellManager, AxesTypes...>& grid, const unsigned int,
           typename std::enable_if<std::is_default_constructible<
-            typename Euclid::GridContainer::GridCellManagerTraits<GridCellManager>::data_type
-          >::value>::type * = 0) {
+              typename Euclid::GridContainer::GridCellManagerTraits<GridCellManager>::data_type>::value>::type* = 0) {
   for (auto& cell : grid) {
     ar >> cell;
   }
@@ -79,16 +76,15 @@ void load(Archive& ar, Euclid::GridContainer::GridContainer<GridCellManager,Axes
 
 /// Method which loads a GridContainer instance from an archive. This version handles
 /// non-default constructible cell values.
-template<class Archive, typename GridCellManager, typename... AxesTypes>
-void load(Archive& ar, Euclid::GridContainer::GridContainer<GridCellManager,AxesTypes...>& grid, const unsigned int,
+template <class Archive, typename GridCellManager, typename... AxesTypes>
+void load(Archive& ar, Euclid::GridContainer::GridContainer<GridCellManager, AxesTypes...>& grid, const unsigned int,
           typename std::enable_if<!std::is_default_constructible<
-            typename Euclid::GridContainer::GridCellManagerTraits<GridCellManager>::data_type
-          >::value>::type * = 0) {
+              typename Euclid::GridContainer::GridCellManagerTraits<GridCellManager>::data_type>::value>::type* = 0) {
   for (auto& cell : grid) {
     typename Euclid::GridContainer::GridCellManagerTraits<GridCellManager>::data_type* ptr;
     ar >> ptr;
     // We use a unique_ptr to guarantee deletion of the pointer
-    std::unique_ptr<typename Euclid::GridContainer::GridCellManagerTraits<GridCellManager>::data_type> deleter {ptr};
+    std::unique_ptr<typename Euclid::GridContainer::GridCellManagerTraits<GridCellManager>::data_type> deleter{ptr};
     cell = *deleter;
   }
 }
@@ -97,9 +93,8 @@ void load(Archive& ar, Euclid::GridContainer::GridContainer<GridCellManager,Axes
 /// check that the GridCellManager of the GridContainer allows for boost serialization.
 /// This check is done in compilation time. After the check the save/load action
 /// is delegated to the save and load methods.
-template<class Archive, typename GridCellManager, typename... AxesTypes>
-void serialize(Archive& ar, Euclid::GridContainer::GridContainer<GridCellManager, AxesTypes...>& grid,
-               const unsigned int version) {
+template <class Archive, typename GridCellManager, typename... AxesTypes>
+void serialize(Archive& ar, Euclid::GridContainer::GridContainer<GridCellManager, AxesTypes...>& grid, const unsigned int version) {
   static_assert(Euclid::GridContainer::GridCellManagerTraits<GridCellManager>::enable_boost_serialize,
                 "Boost serialization of GridContainer with unsupported GridCellManager");
   split_free(ar, grid, version);
@@ -110,9 +105,9 @@ void serialize(Archive& ar, Euclid::GridContainer::GridContainer<GridCellManager
 /// The cell data are handled in the serialize method.
 /// NOTE: Any changes in this method should be reflected in the
 /// load_construct_data method.
-template<class Archive, typename GridCellManager, typename... AxesTypes>
-void save_construct_data(Archive& ar, const Euclid::GridContainer::GridContainer<GridCellManager,AxesTypes...>* t,
-                                const unsigned int) {
+template <class Archive, typename GridCellManager, typename... AxesTypes>
+void save_construct_data(Archive& ar, const Euclid::GridContainer::GridContainer<GridCellManager, AxesTypes...>* t,
+                         const unsigned int) {
   std::tuple<Euclid::GridContainer::GridAxis<AxesTypes>...> axes_tuple = t->getAxesTuple();
   ar << axes_tuple;
 }
@@ -129,19 +124,17 @@ Euclid::GridContainer::GridAxis<T> emptyGridAxis() {
 /// data red are the axes tuple and the GridCellManager.
 /// NOTE: Any changes in this method should be reflected in the
 /// save_construct_data method.
-template<class Archive, typename GridCellManager, typename... AxesTypes>
-void load_construct_data(Archive& ar, Euclid::GridContainer::GridContainer<GridCellManager,AxesTypes...>* t,
-                                const unsigned int) {
+template <class Archive, typename GridCellManager, typename... AxesTypes>
+void load_construct_data(Archive& ar, Euclid::GridContainer::GridContainer<GridCellManager, AxesTypes...>* t, const unsigned int) {
   // We create a tuple containing empty GridAxis objects. These will be replaced
   // when we read from the stream with the real GridAxis objects. We have to do
   // that because the GridAxis does not have a default constructor.
-  std::tuple<Euclid::GridContainer::GridAxis<AxesTypes>...> axes_tuple {(emptyGridAxis<AxesTypes>())...};
+  std::tuple<Euclid::GridContainer::GridAxis<AxesTypes>...> axes_tuple{(emptyGridAxis<AxesTypes>())...};
   ar >> axes_tuple;
-  ::new(t) Euclid::GridContainer::GridContainer<GridCellManager,AxesTypes...>(axes_tuple);
+  ::new (t) Euclid::GridContainer::GridContainer<GridCellManager, AxesTypes...>(axes_tuple);
 }
 
 } /* end of namespace serialization */
 } /* end of namespace boost */
 
-#endif  /* GRIDCONTAINER_SERIALIZATION_GRIDCONTAINER_H */
-
+#endif /* GRIDCONTAINER_SERIALIZATION_GRIDCONTAINER_H */

--- a/GridContainer/GridContainer/serialization/tuple.h
+++ b/GridContainer/GridContainer/serialization/tuple.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file GridContainer/serialization/tuple.h
  * @date May 16, 2014
  * @author Nikolaos Apostolakos
@@ -25,10 +25,10 @@
 #ifndef GRIDCONTAINER_SERIALIZATION_TUPLE_H
 #define GRIDCONTAINER_SERIALIZATION_TUPLE_H
 
+#include <boost/serialization/split_free.hpp>
+#include <memory>
 #include <tuple>
 #include <type_traits>
-#include <memory>
-#include <boost/serialization/split_free.hpp>
 
 namespace boost {
 namespace serialization {
@@ -36,109 +36,109 @@ namespace serialization {
 /// Class which saves in a boost serialization archive the elements of a tuple
 /// in a recursive way. It uses two different ways to save the elements,
 /// depending if their type has default constructor or not.
-template<size_t N>
+template <size_t N>
 struct Save {
 
   /// Version of save for default constructible tuple elements. It just saves
   /// in the archive the element.
-  template<typename Archive, typename... Args>
-  static void save(Archive& ar, const std::tuple<Args...>& t, const unsigned int version,
-                   typename std::enable_if<std::is_default_constructible<
-                     typename std::tuple_element<N - 1, std::tuple<Args...>>::type>::value
-                   >::type* = 0) {
-    ar << std::get<N-1>(t);
-    Save<N-1>::save(ar, t, version);
+  template <typename Archive, typename... Args>
+  static void
+  save(Archive& ar, const std::tuple<Args...>& t, const unsigned int version,
+       typename std::enable_if<
+           std::is_default_constructible<typename std::tuple_element<N - 1, std::tuple<Args...>>::type>::value>::type* = 0) {
+    ar << std::get<N - 1>(t);
+    Save<N - 1>::save(ar, t, version);
   }
 
   /// Version of save for non default constructible tuple elements. It saves
   /// in the archive a pointer to the element, to enable the boost serialization
   /// non default constructor support. These objects must be read as pointers.
-  template<typename Archive, typename... Args>
-  static void save(Archive& ar, const std::tuple<Args...>& t, const unsigned int version,
-                   typename std::enable_if<!std::is_default_constructible<
-                     typename std::tuple_element<N - 1, std::tuple<Args...>>::type
-                   >::value>::type * = 0) {
+  template <typename Archive, typename... Args>
+  static void
+  save(Archive& ar, const std::tuple<Args...>& t, const unsigned int version,
+       typename std::enable_if<
+           !std::is_default_constructible<typename std::tuple_element<N - 1, std::tuple<Args...>>::type>::value>::type* = 0) {
     // Do NOT delete this pointer! It points in the element of the tuple and
     // the tuple will take care of the memory management
-    typename std::remove_reference<decltype(std::get<N-1>(t))>::type* ptr = &std::get<N-1>(t);
+    typename std::remove_reference<decltype(std::get<N - 1>(t))>::type* ptr = &std::get<N - 1>(t);
     ar << ptr;
-    Save<N-1>::save(ar, t, version);
+    Save<N - 1>::save(ar, t, version);
   }
 };
 
 /// Class which defines the end of the recursion when saving the elements of
 /// a tuple in a boost archive.
-template<>
+template <>
 struct Save<0> {
   /// This method does nothing. It exists to break the recursion.
-  template<typename Archive, typename... Args>
-  static void save(Archive&, const std::tuple<Args...>&, const unsigned int) { }
+  template <typename Archive, typename... Args>
+  static void save(Archive&, const std::tuple<Args...>&, const unsigned int) {}
 };
 
 /// Class which loads from a boost serialization archive the elements of a tuple
 /// in a recursive way. It uses two different ways to load the elements,
 /// depending if their type has default constructor or not. Note that non
 /// default constructible elements must have a copy assignment operator.
-template<size_t N>
+template <size_t N>
 struct Load {
 
   /// Version of load for default constructible tuple elements. It just loads
   /// from the archive the element into the default constructed element of the
   /// tuple.
-  template<typename Archive, typename... Args>
-  static void load(Archive& ar, std::tuple<Args...>& t, const unsigned int version,
-                   typename std::enable_if<std::is_default_constructible<
-                     typename std::tuple_element<N - 1, std::tuple<Args...>>::type>::value
-                   >::type * = 0) {
-    ar >> std::get<N-1>(t);
-    Load<N-1>::load(ar, t, version);
+  template <typename Archive, typename... Args>
+  static void
+  load(Archive& ar, std::tuple<Args...>& t, const unsigned int version,
+       typename std::enable_if<
+           std::is_default_constructible<typename std::tuple_element<N - 1, std::tuple<Args...>>::type>::value>::type* = 0) {
+    ar >> std::get<N - 1>(t);
+    Load<N - 1>::load(ar, t, version);
   }
 
   /// Version of load for non default constructible tuple elements. It reads
   /// from the archive a pointer to enable the boost non default constructor
   /// mechanisms and then it uses the copy assignment operator to move the
   /// just red object in the tuple.
-  template<typename Archive, typename... Args>
-  static void load(Archive& ar, std::tuple<Args...>& t, const unsigned int version,
-                   typename std::enable_if<!std::is_default_constructible<
-                     typename std::tuple_element<N - 1, std::tuple<Args...>>::type
-                   >::value>::type * = 0) {
-    typedef typename std::remove_reference<decltype(std::get<N-1>(t))>::type ElementType;
-    ElementType* ptr;
+  template <typename Archive, typename... Args>
+  static void
+  load(Archive& ar, std::tuple<Args...>& t, const unsigned int version,
+       typename std::enable_if<
+           !std::is_default_constructible<typename std::tuple_element<N - 1, std::tuple<Args...>>::type>::value>::type* = 0) {
+    typedef typename std::remove_reference<decltype(std::get<N - 1>(t))>::type ElementType;
+    ElementType*                                                               ptr;
     ar >> ptr;
     // We use a unique_ptr to guarantee deletion of the pointer
-    std::unique_ptr<ElementType> deleter {ptr};
-    std::get<N-1>(t) = *deleter;
-    Load<N-1>::load(ar, t, version);
+    std::unique_ptr<ElementType> deleter{ptr};
+    std::get<N - 1>(t) = *deleter;
+    Load<N - 1>::load(ar, t, version);
   }
 };
 
 /// Class which defines the end of the recursion when loading the elements of
 /// a tuple in a boost archive.
-template<>
+template <>
 struct Load<0> {
   /// This method does nothing. It exists to break the recursion.
-  template<typename Archive, typename... Args>
-  static void load(Archive&, std::tuple<Args...>&, const unsigned int) { }
+  template <typename Archive, typename... Args>
+  static void load(Archive&, std::tuple<Args...>&, const unsigned int) {}
 };
 
 /// Method which saves a tuple instance to an archive. It uses the Save class
 /// to recursively save all the tuple elements.
-template<typename Archive, typename... Args>
+template <typename Archive, typename... Args>
 void save(Archive& ar, const std::tuple<Args...>& t, const unsigned int version) {
   Save<sizeof...(Args)>::save(ar, t, version);
 }
 
 /// Method which loads a tuple instance to an archive. It uses the Load class
 /// to recursively load all the tuple elements.
-template<typename Archive, typename... Args>
+template <typename Archive, typename... Args>
 void load(Archive& ar, std::tuple<Args...>& t, const unsigned int version) {
   Load<sizeof...(Args)>::load(ar, t, version);
 }
 
 /// Method which saves/loads a tuple instance to/from an archive. It uses the
 /// split_free method to split the two actions in different methods.
-template<typename Archive, typename... Args>
+template <typename Archive, typename... Args>
 void serialize(Archive& ar, std::tuple<Args...>& t, const unsigned int version) {
   split_free(ar, t, version);
 }
@@ -146,5 +146,4 @@ void serialize(Archive& ar, std::tuple<Args...>& t, const unsigned int version) 
 } /* end of namespace serialization */
 } /* end of namespace boost */
 
-#endif  /* GRIDCONTAINER_SERIALIZATION_TUPLE_H */
-
+#endif /* GRIDCONTAINER_SERIALIZATION_TUPLE_H */

--- a/GridContainer/GridContainer/serialize.h
+++ b/GridContainer/GridContainer/serialize.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file GridContainer/serialize.h
  * @date May 19, 2014
  * @author Nikolaos Apostolakos
@@ -25,13 +25,13 @@
 #ifndef GRIDCONTAINER_SERIALIZE_H
 #define GRIDCONTAINER_SERIALIZE_H
 
-#include <iostream>
-#include <memory>
+#include "GridContainer/GridContainer.h"
+#include "GridContainer/serialization/GridContainer.h"
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/filesystem.hpp>
-#include "GridContainer/GridContainer.h"
-#include "GridContainer/serialization/GridContainer.h"
+#include <iostream>
+#include <memory>
 
 namespace Euclid {
 namespace GridContainer {
@@ -54,11 +54,11 @@ namespace GridContainer {
  * @param out The stream to write the grid in
  * @param grid The grid to export
  */
-template<typename OArchive, typename GridCellManager, typename... AxesTypes>
+template <typename OArchive, typename GridCellManager, typename... AxesTypes>
 void gridExport(std::ostream& out, const GridContainer<GridCellManager, AxesTypes...>& grid) {
   // Do NOT delete this pointer!!! It  points to the actual grid
   const GridContainer<GridCellManager, AxesTypes...>* ptr = &grid;
-  OArchive boa {out};
+  OArchive                                            boa{out};
   boa << ptr;
 }
 
@@ -79,13 +79,13 @@ void gridExport(std::ostream& out, const GridContainer<GridCellManager, AxesType
  * @param in The stream to read the grid from
  * @return The grid red from the stream
  */
-template<typename GridType, typename IArchive>
+template <typename GridType, typename IArchive>
 GridType gridImport(std::istream& in) {
-  IArchive bia {in};
+  IArchive bia{in};
   // Do NOT delete manually this pointer. It is wrapped with a unique_ptr later.
   GridType* ptr;
   bia >> ptr;
-  std::unique_ptr<GridType> matr_ptr {ptr};
+  std::unique_ptr<GridType> matr_ptr{ptr};
   // We move out to the result the grid pointed by the pointer. The unique_ptr
   // will delete the (now empty) pointed object
   return std::move(*matr_ptr);
@@ -99,7 +99,7 @@ GridType gridImport(std::istream& in) {
  * @param out The stream to write the grid in
  * @param grid The grid to export
  */
-template<typename GridCellManager, typename... AxesTypes>
+template <typename GridCellManager, typename... AxesTypes>
 void gridBinaryExport(std::ostream& out, const GridContainer<GridCellManager, AxesTypes...>& grid) {
   gridExport<boost::archive::binary_oarchive>(out, grid);
 }
@@ -111,7 +111,7 @@ void gridBinaryExport(std::ostream& out, const GridContainer<GridCellManager, Ax
  * @param in The stream to read the grid from
  * @return The grid red from the stream
  */
-template<typename GridType>
+template <typename GridType>
 GridType gridBinaryImport(std::istream& in) {
   return gridImport<GridType, boost::archive::binary_iarchive>(in);
 }
@@ -139,9 +139,8 @@ GridType gridBinaryImport(std::istream& in) {
  * @param hdu_name The name of the array HDU
  * @param grid The grid to store
  */
-template<typename GridCellManager, typename... AxesTypes>
-void gridFitsExport(const boost::filesystem::path& filename,
-                    const std::string& hdu_name,
+template <typename GridCellManager, typename... AxesTypes>
+void gridFitsExport(const boost::filesystem::path& filename, const std::string& hdu_name,
                     const GridContainer<GridCellManager, AxesTypes...>& grid);
 
 /**
@@ -155,13 +154,12 @@ void gridFitsExport(const boost::filesystem::path& filename,
  * @param hdu_index The index of the array HDU with the grid data
  * @return The grid
  */
-template<typename GridType>
+template <typename GridType>
 GridType gridFitsImport(const boost::filesystem::path& filename, int hdu_index);
 
-} // end of namespace GridContainer
-} // end of namespace Euclid
+}  // end of namespace GridContainer
+}  // end of namespace Euclid
 
 #include "GridContainer/_impl/FitsSerialize.icpp"
 
-#endif  /* GRIDCONTAINER_SERIALIZE_H */
-
+#endif /* GRIDCONTAINER_SERIALIZE_H */

--- a/GridContainer/tests/src/GridAxis_test.cpp
+++ b/GridContainer/tests/src/GridAxis_test.cpp
@@ -16,18 +16,18 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/GridAxis_test.cpp
  * @date June 16, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
 #include "GridContainer/GridAxis.h"
+#include <boost/test/unit_test.hpp>
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (GridAxis_test)
+BOOST_AUTO_TEST_SUITE(GridAxis_test)
 
 //-----------------------------------------------------------------------------
 // Test the name is set correctly
@@ -36,16 +36,15 @@ BOOST_AUTO_TEST_SUITE (GridAxis_test)
 BOOST_AUTO_TEST_CASE(name) {
 
   // Given
-  std::string test_name = "AxisName";
-  std::vector<double> knots {};
-  Euclid::GridContainer::GridAxis<double> axis {test_name, knots};
+  std::string                             test_name = "AxisName";
+  std::vector<double>                     knots{};
+  Euclid::GridContainer::GridAxis<double> axis{test_name, knots};
 
   // When
   auto& result = axis.name();
 
   // Then
   BOOST_CHECK_EQUAL(result, test_name);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -55,16 +54,15 @@ BOOST_AUTO_TEST_CASE(name) {
 BOOST_AUTO_TEST_CASE(axisSize) {
 
   // Given
-  std::string test_name = "AxisName";
-  std::vector<double> knots {{1., 2., 2.5, 3.8}};
-  Euclid::GridContainer::GridAxis<double> axis {test_name, knots};
+  std::string                             test_name = "AxisName";
+  std::vector<double>                     knots{{1., 2., 2.5, 3.8}};
+  Euclid::GridContainer::GridAxis<double> axis{test_name, knots};
 
   // When
   auto size = axis.size();
 
   // Then
   BOOST_CHECK_EQUAL(size, knots.size());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -74,22 +72,21 @@ BOOST_AUTO_TEST_CASE(axisSize) {
 BOOST_AUTO_TEST_CASE(iterator) {
 
   // Given
-  std::string test_name = "AxisName";
-  std::vector<double> knots {{1., 2., 2.5, 3.8}};
-  Euclid::GridContainer::GridAxis<double> axis {test_name, knots};
+  std::string                             test_name = "AxisName";
+  std::vector<double>                     knots{{1., 2., 2.5, 3.8}};
+  Euclid::GridContainer::GridAxis<double> axis{test_name, knots};
 
   // When
-  auto axis_iter = axis.begin();
-  auto axis_end = axis.end();
+  auto axis_iter  = axis.begin();
+  auto axis_end   = axis.end();
   auto knots_iter = knots.begin();
 
   // Then
   while (axis_iter != axis_end) {
     BOOST_CHECK_EQUAL(*axis_iter, *knots_iter);
     ++axis_iter;
-    ++ knots_iter;
+    ++knots_iter;
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -99,22 +96,21 @@ BOOST_AUTO_TEST_CASE(iterator) {
 BOOST_AUTO_TEST_CASE(indexAccess) {
 
   // Given
-  std::string test_name = "AxisName";
-  std::vector<double> knots {{1., 2., 2.5, 3.8}};
-  Euclid::GridContainer::GridAxis<double> axis {test_name, knots};
+  std::string                             test_name = "AxisName";
+  std::vector<double>                     knots{{1., 2., 2.5, 3.8}};
+  Euclid::GridContainer::GridAxis<double> axis{test_name, knots};
 
   // When
-  auto axis_iter = axis.begin();
-  auto axis_end = axis.end();
+  auto axis_iter  = axis.begin();
+  auto axis_end   = axis.end();
   auto knots_iter = knots.begin();
 
   // Then
   while (axis_iter != axis_end) {
     BOOST_CHECK_EQUAL(*axis_iter, *knots_iter);
     ++axis_iter;
-    ++ knots_iter;
+    ++knots_iter;
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -124,21 +120,20 @@ BOOST_AUTO_TEST_CASE(indexAccess) {
 BOOST_AUTO_TEST_CASE(equalityOperatorSameType) {
 
   // Given
-  std::string name_1 = "Axis1";
-  std::vector<double> knots_1 {{1., 2., 2.5, 3.8}};
-  std::string name_2 = "Axis2";
-  std::vector<double> knots_2 {{1., 2., 2.5, 3.8}};
+  std::string         name_1 = "Axis1";
+  std::vector<double> knots_1{{1., 2., 2.5, 3.8}};
+  std::string         name_2 = "Axis2";
+  std::vector<double> knots_2{{1., 2., 2.5, 3.8}};
 
   // When
-  Euclid::GridContainer::GridAxis<double> axis_1 {name_1, knots_1};
-  Euclid::GridContainer::GridAxis<double> axis_2 {name_2, knots_2};
+  Euclid::GridContainer::GridAxis<double> axis_1{name_1, knots_1};
+  Euclid::GridContainer::GridAxis<double> axis_2{name_2, knots_2};
 
   // Then
   BOOST_CHECK(axis_1 == axis_2);
   BOOST_CHECK(axis_2 == axis_1);
   BOOST_CHECK(!(axis_1 != axis_2));
   BOOST_CHECK(!(axis_2 != axis_1));
-
 }
 
 //-----------------------------------------------------------------------------
@@ -148,21 +143,20 @@ BOOST_AUTO_TEST_CASE(equalityOperatorSameType) {
 BOOST_AUTO_TEST_CASE(equalityOperatorSameTypeDifferentValues) {
 
   // Given
-  std::string name_1 = "Axis1";
-  std::vector<double> knots_1 {{1., 2., 2.5, 3.8}};
-  std::string name_2 = "Axis2";
-  std::vector<double> knots_2 {{1., 2., 3.5, 3.8}};
+  std::string         name_1 = "Axis1";
+  std::vector<double> knots_1{{1., 2., 2.5, 3.8}};
+  std::string         name_2 = "Axis2";
+  std::vector<double> knots_2{{1., 2., 3.5, 3.8}};
 
   // When
-  Euclid::GridContainer::GridAxis<double> axis_1 {name_1, knots_1};
-  Euclid::GridContainer::GridAxis<double> axis_2 {name_2, knots_2};
+  Euclid::GridContainer::GridAxis<double> axis_1{name_1, knots_1};
+  Euclid::GridContainer::GridAxis<double> axis_2{name_2, knots_2};
 
   // Then
   BOOST_CHECK(axis_1 != axis_2);
   BOOST_CHECK(axis_2 != axis_1);
   BOOST_CHECK(!(axis_1 == axis_2));
   BOOST_CHECK(!(axis_2 == axis_1));
-
 }
 
 //-----------------------------------------------------------------------------
@@ -172,21 +166,20 @@ BOOST_AUTO_TEST_CASE(equalityOperatorSameTypeDifferentValues) {
 BOOST_AUTO_TEST_CASE(equalityOperatorSameTypeDifferentSize) {
 
   // Given
-  std::string name_1 = "Axis1";
-  std::vector<double> knots_1 {{1., 2., 2.5, 3.8}};
-  std::string name_2 = "Axis2";
-  std::vector<double> knots_2 {{1., 2., 2.5, 3.8, 4.}};
+  std::string         name_1 = "Axis1";
+  std::vector<double> knots_1{{1., 2., 2.5, 3.8}};
+  std::string         name_2 = "Axis2";
+  std::vector<double> knots_2{{1., 2., 2.5, 3.8, 4.}};
 
   // When
-  Euclid::GridContainer::GridAxis<double> axis_1 {name_1, knots_1};
-  Euclid::GridContainer::GridAxis<double> axis_2 {name_2, knots_2};
+  Euclid::GridContainer::GridAxis<double> axis_1{name_1, knots_1};
+  Euclid::GridContainer::GridAxis<double> axis_2{name_2, knots_2};
 
   // Then
   BOOST_CHECK(axis_1 != axis_2);
   BOOST_CHECK(axis_2 != axis_1);
   BOOST_CHECK(!(axis_1 == axis_2));
   BOOST_CHECK(!(axis_2 == axis_1));
-
 }
 
 //-----------------------------------------------------------------------------
@@ -196,21 +189,20 @@ BOOST_AUTO_TEST_CASE(equalityOperatorSameTypeDifferentSize) {
 BOOST_AUTO_TEST_CASE(equalityOperatorDifferentType) {
 
   // Given
-  std::string name_1 = "Axis1";
-  std::vector<double> knots_1 {{1., 2., 3., 4.}};
-  std::string name_2 = "Axis2";
-  std::vector<int> knots_2 {{1, 2, 3, 4}};
+  std::string         name_1 = "Axis1";
+  std::vector<double> knots_1{{1., 2., 3., 4.}};
+  std::string         name_2 = "Axis2";
+  std::vector<int>    knots_2{{1, 2, 3, 4}};
 
   // When
-  Euclid::GridContainer::GridAxis<double> axis_1 {name_1, knots_1};
-  Euclid::GridContainer::GridAxis<int> axis_2 {name_2, knots_2};
+  Euclid::GridContainer::GridAxis<double> axis_1{name_1, knots_1};
+  Euclid::GridContainer::GridAxis<int>    axis_2{name_2, knots_2};
 
   // Then
   BOOST_CHECK(axis_1 == axis_2);
   BOOST_CHECK(axis_2 == axis_1);
   BOOST_CHECK(!(axis_1 != axis_2));
   BOOST_CHECK(!(axis_2 != axis_1));
-
 }
 
 //-----------------------------------------------------------------------------
@@ -220,21 +212,20 @@ BOOST_AUTO_TEST_CASE(equalityOperatorDifferentType) {
 BOOST_AUTO_TEST_CASE(equalityOperatorDifferentTypeDifferentValues) {
 
   // Given
-  std::string name_1 = "Axis1";
-  std::vector<double> knots_1 {{1., 2., 3.5, 4.}};
-  std::string name_2 = "Axis2";
-  std::vector<int> knots_2 {{1, 2, 3, 4}};
+  std::string         name_1 = "Axis1";
+  std::vector<double> knots_1{{1., 2., 3.5, 4.}};
+  std::string         name_2 = "Axis2";
+  std::vector<int>    knots_2{{1, 2, 3, 4}};
 
   // When
-  Euclid::GridContainer::GridAxis<double> axis_1 {name_1, knots_1};
-  Euclid::GridContainer::GridAxis<int> axis_2 {name_2, knots_2};
+  Euclid::GridContainer::GridAxis<double> axis_1{name_1, knots_1};
+  Euclid::GridContainer::GridAxis<int>    axis_2{name_2, knots_2};
 
   // Then
   BOOST_CHECK(axis_1 != axis_2);
   BOOST_CHECK(axis_2 != axis_1);
   BOOST_CHECK(!(axis_1 == axis_2));
   BOOST_CHECK(!(axis_2 == axis_1));
-
 }
 
 //-----------------------------------------------------------------------------
@@ -244,23 +235,22 @@ BOOST_AUTO_TEST_CASE(equalityOperatorDifferentTypeDifferentValues) {
 BOOST_AUTO_TEST_CASE(equalityOperatorDifferentTypeDifferentSize) {
 
   // Given
-  std::string name_1 = "Axis1";
-  std::vector<double> knots_1 {{1., 2., 3., 4.}};
-  std::string name_2 = "Axis2";
-  std::vector<int> knots_2 {{1, 2, 3, 4, 5}};
+  std::string         name_1 = "Axis1";
+  std::vector<double> knots_1{{1., 2., 3., 4.}};
+  std::string         name_2 = "Axis2";
+  std::vector<int>    knots_2{{1, 2, 3, 4, 5}};
 
   // When
-  Euclid::GridContainer::GridAxis<double> axis_1 {name_1, knots_1};
-  Euclid::GridContainer::GridAxis<int> axis_2 {name_2, knots_2};
+  Euclid::GridContainer::GridAxis<double> axis_1{name_1, knots_1};
+  Euclid::GridContainer::GridAxis<int>    axis_2{name_2, knots_2};
 
   // Then
   BOOST_CHECK(axis_1 != axis_2);
   BOOST_CHECK(axis_2 != axis_1);
   BOOST_CHECK(!(axis_1 == axis_2));
   BOOST_CHECK(!(axis_2 == axis_1));
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/GridContainer/tests/src/GridCellManagerTraits_test.cpp
+++ b/GridContainer/tests/src/GridCellManagerTraits_test.cpp
@@ -16,18 +16,18 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file GridCellManagerTraits_test.cpp
  * @date July 4, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
 #include "GridContainer/GridCellManagerTraits.h"
+#include <boost/test/unit_test.hpp>
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (GridCellManagerTraits_test)
+BOOST_AUTO_TEST_SUITE(GridCellManagerTraits_test)
 
 //-----------------------------------------------------------------------------
 // Test the default operations of the GridCellManagerTraits
@@ -38,18 +38,31 @@ BOOST_AUTO_TEST_CASE(defaultOperations) {
   // Given
   class DefaultCellManager {
     int m_size;
+
   public:
     explicit DefaultCellManager(int size) : m_size{size} {}
     typedef double data_type;
-    struct iterator { int m_i {0}; };
-    size_t size() const { return m_size; };
-    iterator begin() { iterator i{}; i.m_i = 1; return i; };
-    iterator end() { iterator i{}; i.m_i = 2; return i; };
+    struct iterator {
+      int m_i{0};
+    };
+    size_t size() const {
+      return m_size;
+    };
+    iterator begin() {
+      iterator i{};
+      i.m_i = 1;
+      return i;
+    };
+    iterator end() {
+      iterator i{};
+      i.m_i = 2;
+      return i;
+    };
   };
 
   // When
-  typedef Euclid::GridContainer::GridCellManagerTraits<DefaultCellManager> traits;
-  auto result = traits::factory(5);
+  using traits = Euclid::GridContainer::GridCellManagerTraits<DefaultCellManager>;
+  auto result  = traits::factory(5);
 
   // Then
   BOOST_CHECK(typeid(traits::data_type) == typeid(DefaultCellManager::data_type));
@@ -59,7 +72,6 @@ BOOST_AUTO_TEST_CASE(defaultOperations) {
   BOOST_CHECK_EQUAL(traits::begin(*result).m_i, 1);
   BOOST_CHECK_EQUAL(traits::end(*result).m_i, 2);
   BOOST_CHECK(!traits::enable_boost_serialize);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -73,7 +85,7 @@ BOOST_AUTO_TEST_CASE(vectorOperations) {
 
   // When
   typedef Euclid::GridContainer::GridCellManagerTraits<VectorCellManager> traits;
-  auto result = traits::factory(5);
+  auto                                                                    result = traits::factory(5);
 
   // Then
   BOOST_CHECK(typeid(traits::data_type) == typeid(double));
@@ -83,9 +95,8 @@ BOOST_AUTO_TEST_CASE(vectorOperations) {
   BOOST_CHECK(traits::begin(*result) == result->begin());
   BOOST_CHECK(traits::end(*result) == result->end());
   BOOST_CHECK(traits::enable_boost_serialize);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/GridContainer/tests/src/GridConstructionHelper_test.cpp
+++ b/GridContainer/tests/src/GridConstructionHelper_test.cpp
@@ -1,53 +1,53 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file tests/src/GridConstructionHelper_test.cpp
  * @date July 2, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
 #include "GridContainer/_impl/GridConstructionHelper.h"
+#include <boost/test/unit_test.hpp>
 
 struct GridConstructionHelper_Fixture {
-  typedef Euclid::GridContainer::GridAxis<int> IntAxis;
-  IntAxis axis1 {"Axis 1", {1, 2, 3, 4, 5}};
-  IntAxis axis2 {"Axis 2", {1, 2, 3}};
-  IntAxis axis3 {"Axis 3", {1, 2, 3, 4, 5, 6}};
-  IntAxis axis4 {"Axis 4", {1, 2}};
-  std::tuple<IntAxis, IntAxis, IntAxis, IntAxis> axes_tuple {axis1, axis2, axis3, axis4};
+  typedef Euclid::GridContainer::GridAxis<int>                              IntAxis;
+  IntAxis                                                                   axis1{"Axis 1", {1, 2, 3, 4, 5}};
+  IntAxis                                                                   axis2{"Axis 2", {1, 2, 3}};
+  IntAxis                                                                   axis3{"Axis 3", {1, 2, 3, 4, 5, 6}};
+  IntAxis                                                                   axis4{"Axis 4", {1, 2}};
+  std::tuple<IntAxis, IntAxis, IntAxis, IntAxis>                            axes_tuple{axis1, axis2, axis3, axis4};
   typedef Euclid::GridContainer::GridConstructionHelper<int, int, int, int> Helper;
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (GridConstructionHelper_test)
+BOOST_AUTO_TEST_SUITE(GridConstructionHelper_test)
 
 //-----------------------------------------------------------------------------
 // Test the createAxesSizesVector method
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(createAxesSizesVector, GridConstructionHelper_Fixture) {
-  
+
   // When
   std::vector<size_t> result = Helper::createAxesSizesVector(axes_tuple, Euclid::GridContainer::TemplateLoopCounter<4>{});
-            
+
   // Then
   BOOST_CHECK_EQUAL(result.size(), 4u);
   BOOST_CHECK_EQUAL(result[0], axis1.size());
@@ -59,21 +59,21 @@ BOOST_FIXTURE_TEST_CASE(createAxesSizesVector, GridConstructionHelper_Fixture) {
 //-----------------------------------------------------------------------------
 // Test the createAxisIndexFactorVector method
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(createAxisIndexFactorVector, GridConstructionHelper_Fixture) {
-  
+
   // When
   std::vector<size_t> result = Helper::createAxisIndexFactorVector(axes_tuple, Euclid::GridContainer::TemplateLoopCounter<4>{});
-            
+
   // Then
   BOOST_CHECK_EQUAL(result.size(), 5u);
   BOOST_CHECK_EQUAL(result[0], 1u);
   BOOST_CHECK_EQUAL(result[1], axis1.size());
-  BOOST_CHECK_EQUAL(result[2], axis1.size()*axis2.size());
-  BOOST_CHECK_EQUAL(result[3], axis1.size()*axis2.size()*axis3.size());
-  BOOST_CHECK_EQUAL(result[4], axis1.size()*axis2.size()*axis3.size()*axis4.size());
+  BOOST_CHECK_EQUAL(result[2], axis1.size() * axis2.size());
+  BOOST_CHECK_EQUAL(result[3], axis1.size() * axis2.size() * axis3.size());
+  BOOST_CHECK_EQUAL(result[4], axis1.size() * axis2.size() * axis3.size() * axis4.size());
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/GridContainer/tests/src/GridContainerToTable_test.cpp
+++ b/GridContainer/tests/src/GridContainerToTable_test.cpp
@@ -16,25 +16,25 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "GridContainer/GridContainerToTable.h"
+#include <boost/test/unit_test.hpp>
+#include <cmath>
 #include <string>
 #include <tuple>
 #include <vector>
-#include <boost/test/unit_test.hpp>
-#include <cmath>
-#include "GridContainer/GridContainerToTable.h"
 
 using namespace Euclid::GridContainer;
 
 struct SimpleGridContainer_Fixture {
   typedef GridContainer<std::vector<double>, int, int, std::string, float> GridContainerType;
-  typedef GridAxis<int> IntAxis;
-  typedef GridAxis<std::string> StrAxis;
-  typedef GridAxis<float> FloatAxis;
-  IntAxis axis1{"Axis 1", {1, 2, 3, 4, 5}};
-  IntAxis axis2{"Axis 2", {1, 2, 3}};
-  StrAxis axis3{"Axis 3", {"a", "b", "c", "d", "e", "f"}};
-  FloatAxis axis4{"Axis 4", {1, 2}};
-  std::tuple<IntAxis, IntAxis, StrAxis, FloatAxis> axes_tuple{axis1, axis2, axis3, axis4};
+  typedef GridAxis<int>                                                    IntAxis;
+  typedef GridAxis<std::string>                                            StrAxis;
+  typedef GridAxis<float>                                                  FloatAxis;
+  IntAxis                                                                  axis1{"Axis 1", {1, 2, 3, 4, 5}};
+  IntAxis                                                                  axis2{"Axis 2", {1, 2, 3}};
+  StrAxis                                                                  axis3{"Axis 3", {"a", "b", "c", "d", "e", "f"}};
+  FloatAxis                                                                axis4{"Axis 4", {1, 2}};
+  std::tuple<IntAxis, IntAxis, StrAxis, FloatAxis>                         axes_tuple{axis1, axis2, axis3, axis4};
 
   GridContainerType grid{axis1, axis2, axis3, axis4};
 
@@ -56,12 +56,13 @@ struct SimpleGridContainer_Fixture {
 };
 
 struct CellWithAttributes {
-  double flux, error;
+  double      flux, error;
   std::string description;
 };
 
-namespace Euclid { namespace GridContainer {
-template<>
+namespace Euclid {
+namespace GridContainer {
+template <>
 struct GridCellToTable<CellWithAttributes> {
   static void addColumnDescriptions(const CellWithAttributes&, std::vector<Euclid::Table::ColumnDescription>& columns) {
     columns.emplace_back("MyFlux", typeid(double));
@@ -75,17 +76,18 @@ struct GridCellToTable<CellWithAttributes> {
     row.emplace_back(c.description);
   }
 };
-}}
+}  // namespace GridContainer
+}  // namespace Euclid
 
 struct ComposedGridContainer_Fixture {
   typedef GridContainer<std::vector<CellWithAttributes>, int, int, std::string, float> GridContainerType;
-  typedef GridAxis<int> IntAxis;
-  typedef GridAxis<std::string> StrAxis;
-  typedef GridAxis<float> FloatAxis;
-  IntAxis axis1{"Axis 1", {1, 2, 3, 4, 5}};
-  IntAxis axis2{"Axis 2", {1, 2, 3}};
-  StrAxis axis3{"Axis 3", {"a", "b", "c", "d", "e", "f"}};
-  FloatAxis axis4{"Axis 4", {1, 2}};
+  typedef GridAxis<int>                                                                IntAxis;
+  typedef GridAxis<std::string>                                                        StrAxis;
+  typedef GridAxis<float>                                                              FloatAxis;
+  IntAxis                                                                              axis1{"Axis 1", {1, 2, 3, 4, 5}};
+  IntAxis                                                                              axis2{"Axis 2", {1, 2, 3}};
+  StrAxis                                          axis3{"Axis 3", {"a", "b", "c", "d", "e", "f"}};
+  FloatAxis                                        axis4{"Axis 4", {1, 2}};
   std::tuple<IntAxis, IntAxis, StrAxis, FloatAxis> axes_tuple{axis1, axis2, axis3, axis4};
 
   GridContainerType grid{axis1, axis2, axis3, axis4};
@@ -100,9 +102,9 @@ struct ComposedGridContainer_Fixture {
         for (size_t a3 = 0; a3 < axis3.size(); ++a3) {
           for (size_t a4 = 0; a4 < axis4.size(); ++a4) {
             CellWithAttributes c;
-            c.flux = Fx(axis1[a1], axis2[a2], axis3[a3], axis4[a4]);
-            c.error = std::sqrt(c.flux);
-            c.description = std::string(a4 + 1, 'x');
+            c.flux                  = Fx(axis1[a1], axis2[a2], axis3[a3], axis4[a4]);
+            c.error                 = std::sqrt(c.flux);
+            c.description           = std::string(a4 + 1, 'x');
             grid.at(a1, a2, a3, a4) = c;
           }
         }
@@ -113,7 +115,7 @@ struct ComposedGridContainer_Fixture {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (GridToTable_test)
+BOOST_AUTO_TEST_SUITE(GridToTable_test)
 
 //-----------------------------------------------------------------------------
 
@@ -140,12 +142,12 @@ BOOST_FIXTURE_TEST_CASE(SimpleToTable, SimpleGridContainer_Fixture) {
   BOOST_CHECK(std::type_index(typeid(double)) == cell_col.type);
 
   // The order is not so important as to keep the proper values together!
-  for (auto& row: table) {
-    auto ax1 = boost::get<int>(row["Axis_1"]);
-    auto ax2 = boost::get<int>(row["Axis_2"]);
-    auto ax3 = boost::get<std::string>(row["Axis_3"]);
-    auto ax4 = boost::get<float>(row["Axis_4"]);
-    double v = Fx(ax1, ax2, ax3, ax4);
+  for (auto& row : table) {
+    auto   ax1 = boost::get<int>(row["Axis_1"]);
+    auto   ax2 = boost::get<int>(row["Axis_2"]);
+    auto   ax3 = boost::get<std::string>(row["Axis_3"]);
+    auto   ax4 = boost::get<float>(row["Axis_4"]);
+    double v   = Fx(ax1, ax2, ax3, ax4);
     BOOST_CHECK_CLOSE(boost::get<double>(row["value"]), v, 1e-7);
   }
 }
@@ -181,12 +183,12 @@ BOOST_FIXTURE_TEST_CASE(ComposedToTable, ComposedGridContainer_Fixture) {
   BOOST_CHECK(std::type_index(typeid(std::string)) == descr_col.type);
 
   // The order is not so important as to keep the proper values together!
-  for (auto& row: table) {
-    auto ax1 = boost::get<int>(row["Axis_1"]);
-    auto ax2 = boost::get<int>(row["Axis_2"]);
-    auto ax3 = boost::get<std::string>(row["Axis_3"]);
-    auto ax4 = boost::get<float>(row["Axis_4"]);
-    double v = Fx(ax1, ax2, ax3, ax4);
+  for (auto& row : table) {
+    auto   ax1 = boost::get<int>(row["Axis_1"]);
+    auto   ax2 = boost::get<int>(row["Axis_2"]);
+    auto   ax3 = boost::get<std::string>(row["Axis_3"]);
+    auto   ax4 = boost::get<float>(row["Axis_4"]);
+    double v   = Fx(ax1, ax2, ax3, ax4);
     BOOST_CHECK_CLOSE(boost::get<double>(row["MyFlux"]), v, 1e-7);
     BOOST_CHECK_CLOSE(boost::get<double>(row["MyError"]), std::sqrt(v), 1e-7);
   }

--- a/GridContainer/tests/src/GridContainer_test.cpp
+++ b/GridContainer/tests/src/GridContainer_test.cpp
@@ -16,34 +16,34 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file GridContainer_test.cpp
  * @date July 4, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <vector>
-#include <boost/test/unit_test.hpp>
-#include <boost/test/test_tools.hpp>
-#include <ElementsKernel/Real.h>
 #include "GridContainer/GridContainer.h"
+#include <ElementsKernel/Real.h>
+#include <boost/test/test_tools.hpp>
+#include <boost/test/unit_test.hpp>
+#include <vector>
 
 using Elements::isEqual;
 
 struct GridContainer_Fixture {
   typedef Euclid::GridContainer::GridContainer<std::vector<double>, int, int, int, int> GridContainerType;
-  typedef Euclid::GridContainer::GridAxis<int> IntAxis;
-  IntAxis axis1 {"Axis 1", {1, 2, 3, 4, 5}};
-  IntAxis axis2 {"Axis 2", {1, 2, 3}};
-  IntAxis axis3 {"Axis 3", {1, 2, 3, 4, 5, 6}};
-  IntAxis axis4 {"Axis 4", {1, 2}};
-  std::tuple<IntAxis, IntAxis, IntAxis, IntAxis> axes_tuple {axis1, axis2, axis3, axis4};
+  typedef Euclid::GridContainer::GridAxis<int>                                          IntAxis;
+  IntAxis                                                                               axis1{"Axis 1", {1, 2, 3, 4, 5}};
+  IntAxis                                                                               axis2{"Axis 2", {1, 2, 3}};
+  IntAxis                                                                               axis3{"Axis 3", {1, 2, 3, 4, 5, 6}};
+  IntAxis                                                                               axis4{"Axis 4", {1, 2}};
+  std::tuple<IntAxis, IntAxis, IntAxis, IntAxis>                                        axes_tuple{axis1, axis2, axis3, axis4};
   size_t total_size = axis1.size() * axis2.size() * axis3.size() * axis4.size();
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (GridContainer_test)
+BOOST_AUTO_TEST_SUITE(GridContainer_test)
 
 //-----------------------------------------------------------------------------
 // Test construction with GridAxis objects
@@ -52,8 +52,8 @@ BOOST_AUTO_TEST_SUITE (GridContainer_test)
 BOOST_FIXTURE_TEST_CASE(GridAxisConstructor, GridContainer_Fixture) {
 
   // When
-  GridContainerType result_grid {axis1, axis2, axis3, axis4};
-  auto& result_axes_tuple = result_grid.getAxesTuple();
+  GridContainerType result_grid{axis1, axis2, axis3, axis4};
+  auto&             result_axes_tuple = result_grid.getAxesTuple();
 
   // Then
   BOOST_CHECK_EQUAL(result_grid.size(), total_size);
@@ -61,22 +61,17 @@ BOOST_FIXTURE_TEST_CASE(GridAxisConstructor, GridContainer_Fixture) {
     BOOST_CHECK_EQUAL(value, 0.);
   }
   BOOST_CHECK_EQUAL(std::get<0>(result_axes_tuple).name(), axis1.name());
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      std::get<0>(result_axes_tuple).begin(), std::get<0>(result_axes_tuple).end(),
-      axis1.begin(), axis1.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(std::get<0>(result_axes_tuple).begin(), std::get<0>(result_axes_tuple).end(), axis1.begin(),
+                                axis1.end());
   BOOST_CHECK_EQUAL(std::get<1>(result_axes_tuple).name(), axis2.name());
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      std::get<1>(result_axes_tuple).begin(), std::get<1>(result_axes_tuple).end(),
-      axis2.begin(), axis2.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(std::get<1>(result_axes_tuple).begin(), std::get<1>(result_axes_tuple).end(), axis2.begin(),
+                                axis2.end());
   BOOST_CHECK_EQUAL(std::get<2>(result_axes_tuple).name(), axis3.name());
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      std::get<2>(result_axes_tuple).begin(), std::get<2>(result_axes_tuple).end(),
-      axis3.begin(), axis3.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(std::get<2>(result_axes_tuple).begin(), std::get<2>(result_axes_tuple).end(), axis3.begin(),
+                                axis3.end());
   BOOST_CHECK_EQUAL(std::get<3>(result_axes_tuple).name(), axis4.name());
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      std::get<3>(result_axes_tuple).begin(), std::get<3>(result_axes_tuple).end(),
-      axis4.begin(), axis4.end());
-
+  BOOST_CHECK_EQUAL_COLLECTIONS(std::get<3>(result_axes_tuple).begin(), std::get<3>(result_axes_tuple).end(), axis4.begin(),
+                                axis4.end());
 }
 
 //-----------------------------------------------------------------------------
@@ -86,8 +81,8 @@ BOOST_FIXTURE_TEST_CASE(GridAxisConstructor, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(GridAxisTupleonstructor, GridContainer_Fixture) {
 
   // When
-  GridContainerType result_grid {axes_tuple};
-  auto& result_axes_tuple = result_grid.getAxesTuple();
+  GridContainerType result_grid{axes_tuple};
+  auto&             result_axes_tuple = result_grid.getAxesTuple();
 
   // Then
   BOOST_CHECK_EQUAL(result_grid.size(), total_size);
@@ -95,22 +90,17 @@ BOOST_FIXTURE_TEST_CASE(GridAxisTupleonstructor, GridContainer_Fixture) {
     BOOST_CHECK_EQUAL(value, 0.);
   }
   BOOST_CHECK_EQUAL(std::get<0>(result_axes_tuple).name(), axis1.name());
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      std::get<0>(result_axes_tuple).begin(), std::get<0>(result_axes_tuple).end(),
-      axis1.begin(), axis1.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(std::get<0>(result_axes_tuple).begin(), std::get<0>(result_axes_tuple).end(), axis1.begin(),
+                                axis1.end());
   BOOST_CHECK_EQUAL(std::get<1>(result_axes_tuple).name(), axis2.name());
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      std::get<1>(result_axes_tuple).begin(), std::get<1>(result_axes_tuple).end(),
-      axis2.begin(), axis2.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(std::get<1>(result_axes_tuple).begin(), std::get<1>(result_axes_tuple).end(), axis2.begin(),
+                                axis2.end());
   BOOST_CHECK_EQUAL(std::get<2>(result_axes_tuple).name(), axis3.name());
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      std::get<2>(result_axes_tuple).begin(), std::get<2>(result_axes_tuple).end(),
-      axis3.begin(), axis3.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(std::get<2>(result_axes_tuple).begin(), std::get<2>(result_axes_tuple).end(), axis3.begin(),
+                                axis3.end());
   BOOST_CHECK_EQUAL(std::get<3>(result_axes_tuple).name(), axis4.name());
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      std::get<3>(result_axes_tuple).begin(), std::get<3>(result_axes_tuple).end(),
-      axis4.begin(), axis4.end());
-
+  BOOST_CHECK_EQUAL_COLLECTIONS(std::get<3>(result_axes_tuple).begin(), std::get<3>(result_axes_tuple).end(), axis4.begin(),
+                                axis4.end());
 }
 
 //-----------------------------------------------------------------------------
@@ -120,11 +110,10 @@ BOOST_FIXTURE_TEST_CASE(GridAxisTupleonstructor, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(rank, GridContainer_Fixture) {
 
   // When
-  GridContainerType grid {axes_tuple};
+  GridContainerType grid{axes_tuple};
 
   // Then
   BOOST_CHECK_EQUAL(grid.axisNumber(), 4u);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -134,14 +123,13 @@ BOOST_FIXTURE_TEST_CASE(rank, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(getAxis, GridContainer_Fixture) {
 
   // When
-  GridContainerType grid {axes_tuple};
+  GridContainerType grid{axes_tuple};
 
   // Then
   BOOST_CHECK_EQUAL(grid.getAxis<0>().name(), axis1.name());
   BOOST_CHECK_EQUAL(grid.getAxis<1>().name(), axis2.name());
   BOOST_CHECK_EQUAL(grid.getAxis<2>().name(), axis3.name());
   BOOST_CHECK_EQUAL(grid.getAxis<3>().name(), axis4.name());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -151,11 +139,10 @@ BOOST_FIXTURE_TEST_CASE(getAxis, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(size, GridContainer_Fixture) {
 
   // When
-  GridContainerType grid {axes_tuple};
+  GridContainerType grid{axes_tuple};
 
   // Then
   BOOST_CHECK_EQUAL(grid.size(), total_size);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -165,7 +152,7 @@ BOOST_FIXTURE_TEST_CASE(size, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(parenthesisOperator, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // When
@@ -176,7 +163,7 @@ BOOST_FIXTURE_TEST_CASE(parenthesisOperator, GridContainer_Fixture) {
   }
 
   // Then
-  double expected_value {0};
+  double expected_value{0};
   for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
     for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
       for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
@@ -188,7 +175,6 @@ BOOST_FIXTURE_TEST_CASE(parenthesisOperator, GridContainer_Fixture) {
       }
     }
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -198,7 +184,7 @@ BOOST_FIXTURE_TEST_CASE(parenthesisOperator, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(at, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // When
@@ -209,7 +195,7 @@ BOOST_FIXTURE_TEST_CASE(at, GridContainer_Fixture) {
   }
 
   // Then
-  double expected_value {0};
+  double expected_value{0};
   for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
     for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
       for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
@@ -221,7 +207,6 @@ BOOST_FIXTURE_TEST_CASE(at, GridContainer_Fixture) {
       }
     }
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -231,7 +216,7 @@ BOOST_FIXTURE_TEST_CASE(at, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(atOutOfBound, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // When
@@ -250,7 +235,6 @@ BOOST_FIXTURE_TEST_CASE(atOutOfBound, GridContainer_Fixture) {
   BOOST_CHECK_THROW(const_grid.at(0, axis2.size(), 0, 0), Elements::Exception);
   BOOST_CHECK_THROW(const_grid.at(0, 0, axis3.size(), 0), Elements::Exception);
   BOOST_CHECK_THROW(const_grid.at(0, 0, 0, axis4.size()), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -260,7 +244,7 @@ BOOST_FIXTURE_TEST_CASE(atOutOfBound, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(iterator, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // When
@@ -271,7 +255,7 @@ BOOST_FIXTURE_TEST_CASE(iterator, GridContainer_Fixture) {
   }
 
   // Then
-  double expected_value {0};
+  double expected_value{0};
   for (auto& result_value : grid) {
     expected_value += 0.1;
     BOOST_CHECK_CLOSE(result_value, expected_value, 1e-6);
@@ -281,7 +265,6 @@ BOOST_FIXTURE_TEST_CASE(iterator, GridContainer_Fixture) {
     expected_value += 0.1;
     BOOST_CHECK_CLOSE(result_value, expected_value, 1e-6);
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -291,18 +274,18 @@ BOOST_FIXTURE_TEST_CASE(iterator, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(iteratorAxisIndex, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // When
-  auto iterator = grid.begin();
+  auto iterator       = grid.begin();
   auto const_iterator = const_grid.begin();
 
   // Then
-  for (size_t coord4=0; coord4<axis4.size(); ++coord4) {
-    for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
-      for (size_t coord2=0; coord2<axis2.size(); ++coord2) {
-        for (size_t coord1=0; coord1<axis1.size(); ++coord1) {
+  for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
+    for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
+      for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
+        for (size_t coord1 = 0; coord1 < axis1.size(); ++coord1) {
           BOOST_CHECK_EQUAL(iterator.axisIndex<0>(), coord1);
           BOOST_CHECK_EQUAL(iterator.axisIndex<1>(), coord2);
           BOOST_CHECK_EQUAL(iterator.axisIndex<2>(), coord3);
@@ -312,10 +295,10 @@ BOOST_FIXTURE_TEST_CASE(iteratorAxisIndex, GridContainer_Fixture) {
       }
     }
   }
-  for (size_t coord4=0; coord4<axis4.size(); ++coord4) {
-    for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
-      for (size_t coord2=0; coord2<axis2.size(); ++coord2) {
-        for (size_t coord1=0; coord1<axis1.size(); ++coord1) {
+  for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
+    for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
+      for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
+        for (size_t coord1 = 0; coord1 < axis1.size(); ++coord1) {
           BOOST_CHECK_EQUAL(const_iterator.axisIndex<0>(), coord1);
           BOOST_CHECK_EQUAL(const_iterator.axisIndex<1>(), coord2);
           BOOST_CHECK_EQUAL(const_iterator.axisIndex<2>(), coord3);
@@ -325,7 +308,6 @@ BOOST_FIXTURE_TEST_CASE(iteratorAxisIndex, GridContainer_Fixture) {
       }
     }
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -335,18 +317,18 @@ BOOST_FIXTURE_TEST_CASE(iteratorAxisIndex, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(iteratorAxisValue, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // When
-  auto iterator = grid.begin();
+  auto iterator       = grid.begin();
   auto const_iterator = const_grid.begin();
 
   // Then
-  for (size_t coord4=0; coord4<axis4.size(); ++coord4) {
-    for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
-      for (size_t coord2=0; coord2<axis2.size(); ++coord2) {
-        for (size_t coord1=0; coord1<axis1.size(); ++coord1) {
+  for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
+    for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
+      for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
+        for (size_t coord1 = 0; coord1 < axis1.size(); ++coord1) {
           BOOST_CHECK_EQUAL(iterator.axisValue<0>(), axis1[coord1]);
           BOOST_CHECK_EQUAL(iterator.axisValue<1>(), axis2[coord2]);
           BOOST_CHECK_EQUAL(iterator.axisValue<2>(), axis3[coord3]);
@@ -356,10 +338,10 @@ BOOST_FIXTURE_TEST_CASE(iteratorAxisValue, GridContainer_Fixture) {
       }
     }
   }
-  for (size_t coord4=0; coord4<axis4.size(); ++coord4) {
-    for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
-      for (size_t coord2=0; coord2<axis2.size(); ++coord2) {
-        for (size_t coord1=0; coord1<axis1.size(); ++coord1) {
+  for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
+    for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
+      for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
+        for (size_t coord1 = 0; coord1 < axis1.size(); ++coord1) {
           BOOST_CHECK_EQUAL(const_iterator.axisValue<0>(), axis1[coord1]);
           BOOST_CHECK_EQUAL(const_iterator.axisValue<1>(), axis2[coord2]);
           BOOST_CHECK_EQUAL(const_iterator.axisValue<2>(), axis3[coord3]);
@@ -369,7 +351,6 @@ BOOST_FIXTURE_TEST_CASE(iteratorAxisValue, GridContainer_Fixture) {
       }
     }
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -379,10 +360,10 @@ BOOST_FIXTURE_TEST_CASE(iteratorAxisValue, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(fixIteratorByIndex, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
-  for (size_t fixed_index=0; fixed_index<axis1.size(); ++fixed_index) {
+  for (size_t fixed_index = 0; fixed_index < axis1.size(); ++fixed_index) {
 
     // When
     auto iterator = grid.begin();
@@ -413,10 +394,9 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndex, GridContainer_Fixture) {
         }
       }
     }
-
   }
 
-  for (size_t fixed_index=0; fixed_index<axis2.size(); ++fixed_index) {
+  for (size_t fixed_index = 0; fixed_index < axis2.size(); ++fixed_index) {
 
     // When
     auto iterator = grid.begin();
@@ -447,10 +427,9 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndex, GridContainer_Fixture) {
         }
       }
     }
-
   }
 
-  for (size_t fixed_index=0; fixed_index<axis3.size(); ++fixed_index) {
+  for (size_t fixed_index = 0; fixed_index < axis3.size(); ++fixed_index) {
 
     // When
     auto iterator = grid.begin();
@@ -481,10 +460,9 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndex, GridContainer_Fixture) {
         }
       }
     }
-
   }
 
-  for (size_t fixed_index=0; fixed_index<axis4.size(); ++fixed_index) {
+  for (size_t fixed_index = 0; fixed_index < axis4.size(); ++fixed_index) {
 
     // When
     auto iterator = grid.begin();
@@ -515,9 +493,7 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndex, GridContainer_Fixture) {
         }
       }
     }
-
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -527,11 +503,11 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndex, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(fixIteratorByIndexOutOfBound, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // When
-  auto iterator = grid.begin();
+  auto iterator       = grid.begin();
   auto const_iterator = const_grid.begin();
 
   // Then
@@ -543,7 +519,6 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndexOutOfBound, GridContainer_Fixture) {
   BOOST_CHECK_THROW(const_iterator.fixAxisByIndex<1>(axis2.size()), Elements::Exception);
   BOOST_CHECK_THROW(const_iterator.fixAxisByIndex<2>(axis3.size()), Elements::Exception);
   BOOST_CHECK_THROW(const_iterator.fixAxisByIndex<3>(axis4.size()), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -553,14 +528,12 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndexOutOfBound, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(fixIteratorByIndexTwiceForSameAxis, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // When
-  auto iterator = grid.begin().fixAxisByIndex<0>(0).fixAxisByIndex<1>(0)
-                              .fixAxisByIndex<2>(0).fixAxisByIndex<3>(0);
-  auto const_iterator = const_grid.begin().fixAxisByIndex<0>(0).fixAxisByIndex<1>(0)
-                                          .fixAxisByIndex<2>(0).fixAxisByIndex<3>(0);
+  auto iterator       = grid.begin().fixAxisByIndex<0>(0).fixAxisByIndex<1>(0).fixAxisByIndex<2>(0).fixAxisByIndex<3>(0);
+  auto const_iterator = const_grid.begin().fixAxisByIndex<0>(0).fixAxisByIndex<1>(0).fixAxisByIndex<2>(0).fixAxisByIndex<3>(0);
 
   // Then
   iterator.fixAxisByIndex<0>(0);
@@ -571,7 +544,6 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndexTwiceForSameAxis, GridContainer_Fixtur
   const_iterator.fixAxisByIndex<1>(0);
   BOOST_CHECK_THROW(const_iterator.fixAxisByIndex<2>(1), Elements::Exception);
   BOOST_CHECK_THROW(const_iterator.fixAxisByIndex<3>(1), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -581,10 +553,10 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByIndexTwiceForSameAxis, GridContainer_Fixtur
 BOOST_FIXTURE_TEST_CASE(fixIteratorByValue, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
-  for (size_t fixed_index=0; fixed_index<axis1.size(); ++fixed_index) {
+  for (size_t fixed_index = 0; fixed_index < axis1.size(); ++fixed_index) {
 
     // When
     auto iterator = grid.begin();
@@ -615,10 +587,9 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByValue, GridContainer_Fixture) {
         }
       }
     }
-
   }
 
-  for (size_t fixed_index=0; fixed_index<axis2.size(); ++fixed_index) {
+  for (size_t fixed_index = 0; fixed_index < axis2.size(); ++fixed_index) {
 
     // When
     auto iterator = grid.begin();
@@ -649,10 +620,9 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByValue, GridContainer_Fixture) {
         }
       }
     }
-
   }
 
-  for (size_t fixed_index=0; fixed_index<axis3.size(); ++fixed_index) {
+  for (size_t fixed_index = 0; fixed_index < axis3.size(); ++fixed_index) {
 
     // When
     auto iterator = grid.begin();
@@ -683,10 +653,9 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByValue, GridContainer_Fixture) {
         }
       }
     }
-
   }
 
-  for (size_t fixed_index=0; fixed_index<axis4.size(); ++fixed_index) {
+  for (size_t fixed_index = 0; fixed_index < axis4.size(); ++fixed_index) {
 
     // When
     auto iterator = grid.begin();
@@ -717,9 +686,7 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByValue, GridContainer_Fixture) {
         }
       }
     }
-
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -729,23 +696,22 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByValue, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(fixIteratorByValueNotFound, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // When
-  auto iterator = grid.begin();
+  auto iterator       = grid.begin();
   auto const_iterator = const_grid.begin();
 
   // Then
-  BOOST_CHECK_THROW(iterator.fixAxisByValue<0>(axis1.size()+1), Elements::Exception);
-  BOOST_CHECK_THROW(iterator.fixAxisByValue<1>(axis2.size()+1), Elements::Exception);
-  BOOST_CHECK_THROW(iterator.fixAxisByValue<2>(axis3.size()+1), Elements::Exception);
-  BOOST_CHECK_THROW(iterator.fixAxisByValue<3>(axis4.size()+1), Elements::Exception);
-  BOOST_CHECK_THROW(const_iterator.fixAxisByValue<0>(axis1.size()+1), Elements::Exception);
-  BOOST_CHECK_THROW(const_iterator.fixAxisByValue<1>(axis2.size()+1), Elements::Exception);
-  BOOST_CHECK_THROW(const_iterator.fixAxisByValue<2>(axis3.size()+1), Elements::Exception);
-  BOOST_CHECK_THROW(const_iterator.fixAxisByValue<3>(axis4.size()+1), Elements::Exception);
-
+  BOOST_CHECK_THROW(iterator.fixAxisByValue<0>(axis1.size() + 1), Elements::Exception);
+  BOOST_CHECK_THROW(iterator.fixAxisByValue<1>(axis2.size() + 1), Elements::Exception);
+  BOOST_CHECK_THROW(iterator.fixAxisByValue<2>(axis3.size() + 1), Elements::Exception);
+  BOOST_CHECK_THROW(iterator.fixAxisByValue<3>(axis4.size() + 1), Elements::Exception);
+  BOOST_CHECK_THROW(const_iterator.fixAxisByValue<0>(axis1.size() + 1), Elements::Exception);
+  BOOST_CHECK_THROW(const_iterator.fixAxisByValue<1>(axis2.size() + 1), Elements::Exception);
+  BOOST_CHECK_THROW(const_iterator.fixAxisByValue<2>(axis3.size() + 1), Elements::Exception);
+  BOOST_CHECK_THROW(const_iterator.fixAxisByValue<3>(axis4.size() + 1), Elements::Exception);
 }
 
 //-----------------------------------------------------------------------------
@@ -755,14 +721,12 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByValueNotFound, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(fixIteratorByValueTwiceForSameAxis, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // When
-  auto iterator = grid.begin().fixAxisByValue<0>(1).fixAxisByValue<1>(1)
-                              .fixAxisByValue<2>(1).fixAxisByValue<3>(1);
-  auto const_iterator = const_grid.begin().fixAxisByValue<0>(1).fixAxisByValue<1>(1)
-                                          .fixAxisByValue<2>(1).fixAxisByValue<3>(1);
+  auto iterator       = grid.begin().fixAxisByValue<0>(1).fixAxisByValue<1>(1).fixAxisByValue<2>(1).fixAxisByValue<3>(1);
+  auto const_iterator = const_grid.begin().fixAxisByValue<0>(1).fixAxisByValue<1>(1).fixAxisByValue<2>(1).fixAxisByValue<3>(1);
 
   // Then
   iterator.fixAxisByValue<0>(1);
@@ -773,7 +737,6 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByValueTwiceForSameAxis, GridContainer_Fixtur
   const_iterator.fixAxisByValue<1>(1);
   BOOST_CHECK_THROW(const_iterator.fixAxisByValue<2>(2), Elements::Exception);
   BOOST_CHECK_THROW(const_iterator.fixAxisByValue<3>(2), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -783,10 +746,10 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorByValueTwiceForSameAxis, GridContainer_Fixtur
 BOOST_FIXTURE_TEST_CASE(fixIteratorAllAxes, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid1 {axes_tuple};
-  auto iter1 = grid1.begin();
-  GridContainerType grid2 {axes_tuple};
-  auto iter2 = grid2.begin();
+  GridContainerType grid1{axes_tuple};
+  auto              iter1 = grid1.begin();
+  GridContainerType grid2{axes_tuple};
+  auto              iter2 = grid2.begin();
 
   // When
   iter1.fixAxisByIndex<0>(3).fixAxisByIndex<1>(2).fixAxisByIndex<2>(1).fixAxisByIndex<3>(0);
@@ -797,7 +760,6 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorAllAxes, GridContainer_Fixture) {
   BOOST_CHECK_EQUAL(iter2.axisIndex<1>(), 2u);
   BOOST_CHECK_EQUAL(iter2.axisIndex<2>(), 1u);
   BOOST_CHECK_EQUAL(iter2.axisIndex<3>(), 0u);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -807,7 +769,7 @@ BOOST_FIXTURE_TEST_CASE(fixIteratorAllAxes, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(sliceByIndexOutOfBound, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // Then
@@ -819,7 +781,6 @@ BOOST_FIXTURE_TEST_CASE(sliceByIndexOutOfBound, GridContainer_Fixture) {
   BOOST_CHECK_THROW(const_grid.fixAxisByIndex<1>(axis2.size()), Elements::Exception);
   BOOST_CHECK_THROW(const_grid.fixAxisByIndex<2>(axis3.size()), Elements::Exception);
   BOOST_CHECK_THROW(const_grid.fixAxisByIndex<3>(axis4.size()), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -829,14 +790,14 @@ BOOST_FIXTURE_TEST_CASE(sliceByIndexOutOfBound, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(sliceByIndexTwiceSameAxis, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // When
-  auto slice0 = grid.fixAxisByIndex<0>(0);
-  auto slice1 = grid.fixAxisByIndex<1>(0);
-  auto slice2 = grid.fixAxisByIndex<2>(0);
-  auto slice3 = grid.fixAxisByIndex<3>(0);
+  auto  slice0       = grid.fixAxisByIndex<0>(0);
+  auto  slice1       = grid.fixAxisByIndex<1>(0);
+  auto  slice2       = grid.fixAxisByIndex<2>(0);
+  auto  slice3       = grid.fixAxisByIndex<3>(0);
   auto& const_slice0 = const_grid.fixAxisByIndex<0>(0);
   auto& const_slice1 = const_grid.fixAxisByIndex<1>(0);
   auto& const_slice2 = const_grid.fixAxisByIndex<2>(0);
@@ -851,7 +812,6 @@ BOOST_FIXTURE_TEST_CASE(sliceByIndexTwiceSameAxis, GridContainer_Fixture) {
   BOOST_CHECK_THROW(const_slice1.fixAxisByIndex<1>(0), Elements::Exception);
   BOOST_CHECK_THROW(const_slice2.fixAxisByIndex<2>(1), Elements::Exception);
   BOOST_CHECK_THROW(const_slice3.fixAxisByIndex<3>(1), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -861,19 +821,18 @@ BOOST_FIXTURE_TEST_CASE(sliceByIndexTwiceSameAxis, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(sliceByValueNotFound, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // Then
-  BOOST_CHECK_THROW(grid.fixAxisByValue<0>(axis1.size()+1), Elements::Exception);
-  BOOST_CHECK_THROW(grid.fixAxisByValue<1>(axis2.size()+1), Elements::Exception);
-  BOOST_CHECK_THROW(grid.fixAxisByValue<2>(axis3.size()+1), Elements::Exception);
-  BOOST_CHECK_THROW(grid.fixAxisByValue<3>(axis4.size()+1), Elements::Exception);
-  BOOST_CHECK_THROW(const_grid.fixAxisByValue<0>(axis1.size()+1), Elements::Exception);
-  BOOST_CHECK_THROW(const_grid.fixAxisByValue<1>(axis2.size()+1), Elements::Exception);
-  BOOST_CHECK_THROW(const_grid.fixAxisByValue<2>(axis3.size()+1), Elements::Exception);
-  BOOST_CHECK_THROW(const_grid.fixAxisByValue<3>(axis4.size()+1), Elements::Exception);
-
+  BOOST_CHECK_THROW(grid.fixAxisByValue<0>(axis1.size() + 1), Elements::Exception);
+  BOOST_CHECK_THROW(grid.fixAxisByValue<1>(axis2.size() + 1), Elements::Exception);
+  BOOST_CHECK_THROW(grid.fixAxisByValue<2>(axis3.size() + 1), Elements::Exception);
+  BOOST_CHECK_THROW(grid.fixAxisByValue<3>(axis4.size() + 1), Elements::Exception);
+  BOOST_CHECK_THROW(const_grid.fixAxisByValue<0>(axis1.size() + 1), Elements::Exception);
+  BOOST_CHECK_THROW(const_grid.fixAxisByValue<1>(axis2.size() + 1), Elements::Exception);
+  BOOST_CHECK_THROW(const_grid.fixAxisByValue<2>(axis3.size() + 1), Elements::Exception);
+  BOOST_CHECK_THROW(const_grid.fixAxisByValue<3>(axis4.size() + 1), Elements::Exception);
 }
 
 //-----------------------------------------------------------------------------
@@ -883,14 +842,14 @@ BOOST_FIXTURE_TEST_CASE(sliceByValueNotFound, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(sliceByValueTwiceSameAxis, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // When
-  auto slice0 = grid.fixAxisByValue<0>(1);
-  auto slice1 = grid.fixAxisByValue<1>(1);
-  auto slice2 = grid.fixAxisByValue<2>(1);
-  auto slice3 = grid.fixAxisByValue<3>(1);
+  auto  slice0       = grid.fixAxisByValue<0>(1);
+  auto  slice1       = grid.fixAxisByValue<1>(1);
+  auto  slice2       = grid.fixAxisByValue<2>(1);
+  auto  slice3       = grid.fixAxisByValue<3>(1);
   auto& const_slice0 = const_grid.fixAxisByValue<0>(1);
   auto& const_slice1 = const_grid.fixAxisByValue<1>(1);
   auto& const_slice2 = const_grid.fixAxisByValue<2>(1);
@@ -905,7 +864,6 @@ BOOST_FIXTURE_TEST_CASE(sliceByValueTwiceSameAxis, GridContainer_Fixture) {
   BOOST_CHECK_THROW(const_slice1.fixAxisByValue<1>(1), Elements::Exception);
   BOOST_CHECK_THROW(const_slice2.fixAxisByValue<2>(2), Elements::Exception);
   BOOST_CHECK_THROW(const_slice3.fixAxisByValue<3>(2), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -915,19 +873,17 @@ BOOST_FIXTURE_TEST_CASE(sliceByValueTwiceSameAxis, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(sliceChancesReflected, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
-  auto slice_index = grid.fixAxisByIndex<0>(2).fixAxisByIndex<1>(2).fixAxisByIndex<2>(2).fixAxisByIndex<3>(1);
-  auto slice_value = grid.fixAxisByValue<0>(2).fixAxisByValue<1>(2).fixAxisByValue<2>(2).fixAxisByValue<3>(1);
+  GridContainerType grid{axes_tuple};
+  auto              slice_index = grid.fixAxisByIndex<0>(2).fixAxisByIndex<1>(2).fixAxisByIndex<2>(2).fixAxisByIndex<3>(1);
+  auto              slice_value = grid.fixAxisByValue<0>(2).fixAxisByValue<1>(2).fixAxisByValue<2>(2).fixAxisByValue<3>(1);
 
   // When
   *slice_index.begin() = -10;
   *slice_value.begin() = -20;
 
-
   // Then
   BOOST_CHECK_EQUAL(grid(2, 2, 2, 1), -10);
   BOOST_CHECK_EQUAL(grid(1, 1, 1, 0), -20);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -937,12 +893,12 @@ BOOST_FIXTURE_TEST_CASE(sliceChancesReflected, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(sliceAxes, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
-  const GridContainerType& const_grid = grid;
-  std::vector<int> expected_fixed_axis = {2};
+  GridContainerType        grid{axes_tuple};
+  const GridContainerType& const_grid          = grid;
+  std::vector<int>         expected_fixed_axis = {2};
 
   // When
-  auto slice = grid.fixAxisByIndex<1>(1);
+  auto  slice       = grid.fixAxisByIndex<1>(1);
   auto& const_slice = const_grid.fixAxisByIndex<1>(1);
 
   // Then
@@ -950,8 +906,8 @@ BOOST_FIXTURE_TEST_CASE(sliceAxes, GridContainer_Fixture) {
   BOOST_CHECK_EQUAL(slice.getAxis<0>().name(), axis1.name());
   BOOST_CHECK_EQUAL_COLLECTIONS(slice.getAxis<0>().begin(), slice.getAxis<0>().end(), axis1.begin(), axis1.end());
   BOOST_CHECK_EQUAL(slice.getAxis<1>().name(), axis2.name());
-  BOOST_CHECK_EQUAL_COLLECTIONS(slice.getAxis<1>().begin(), slice.getAxis<1>().end(),
-                                expected_fixed_axis.begin(), expected_fixed_axis.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(slice.getAxis<1>().begin(), slice.getAxis<1>().end(), expected_fixed_axis.begin(),
+                                expected_fixed_axis.end());
   BOOST_CHECK_EQUAL(slice.getAxis<2>().name(), axis3.name());
   BOOST_CHECK_EQUAL_COLLECTIONS(slice.getAxis<2>().begin(), slice.getAxis<2>().end(), axis3.begin(), axis3.end());
   BOOST_CHECK_EQUAL(slice.getAxis<3>().name(), axis4.name());
@@ -960,13 +916,12 @@ BOOST_FIXTURE_TEST_CASE(sliceAxes, GridContainer_Fixture) {
   BOOST_CHECK_EQUAL(const_slice.getAxis<0>().name(), axis1.name());
   BOOST_CHECK_EQUAL_COLLECTIONS(const_slice.getAxis<0>().begin(), const_slice.getAxis<0>().end(), axis1.begin(), axis1.end());
   BOOST_CHECK_EQUAL(const_slice.getAxis<1>().name(), axis2.name());
-  BOOST_CHECK_EQUAL_COLLECTIONS(const_slice.getAxis<1>().begin(), const_slice.getAxis<1>().end(),
-                                expected_fixed_axis.begin(), expected_fixed_axis.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(const_slice.getAxis<1>().begin(), const_slice.getAxis<1>().end(), expected_fixed_axis.begin(),
+                                expected_fixed_axis.end());
   BOOST_CHECK_EQUAL(const_slice.getAxis<2>().name(), axis3.name());
   BOOST_CHECK_EQUAL_COLLECTIONS(const_slice.getAxis<2>().begin(), const_slice.getAxis<2>().end(), axis3.begin(), axis3.end());
   BOOST_CHECK_EQUAL(const_slice.getAxis<3>().name(), axis4.name());
   BOOST_CHECK_EQUAL_COLLECTIONS(const_slice.getAxis<3>().begin(), const_slice.getAxis<3>().end(), axis4.begin(), axis4.end());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -976,19 +931,19 @@ BOOST_FIXTURE_TEST_CASE(sliceAxes, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(sliceIterator, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType        grid{axes_tuple};
   const GridContainerType& const_grid = grid;
 
   // When
-  auto slice = grid.fixAxisByIndex<1>(1).fixAxisByIndex<3>(0);
-  auto slice_iter = slice.begin();
-  auto grid_iter = grid.begin().fixAxisByIndex<1>(1).fixAxisByIndex<3>(0);
-  auto& const_slice = const_grid.fixAxisByIndex<1>(1).fixAxisByIndex<3>(0);
-  auto const_slice_iter = const_slice.begin();
-  auto const_grid_iter = const_grid.begin().fixAxisByIndex<1>(1).fixAxisByIndex<3>(0);
+  auto  slice            = grid.fixAxisByIndex<1>(1).fixAxisByIndex<3>(0);
+  auto  slice_iter       = slice.begin();
+  auto  grid_iter        = grid.begin().fixAxisByIndex<1>(1).fixAxisByIndex<3>(0);
+  auto& const_slice      = const_grid.fixAxisByIndex<1>(1).fixAxisByIndex<3>(0);
+  auto  const_slice_iter = const_slice.begin();
+  auto  const_grid_iter  = const_grid.begin().fixAxisByIndex<1>(1).fixAxisByIndex<3>(0);
 
   // Then
-  for (; slice_iter!=slice.end(); ++slice_iter, ++grid_iter) {
+  for (; slice_iter != slice.end(); ++slice_iter, ++grid_iter) {
     BOOST_CHECK_EQUAL(*slice_iter, *grid_iter);
     BOOST_CHECK_EQUAL(slice_iter.axisValue<0>(), grid_iter.axisValue<0>());
     BOOST_CHECK_EQUAL(slice_iter.axisValue<1>(), grid_iter.axisValue<1>());
@@ -996,7 +951,7 @@ BOOST_FIXTURE_TEST_CASE(sliceIterator, GridContainer_Fixture) {
     BOOST_CHECK_EQUAL(slice_iter.axisValue<3>(), grid_iter.axisValue<3>());
   }
   BOOST_CHECK(grid_iter == grid.end());
-  for (; const_slice_iter!=const_slice.end(); ++const_slice_iter, ++const_grid_iter) {
+  for (; const_slice_iter != const_slice.end(); ++const_slice_iter, ++const_grid_iter) {
     BOOST_CHECK_EQUAL(*const_slice_iter, *const_grid_iter);
     BOOST_CHECK_EQUAL(const_slice_iter.axisValue<0>(), const_grid_iter.axisValue<0>());
     BOOST_CHECK_EQUAL(const_slice_iter.axisValue<1>(), const_grid_iter.axisValue<1>());
@@ -1004,7 +959,6 @@ BOOST_FIXTURE_TEST_CASE(sliceIterator, GridContainer_Fixture) {
     BOOST_CHECK_EQUAL(const_slice_iter.axisValue<3>(), const_grid_iter.axisValue<3>());
   }
   BOOST_CHECK(const_grid_iter == const_grid.end());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -1014,8 +968,8 @@ BOOST_FIXTURE_TEST_CASE(sliceIterator, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(sliceParenthesisOperator, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
-  double custom_value = 0;
+  GridContainerType grid{axes_tuple};
+  double            custom_value = 0;
   for (auto& cell : grid) {
     custom_value += 0.1;
     cell = custom_value;
@@ -1025,8 +979,8 @@ BOOST_FIXTURE_TEST_CASE(sliceParenthesisOperator, GridContainer_Fixture) {
   auto slice = grid.fixAxisByIndex<1>(2).fixAxisByIndex<3>(1);
 
   // Then
-  for (size_t coord1=0; coord1<axis1.size(); ++coord1) {
-    for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
+  for (size_t coord1 = 0; coord1 < axis1.size(); ++coord1) {
+    for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
       BOOST_CHECK_EQUAL(slice(coord1, 0, coord3, 0), grid(coord1, 2, coord3, 1));
     }
   }
@@ -1039,8 +993,8 @@ BOOST_FIXTURE_TEST_CASE(sliceParenthesisOperator, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(sliceAtOperator, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
-  double custom_value = 0;
+  GridContainerType grid{axes_tuple};
+  double            custom_value = 0;
   for (auto& cell : grid) {
     custom_value += 0.1;
     cell = custom_value;
@@ -1050,12 +1004,11 @@ BOOST_FIXTURE_TEST_CASE(sliceAtOperator, GridContainer_Fixture) {
   auto slice = grid.fixAxisByIndex<1>(2).fixAxisByIndex<3>(1);
 
   // Then
-  for (size_t coord1=0; coord1<axis1.size(); ++coord1) {
-    for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
+  for (size_t coord1 = 0; coord1 < axis1.size(); ++coord1) {
+    for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
       BOOST_CHECK_EQUAL(slice.at(coord1, 0, coord3, 0), grid(coord1, 2, coord3, 1));
     }
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -1065,7 +1018,7 @@ BOOST_FIXTURE_TEST_CASE(sliceAtOperator, GridContainer_Fixture) {
 BOOST_FIXTURE_TEST_CASE(sliceFixAxisNonZeroIndexAccess, GridContainer_Fixture) {
 
   // Given
-  GridContainerType grid {axes_tuple};
+  GridContainerType grid{axes_tuple};
 
   // When
   auto slice = grid.fixAxisByIndex<0>(0).fixAxisByIndex<1>(2).fixAxisByIndex<2>(2).fixAxisByIndex<3>(1);
@@ -1076,9 +1029,8 @@ BOOST_FIXTURE_TEST_CASE(sliceFixAxisNonZeroIndexAccess, GridContainer_Fixture) {
   BOOST_CHECK_THROW(slice.at(0, 1, 0, 0), Elements::Exception);
   BOOST_CHECK_THROW(slice.at(0, 0, 1, 0), Elements::Exception);
   BOOST_CHECK_THROW(slice.at(0, 0, 0, 1), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/GridContainer/tests/src/GridIndexHelper_test.cpp
+++ b/GridContainer/tests/src/GridIndexHelper_test.cpp
@@ -1,60 +1,60 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file tests/src/GridIndexHelper_test.cpp
  * @date July 3, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
 #include "ElementsKernel/Exception.h"
 #include "GridContainer/GridIndexHelper.h"
+#include <boost/test/unit_test.hpp>
 
 struct GridIndexHelper_Fixture {
-  typedef Euclid::GridContainer::GridAxis<int> IntAxis;
-  IntAxis axis1 {"Axis 1", {1, 2, 3, 4, 5}};
-  IntAxis axis2 {"Axis 2", {1, 2, 3}};
-  IntAxis axis3 {"Axis 3", {1, 2, 3, 4, 5, 6}};
-  IntAxis axis4 {"Axis 4", {1, 2}};
-  std::tuple<IntAxis, IntAxis, IntAxis, IntAxis> axes_tuple {axis1, axis2, axis3, axis4};
-  size_t total_size = axis1.size() * axis2.size() * axis3.size() * axis4.size();
+  typedef Euclid::GridContainer::GridAxis<int>   IntAxis;
+  IntAxis                                        axis1{"Axis 1", {1, 2, 3, 4, 5}};
+  IntAxis                                        axis2{"Axis 2", {1, 2, 3}};
+  IntAxis                                        axis3{"Axis 3", {1, 2, 3, 4, 5, 6}};
+  IntAxis                                        axis4{"Axis 4", {1, 2}};
+  std::tuple<IntAxis, IntAxis, IntAxis, IntAxis> axes_tuple{axis1, axis2, axis3, axis4};
+  size_t                                         total_size = axis1.size() * axis2.size() * axis3.size() * axis4.size();
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (GridIndexHelper_test)
+BOOST_AUTO_TEST_SUITE(GridIndexHelper_test)
 
 //-----------------------------------------------------------------------------
 // Test the axisIndex method
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(axisIndex, GridIndexHelper_Fixture) {
-  
+
   // When
   auto helper = Euclid::GridContainer::makeGridIndexHelper(axes_tuple);
-            
+
   // Then
-  size_t array_index {0};
-  for (size_t coord4=0; coord4<axis4.size(); ++coord4) {
-    for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
-      for (size_t coord2=0; coord2<axis2.size(); ++coord2) {
-        for (size_t coord1=0; coord1<axis1.size(); ++coord1) {
+  size_t array_index{0};
+  for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
+    for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
+      for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
+        for (size_t coord1 = 0; coord1 < axis1.size(); ++coord1) {
           BOOST_CHECK_EQUAL(helper.axisIndex(0, array_index), coord1);
           BOOST_CHECK_EQUAL(helper.axisIndex(1, array_index), coord2);
           BOOST_CHECK_EQUAL(helper.axisIndex(2, array_index), coord3);
@@ -64,74 +64,70 @@ BOOST_FIXTURE_TEST_CASE(axisIndex, GridIndexHelper_Fixture) {
       }
     }
   }
-  
 }
 
 //-----------------------------------------------------------------------------
 // Test the totalIndex method
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(totalIndex, GridIndexHelper_Fixture) {
-  
+
   // When
   auto helper = Euclid::GridContainer::makeGridIndexHelper(axes_tuple);
-            
+
   // Then
-  size_t array_index {0};
-  for (size_t coord4=0; coord4<axis4.size(); ++coord4) {
-    for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
-      for (size_t coord2=0; coord2<axis2.size(); ++coord2) {
-        for (size_t coord1=0; coord1<axis1.size(); ++coord1) {
+  size_t array_index{0};
+  for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
+    for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
+      for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
+        for (size_t coord1 = 0; coord1 < axis1.size(); ++coord1) {
           BOOST_CHECK_EQUAL(helper.totalIndex(coord1, coord2, coord3, coord4), array_index);
           ++array_index;
         }
       }
     }
   }
-  
 }
 
 //-----------------------------------------------------------------------------
 // Test the totalIndexChecked method
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(totalIndexChecked, GridIndexHelper_Fixture) {
-  
+
   // When
   auto helper = Euclid::GridContainer::makeGridIndexHelper(axes_tuple);
-            
+
   // Then
-  size_t array_index {0};
-  for (size_t coord4=0; coord4<axis4.size(); ++coord4) {
-    for (size_t coord3=0; coord3<axis3.size(); ++coord3) {
-      for (size_t coord2=0; coord2<axis2.size(); ++coord2) {
-        for (size_t coord1=0; coord1<axis1.size(); ++coord1) {
+  size_t array_index{0};
+  for (size_t coord4 = 0; coord4 < axis4.size(); ++coord4) {
+    for (size_t coord3 = 0; coord3 < axis3.size(); ++coord3) {
+      for (size_t coord2 = 0; coord2 < axis2.size(); ++coord2) {
+        for (size_t coord1 = 0; coord1 < axis1.size(); ++coord1) {
           BOOST_CHECK_EQUAL(helper.totalIndexChecked(coord1, coord2, coord3, coord4), array_index);
           ++array_index;
         }
       }
     }
   }
-  
 }
 
 //-----------------------------------------------------------------------------
 // Test the totalIndexChecked method throws out of bound exception
 //-----------------------------------------------------------------------------
-    
+
 BOOST_FIXTURE_TEST_CASE(totalIndexCheckedOutOfBounds, GridIndexHelper_Fixture) {
-  
+
   // When
   auto helper = Euclid::GridContainer::makeGridIndexHelper(axes_tuple);
-            
+
   // Then
   BOOST_CHECK_THROW(helper.totalIndexChecked(axis1.size(), 0, 0, 0), Elements::Exception);
   BOOST_CHECK_THROW(helper.totalIndexChecked(0, axis2.size(), 0, 0), Elements::Exception);
   BOOST_CHECK_THROW(helper.totalIndexChecked(0, 0, axis3.size(), 0), Elements::Exception);
   BOOST_CHECK_THROW(helper.totalIndexChecked(0, 0, 0, axis4.size()), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/GridContainer/tests/src/serialization/DefaultConstructibleClass.h
+++ b/GridContainer/tests/src/serialization/DefaultConstructibleClass.h
@@ -1,29 +1,29 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file tests/src/serialization/DefaultConstructibleClass.h
  * @date June 27, 2014
  * @author Nikolaos Apostolakos
  */
 
 #ifndef GRIDCONTAINER_DEFAULTCONSTRUCTIBLECLASS_H
-#define	GRIDCONTAINER_DEFAULTCONSTRUCTIBLECLASS_H
+#define GRIDCONTAINER_DEFAULTCONSTRUCTIBLECLASS_H
 
 class DefaultConstructibleClass {
 public:
@@ -34,13 +34,12 @@ public:
 namespace boost {
 namespace serialization {
 
-template<typename Archive>
+template <typename Archive>
 void serialize(Archive& ar, DefaultConstructibleClass& c, const unsigned int) {
-  ar & c.value;
+  ar& c.value;
 }
 
-}
-}
+}  // namespace serialization
+}  // namespace boost
 
-#endif	/* GRIDCONTAINER_DEFAULTCONSTRUCTIBLECLASS_H */
-
+#endif /* GRIDCONTAINER_DEFAULTCONSTRUCTIBLECLASS_H */

--- a/GridContainer/tests/src/serialization/GridAxis_test.cpp
+++ b/GridContainer/tests/src/serialization/GridAxis_test.cpp
@@ -16,28 +16,28 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/serialization/GridAxis_test.cpp
  * @date June 27, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <sstream>
-#include <boost/test/unit_test.hpp>
-#include <boost/test/test_tools.hpp>
+#include "DefaultConstructibleClass.h"
+#include "GridContainer/GridAxis.h"
+#include "GridContainer/serialization/GridAxis.h"
+#include "NonDefaultConstructibleClass.h"
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/mpl/list.hpp>
-#include "GridContainer/GridAxis.h"
-#include "GridContainer/serialization/GridAxis.h"
-#include "DefaultConstructibleClass.h"
-#include "NonDefaultConstructibleClass.h"
+#include <boost/test/test_tools.hpp>
+#include <boost/test/unit_test.hpp>
+#include <sstream>
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (GridAxis_serialization_test)
+BOOST_AUTO_TEST_SUITE(GridAxis_serialization_test)
 
 template <typename I, typename O>
 struct archive {
@@ -46,7 +46,7 @@ struct archive {
 };
 
 typedef archive<boost::archive::binary_iarchive, boost::archive::binary_oarchive> binary_archive;
-typedef archive<boost::archive::text_iarchive, boost::archive::text_oarchive> text_archive;
+typedef archive<boost::archive::text_iarchive, boost::archive::text_oarchive>     text_archive;
 
 typedef boost::mpl::list<binary_archive, text_archive> archive_types;
 
@@ -57,12 +57,12 @@ typedef boost::mpl::list<binary_archive, text_archive> archive_types;
 BOOST_AUTO_TEST_CASE_TEMPLATE(fundamentalKnotValues, T, archive_types) {
 
   // Given
-  std::string name = "AxisName";
-  std::vector<double> knots {0., 3.4, 12E-15};
-  Euclid::GridContainer::GridAxis<double> axis {name, knots};
+  std::string                             name = "AxisName";
+  std::vector<double>                     knots{0., 3.4, 12E-15};
+  Euclid::GridContainer::GridAxis<double> axis{name, knots};
 
   // When
-  std::stringstream stream {};
+  std::stringstream stream{};
 
   // We write to the stream a pointer to enable the non-default constructor
   // functionality of boost serialization
@@ -78,12 +78,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(fundamentalKnotValues, T, archive_types) {
     bia >> result;
   }
   // We use a unique_ptr for the memory management
-  std::unique_ptr<Euclid::GridContainer::GridAxis<double>> result_ptr {result};
+  std::unique_ptr<Euclid::GridContainer::GridAxis<double>> result_ptr{result};
 
   // Then
   BOOST_CHECK_EQUAL(result_ptr->name(), name);
   BOOST_CHECK_EQUAL_COLLECTIONS(result_ptr->begin(), result_ptr->end(), knots.begin(), knots.end());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -93,23 +92,23 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(fundamentalKnotValues, T, archive_types) {
 BOOST_AUTO_TEST_CASE_TEMPLATE(defaultConstructibleKnotValues, T, archive_types) {
 
   // Given
-  std::string name = "AxisName";
-  std::vector<DefaultConstructibleClass> knots {};
+  std::string                            name = "AxisName";
+  std::vector<DefaultConstructibleClass> knots{};
   knots.push_back(DefaultConstructibleClass{});
   knots.back().value = 0.;
   knots.push_back(DefaultConstructibleClass{});
   knots.back().value = 3.4;
   knots.push_back(DefaultConstructibleClass{});
   knots.back().value = 12E-15;
-  Euclid::GridContainer::GridAxis<DefaultConstructibleClass> axis {name, knots};
+  Euclid::GridContainer::GridAxis<DefaultConstructibleClass> axis{name, knots};
 
   // When
-  std::stringstream stream {};
+  std::stringstream stream{};
   {
     typename T::oarchive boa{stream};
     // We write to the stream a pointer to enable the non-default constructor
     // functionality of boost serialization
-    Euclid::GridContainer::GridAxis<DefaultConstructibleClass> *axis_ptr = &axis;
+    Euclid::GridContainer::GridAxis<DefaultConstructibleClass>* axis_ptr = &axis;
     boa << axis_ptr;
   }
   Euclid::GridContainer::GridAxis<DefaultConstructibleClass>* result;
@@ -118,19 +117,18 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(defaultConstructibleKnotValues, T, archive_types) 
     bia >> result;
   }
   // We use a unique_ptr for the memory management
-  std::unique_ptr<Euclid::GridContainer::GridAxis<DefaultConstructibleClass>> result_ptr {result};
+  std::unique_ptr<Euclid::GridContainer::GridAxis<DefaultConstructibleClass>> result_ptr{result};
 
   // Then
   BOOST_CHECK_EQUAL(result_ptr->name(), name);
   BOOST_CHECK_EQUAL(result_ptr->size(), knots.size());
   auto result_iter = result_ptr->begin();
-  auto knots_iter = knots.begin();
+  auto knots_iter  = knots.begin();
   while (result_iter != result_ptr->end()) {
     BOOST_CHECK_EQUAL(result_iter->value, knots_iter->value);
     ++result_iter;
-    ++ knots_iter;
+    ++knots_iter;
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -140,20 +138,20 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(defaultConstructibleKnotValues, T, archive_types) 
 BOOST_AUTO_TEST_CASE_TEMPLATE(nonDefaultConstructibleKnotValues, T, archive_types) {
 
   // Given
-  std::string name = "AxisName";
-  std::vector<NonDefaultConstructibleClass> knots {};
+  std::string                               name = "AxisName";
+  std::vector<NonDefaultConstructibleClass> knots{};
   knots.push_back(NonDefaultConstructibleClass{0.});
   knots.push_back(NonDefaultConstructibleClass{3.4});
   knots.push_back(NonDefaultConstructibleClass{12E-15});
-  Euclid::GridContainer::GridAxis<NonDefaultConstructibleClass> axis {name, knots};
+  Euclid::GridContainer::GridAxis<NonDefaultConstructibleClass> axis{name, knots};
 
   // When
-  std::stringstream stream {};
+  std::stringstream stream{};
   {
     typename T::oarchive boa{stream};
     // We write to the stream a pointer to enable the non-default constructor
     // functionality of boost serialization
-    Euclid::GridContainer::GridAxis<NonDefaultConstructibleClass> *axis_ptr = &axis;
+    Euclid::GridContainer::GridAxis<NonDefaultConstructibleClass>* axis_ptr = &axis;
     boa << axis_ptr;
   }
   Euclid::GridContainer::GridAxis<NonDefaultConstructibleClass>* result;
@@ -162,22 +160,20 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(nonDefaultConstructibleKnotValues, T, archive_type
     bia >> result;
   }
   // We use a unique_ptr for the memory management
-  std::unique_ptr<Euclid::GridContainer::GridAxis<NonDefaultConstructibleClass>> result_ptr {result};
+  std::unique_ptr<Euclid::GridContainer::GridAxis<NonDefaultConstructibleClass>> result_ptr{result};
 
   // Then
   BOOST_CHECK_EQUAL(result_ptr->name(), name);
   BOOST_CHECK_EQUAL(result_ptr->size(), knots.size());
   auto result_iter = result_ptr->begin();
-  auto knots_iter = knots.begin();
+  auto knots_iter  = knots.begin();
   while (result_iter != result_ptr->end()) {
     BOOST_CHECK_EQUAL(result_iter->value, knots_iter->value);
     ++result_iter;
-    ++ knots_iter;
+    ++knots_iter;
   }
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/GridContainer/tests/src/serialization/NonDefaultConstructibleClass.h
+++ b/GridContainer/tests/src/serialization/NonDefaultConstructibleClass.h
@@ -16,14 +16,14 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/serialization/NonDefaultConstructibleClass.h
  * @date June 27, 2014
  * @author Nikolaos Apostolakos
  */
 
 #ifndef GRIDCONTAINER_NONDEFAULTCONSTRUCTIBLECLASS_H
-#define	GRIDCONTAINER_NONDEFAULTCONSTRUCTIBLECLASS_H
+#define GRIDCONTAINER_NONDEFAULTCONSTRUCTIBLECLASS_H
 
 #include "GridContainer/GridCellManagerTraits.h"
 
@@ -36,36 +36,37 @@ public:
 namespace boost {
 namespace serialization {
 
-template<typename Archive>
-void serialize(Archive&, NonDefaultConstructibleClass&, const unsigned int) { }
+template <typename Archive>
+void serialize(Archive&, NonDefaultConstructibleClass&, const unsigned int) {}
 
-template<typename Archive>
-void save_construct_data(Archive &ar, const NonDefaultConstructibleClass* p, const unsigned int) {
+template <typename Archive>
+void save_construct_data(Archive& ar, const NonDefaultConstructibleClass* p, const unsigned int) {
   double v = p->value;
   ar << v;
 }
 
-template<typename Archive>
-void load_construct_data(Archive &ar, NonDefaultConstructibleClass* p, const unsigned int) {
+template <typename Archive>
+void load_construct_data(Archive& ar, NonDefaultConstructibleClass* p, const unsigned int) {
   double v;
   ar >> v;
-  ::new(p) NonDefaultConstructibleClass(v);
+  ::new (p) NonDefaultConstructibleClass(v);
 }
 
-}
-}
+}  // namespace serialization
+}  // namespace boost
 
 namespace Euclid {
 namespace GridContainer {
 
-template<>
+template <>
 struct GridCellManagerTraits<std::vector<NonDefaultConstructibleClass>> {
-  typedef NonDefaultConstructibleClass data_type;
+  typedef NonDefaultConstructibleClass                                 data_type;
   typedef typename std::vector<NonDefaultConstructibleClass>::iterator iterator;
-  static std::unique_ptr<std::vector<NonDefaultConstructibleClass>> factory(size_t size) {
-    return std::unique_ptr<std::vector<NonDefaultConstructibleClass>> {new std::vector<NonDefaultConstructibleClass>(size, NonDefaultConstructibleClass{0})};
+  static std::unique_ptr<std::vector<NonDefaultConstructibleClass>>    factory(size_t size) {
+    return std::unique_ptr<std::vector<NonDefaultConstructibleClass>>{
+        new std::vector<NonDefaultConstructibleClass>(size, NonDefaultConstructibleClass{0})};
   }
-  static size_t size(const std::vector<NonDefaultConstructibleClass>& vector){
+  static size_t size(const std::vector<NonDefaultConstructibleClass>& vector) {
     return vector.size();
   }
   static iterator begin(std::vector<NonDefaultConstructibleClass>& vector) {
@@ -75,11 +76,9 @@ struct GridCellManagerTraits<std::vector<NonDefaultConstructibleClass>> {
     return vector.end();
   }
   static const bool enable_boost_serialize = true;
-
 };
 
-}
-} // end of namespace Euclid
+}  // namespace GridContainer
+}  // end of namespace Euclid
 
-#endif	/* GRIDCONTAINER_NONDEFAULTCONSTRUCTIBLECLASS_H */
-
+#endif /* GRIDCONTAINER_NONDEFAULTCONSTRUCTIBLECLASS_H */

--- a/GridContainer/tests/src/serialization/tuple_test.cpp
+++ b/GridContainer/tests/src/serialization/tuple_test.cpp
@@ -1,187 +1,180 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file tests/src/serialization/tuple_test.cpp
  * @date June 27, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <sstream>
-#include <tuple>
-#include <boost/test/unit_test.hpp>
-#include <boost/archive/binary_iarchive.hpp>
-#include <boost/archive/binary_oarchive.hpp>
+#include "DefaultConstructibleClass.h"
 #include "GridContainer/serialization/GridAxis.h"
 #include "GridContainer/serialization/tuple.h"
-#include "DefaultConstructibleClass.h"
 #include "NonDefaultConstructibleClass.h"
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/test/unit_test.hpp>
+#include <sstream>
+#include <tuple>
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (tuple_serialization_test)
+BOOST_AUTO_TEST_SUITE(tuple_serialization_test)
 
 //-----------------------------------------------------------------------------
 // Test serialization of tuple with fundamental values
 //-----------------------------------------------------------------------------
-    
+
 BOOST_AUTO_TEST_CASE(fundamentalValues) {
-  
+
   // Given
-  std::tuple<double, double, double> tuple {1E-12, 5., 3.4};
-  
+  std::tuple<double, double, double> tuple{1E-12, 5., 3.4};
+
   // When
-  std::stringstream stream {};
-  boost::archive::binary_oarchive boa {stream};
+  std::stringstream               stream{};
+  boost::archive::binary_oarchive boa{stream};
   boa << tuple;
   // Note that we must force the types we will read
   std::tuple<double, double, double> result;
-  boost::archive::binary_iarchive bia {stream};
+  boost::archive::binary_iarchive    bia{stream};
   bia >> result;
-  
+
   // Then
   BOOST_CHECK_EQUAL(std::get<0>(result), std::get<0>(tuple));
   BOOST_CHECK_EQUAL(std::get<1>(result), std::get<1>(tuple));
   BOOST_CHECK_EQUAL(std::get<2>(result), std::get<2>(tuple));
-  
 }
 
 //-----------------------------------------------------------------------------
 // Test serialization of tuple with default constructible values
 //-----------------------------------------------------------------------------
-    
+
 BOOST_AUTO_TEST_CASE(defaultConstructibleValues) {
-  
+
   typedef DefaultConstructibleClass DCC;
   // Given
-  std::tuple<DCC, DCC, DCC> tuple {};
+  std::tuple<DCC, DCC, DCC> tuple{};
   std::get<0>(tuple).value = 1E-12;
   std::get<1>(tuple).value = 5.;
   std::get<2>(tuple).value = 3.4;
-  
+
   // When
-  std::stringstream stream {};
-  boost::archive::binary_oarchive boa {stream};
+  std::stringstream               stream{};
+  boost::archive::binary_oarchive boa{stream};
   boa << tuple;
   // Note that we must force the types we will read
-  std::tuple<DCC, DCC, DCC> result;
-  boost::archive::binary_iarchive bia {stream};
+  std::tuple<DCC, DCC, DCC>       result;
+  boost::archive::binary_iarchive bia{stream};
   bia >> result;
-  
+
   // Then
   BOOST_CHECK_EQUAL(std::get<0>(result).value, std::get<0>(tuple).value);
   BOOST_CHECK_EQUAL(std::get<1>(result).value, std::get<1>(tuple).value);
   BOOST_CHECK_EQUAL(std::get<2>(result).value, std::get<2>(tuple).value);
-  
 }
 
 //-----------------------------------------------------------------------------
 // Test serialization of tuple with non default constructible values
 //-----------------------------------------------------------------------------
-    
+
 BOOST_AUTO_TEST_CASE(nonDefaultConstructibleValues) {
-  
+
   typedef NonDefaultConstructibleClass NDCC;
   // Given
-  std::tuple<NDCC, NDCC, NDCC> tuple {1E-12, 5., 3.4};
-  
+  std::tuple<NDCC, NDCC, NDCC> tuple{1E-12, 5., 3.4};
+
   // When
-  std::stringstream stream {};
-  boost::archive::binary_oarchive boa {stream};
+  std::stringstream               stream{};
+  boost::archive::binary_oarchive boa{stream};
   boa << tuple;
   // Note that we must force the types we will read and that we have to use
   // some dummy default values which will be replaced with the ones from the
   // stream
-  std::tuple<NDCC, NDCC, NDCC> result {0., 0., 0.};
-  boost::archive::binary_iarchive bia {stream};
+  std::tuple<NDCC, NDCC, NDCC>    result{0., 0., 0.};
+  boost::archive::binary_iarchive bia{stream};
   bia >> result;
-  
+
   // Then
   BOOST_CHECK_EQUAL(std::get<0>(result).value, std::get<0>(tuple).value);
   BOOST_CHECK_EQUAL(std::get<1>(result).value, std::get<1>(tuple).value);
   BOOST_CHECK_EQUAL(std::get<2>(result).value, std::get<2>(tuple).value);
-  
 }
 
 //-----------------------------------------------------------------------------
 // Test serialization of tuple with combination of values
 //-----------------------------------------------------------------------------
-    
+
 BOOST_AUTO_TEST_CASE(combinationOfValues) {
-  
-  typedef DefaultConstructibleClass DCC;
+
+  typedef DefaultConstructibleClass    DCC;
   typedef NonDefaultConstructibleClass NDCC;
-  
+
   // Given
-  std::string name0 = "FundamentalAxis";
-  std::vector<double> knots0 {0., 3.4, 12E-15};
-  Euclid::GridContainer::GridAxis<double> axis0 {name0, knots0};
-  std::string name1 = "DefaultConstructibleAxis";
-  std::vector<DCC> knots1 {DCC{}, DCC{}, DCC{}};
+  std::string                             name0 = "FundamentalAxis";
+  std::vector<double>                     knots0{0., 3.4, 12E-15};
+  Euclid::GridContainer::GridAxis<double> axis0{name0, knots0};
+  std::string                             name1 = "DefaultConstructibleAxis";
+  std::vector<DCC>                        knots1{DCC{}, DCC{}, DCC{}};
   knots1[0].value = 0.;
   knots1[1].value = 3.4;
   knots1[2].value = 12E-15;
-  Euclid::GridContainer::GridAxis<DCC> axis1 {name1, knots1};
-  std::string name2 = "NonDefaultConstructibleAxis";
-  std::vector<NDCC> knots2 {};
+  Euclid::GridContainer::GridAxis<DCC> axis1{name1, knots1};
+  std::string                          name2 = "NonDefaultConstructibleAxis";
+  std::vector<NDCC>                    knots2{};
   knots2.push_back(NDCC{0.});
   knots2.push_back(NDCC{3.4});
   knots2.push_back(NDCC{12E-15});
-  Euclid::GridContainer::GridAxis<NDCC> axis2 {name2, knots2};
-  auto tuple = std::make_tuple(axis0, axis1, axis2);
-  
+  Euclid::GridContainer::GridAxis<NDCC> axis2{name2, knots2};
+  auto                                  tuple = std::make_tuple(axis0, axis1, axis2);
+
   // When
-  std::stringstream stream {};
-  boost::archive::binary_oarchive boa {stream};
+  std::stringstream               stream{};
+  boost::archive::binary_oarchive boa{stream};
   boa << tuple;
   // Note that we must force the types we will read and that we have to use
   // some dummy default values which will be replaced with the ones from the
   // stream
-  auto result = std::make_tuple(
-    Euclid::GridContainer::GridAxis<double>{"", {}},
-    Euclid::GridContainer::GridAxis<DCC>{"", {}},
-    Euclid::GridContainer::GridAxis<NDCC>{"", {}}
-  );
-  boost::archive::binary_iarchive bia {stream};
+  auto result = std::make_tuple(Euclid::GridContainer::GridAxis<double>{"", {}}, Euclid::GridContainer::GridAxis<DCC>{"", {}},
+                                Euclid::GridContainer::GridAxis<NDCC>{"", {}});
+  boost::archive::binary_iarchive bia{stream};
   bia >> result;
-  
+
   // Then
   BOOST_CHECK_EQUAL(std::get<0>(result).name(), name0);
   BOOST_CHECK_EQUAL_COLLECTIONS(std::get<0>(result).begin(), std::get<0>(result).end(), knots0.begin(), knots0.end());
   BOOST_CHECK_EQUAL(std::get<1>(result).name(), name1);
   BOOST_CHECK_EQUAL(std::get<1>(result).size(), knots1.size());
   auto result_iter1 = std::get<1>(result).begin();
-  auto knots_iter1 = knots1.begin();
+  auto knots_iter1  = knots1.begin();
   while (result_iter1 != std::get<1>(result).end()) {
     BOOST_CHECK_EQUAL(result_iter1->value, knots_iter1->value);
     ++result_iter1;
-    ++ knots_iter1;
+    ++knots_iter1;
   }
   BOOST_CHECK_EQUAL(std::get<2>(result).name(), name2);
   BOOST_CHECK_EQUAL(std::get<2>(result).size(), knots2.size());
   auto result_iter2 = std::get<2>(result).begin();
-  auto knots_iter2 = knots2.begin();
+  auto knots_iter2  = knots2.begin();
   while (result_iter2 != std::get<2>(result).end()) {
     BOOST_CHECK_EQUAL(result_iter2->value, knots_iter2->value);
     ++result_iter2;
-    ++ knots_iter2;
+    ++knots_iter2;
   }
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -190,33 +183,32 @@ BOOST_AUTO_TEST_CASE(combinationOfValues) {
 // that this test might detect problems related with the GridAxis serialization
 // and not the tuple per se.
 //-----------------------------------------------------------------------------
-    
+
 BOOST_AUTO_TEST_CASE(gridAxesValues) {
-  
-  typedef DefaultConstructibleClass DCC;
+
+  typedef DefaultConstructibleClass    DCC;
   typedef NonDefaultConstructibleClass NDCC;
   // Given
-  std::tuple<double, DCC, NDCC> tuple {1E-12, {}, 3.4};
+  std::tuple<double, DCC, NDCC> tuple{1E-12, {}, 3.4};
   std::get<1>(tuple).value = 5.;
-  
+
   // When
-  std::stringstream stream {};
-  boost::archive::binary_oarchive boa {stream};
+  std::stringstream               stream{};
+  boost::archive::binary_oarchive boa{stream};
   boa << tuple;
   // Note that we must force the types we will read and that we have to use
   // some dummy default values which will be replaced with the ones from the
   // stream
-  std::tuple<double, DCC, NDCC> result {0., {}, 0.};
-  boost::archive::binary_iarchive bia {stream};
+  std::tuple<double, DCC, NDCC>   result{0., {}, 0.};
+  boost::archive::binary_iarchive bia{stream};
   bia >> result;
-  
+
   // Then
   BOOST_CHECK_EQUAL(std::get<0>(result), std::get<0>(tuple));
   BOOST_CHECK_EQUAL(std::get<1>(result).value, std::get<1>(tuple).value);
   BOOST_CHECK_EQUAL(std::get<2>(result).value, std::get<2>(tuple).value);
-  
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/GridContainer/tests/src/serialize_test.cpp
+++ b/GridContainer/tests/src/serialize_test.cpp
@@ -16,26 +16,25 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file serialize_test.cpp
  * @date July 7, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <sstream>
-#include <boost/test/unit_test.hpp>
-#include <boost/test/test_tools.hpp>
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
 #include "ElementsKernel/Temporary.h"
 #include "GridContainer/serialize.h"
 #include "serialization/DefaultConstructibleClass.h"
 #include "serialization/NonDefaultConstructibleClass.h"
-
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/test/test_tools.hpp>
+#include <boost/test/unit_test.hpp>
+#include <sstream>
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (serialize_test)
+BOOST_AUTO_TEST_SUITE(serialize_test)
 
 template <typename I, typename O>
 struct archive {
@@ -44,7 +43,7 @@ struct archive {
 };
 
 typedef archive<boost::archive::binary_iarchive, boost::archive::binary_oarchive> binary_archive;
-typedef archive<boost::archive::text_iarchive, boost::archive::text_oarchive> text_archive;
+typedef archive<boost::archive::text_iarchive, boost::archive::text_oarchive>     text_archive;
 
 typedef boost::mpl::list<binary_archive, text_archive> archive_types;
 
@@ -54,35 +53,35 @@ typedef boost::mpl::list<binary_archive, text_archive> archive_types;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(GridContainerSerializationDefaultConstructibleCells, T, archive_types) {
 
-  typedef DefaultConstructibleClass DCC;
-  typedef NonDefaultConstructibleClass NDCC;
+  typedef DefaultConstructibleClass                                                 DCC;
+  typedef NonDefaultConstructibleClass                                              NDCC;
   typedef Euclid::GridContainer::GridContainer<std::vector<DCC>, double, DCC, NDCC> GridContainerType;
 
   // Given
-  std::string name0 = "FundamentalAxis";
-  std::vector<double> knots0 {0., 3.4, 12E-15};
-  Euclid::GridContainer::GridAxis<double> axis0 {name0, knots0};
-  std::string name1 = "DefaultConstructibleAxis";
-  std::vector<DCC> knots1 {DCC{}, DCC{}, DCC{}};
+  std::string                             name0 = "FundamentalAxis";
+  std::vector<double>                     knots0{0., 3.4, 12E-15};
+  Euclid::GridContainer::GridAxis<double> axis0{name0, knots0};
+  std::string                             name1 = "DefaultConstructibleAxis";
+  std::vector<DCC>                        knots1{DCC{}, DCC{}, DCC{}};
   knots1[0].value = 0.;
   knots1[1].value = 3.4;
   knots1[2].value = 12E-15;
-  Euclid::GridContainer::GridAxis<DCC> axis1 {name1, knots1};
-  std::string name2 = "NonDefaultConstructibleAxis";
-  std::vector<NDCC> knots2 {};
+  Euclid::GridContainer::GridAxis<DCC> axis1{name1, knots1};
+  std::string                          name2 = "NonDefaultConstructibleAxis";
+  std::vector<NDCC>                    knots2{};
   knots2.push_back(NDCC{0.});
   knots2.push_back(NDCC{3.4});
   knots2.push_back(NDCC{12E-15});
-  Euclid::GridContainer::GridAxis<NDCC> axis2 {name2, knots2};
-  GridContainerType grid {axis0, axis1, axis2};
-  double value {0.};
+  Euclid::GridContainer::GridAxis<NDCC> axis2{name2, knots2};
+  GridContainerType                     grid{axis0, axis1, axis2};
+  double                                value{0.};
   for (auto& cell : grid) {
     cell.value = value;
     value += 0.1;
   }
 
   // When
-  std::stringstream stream {};
+  std::stringstream stream{};
   Euclid::GridContainer::gridExport<typename T::oarchive>(stream, grid);
 
   GridContainerType result = Euclid::GridContainer::gridImport<GridContainerType, typename T::iarchive>(stream);
@@ -90,36 +89,33 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(GridContainerSerializationDefaultConstructibleCell
   // Then
   BOOST_CHECK_EQUAL(result.axisNumber(), 3u);
   BOOST_CHECK_EQUAL(result.getAxis<0>().name(), name0);
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      result.getAxis<0>().begin(), result.getAxis<0>().end(),
-      knots0.begin(), knots0.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(result.getAxis<0>().begin(), result.getAxis<0>().end(), knots0.begin(), knots0.end());
   BOOST_CHECK_EQUAL(result.getAxis<1>().name(), name1);
   BOOST_CHECK_EQUAL(result.getAxis<1>().size(), knots1.size());
   auto result_iter1 = result.getAxis<1>().begin();
-  auto knots_iter1 = knots1.begin();
+  auto knots_iter1  = knots1.begin();
   while (result_iter1 != result.getAxis<1>().end()) {
     BOOST_CHECK_EQUAL(result_iter1->value, knots_iter1->value);
     ++result_iter1;
-    ++ knots_iter1;
+    ++knots_iter1;
   }
   BOOST_CHECK_EQUAL(result.getAxis<2>().name(), name2);
   BOOST_CHECK_EQUAL(result.getAxis<2>().size(), knots2.size());
   auto result_iter2 = result.getAxis<2>().begin();
-  auto knots_iter2 = knots2.begin();
+  auto knots_iter2  = knots2.begin();
   while (result_iter2 != result.getAxis<2>().end()) {
     BOOST_CHECK_EQUAL(result_iter2->value, knots_iter2->value);
     ++result_iter2;
-    ++ knots_iter2;
+    ++knots_iter2;
   }
   BOOST_CHECK_EQUAL(result.size(), grid.size());
   auto result_iter = result.begin();
-  auto grid_iter = grid.begin();
+  auto grid_iter   = grid.begin();
   while (result_iter != result.end()) {
     BOOST_CHECK_EQUAL((*result_iter).value, (*grid_iter).value);
     ++result_iter;
     ++grid_iter;
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -128,71 +124,68 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(GridContainerSerializationDefaultConstructibleCell
 
 BOOST_AUTO_TEST_CASE(GridContainerSerializationNonDefaultConstructibleCells) {
 
-  typedef DefaultConstructibleClass DCC;
-  typedef NonDefaultConstructibleClass NDCC;
+  typedef DefaultConstructibleClass                                                  DCC;
+  typedef NonDefaultConstructibleClass                                               NDCC;
   typedef Euclid::GridContainer::GridContainer<std::vector<NDCC>, double, DCC, NDCC> GridContainerType;
 
   // Given
-  std::string name0 = "FundamentalAxis";
-  std::vector<double> knots0 {0., 3.4, 12E-15};
-  Euclid::GridContainer::GridAxis<double> axis0 {name0, knots0};
-  std::string name1 = "DefaultConstructibleAxis";
-  std::vector<DCC> knots1 {DCC{}, DCC{}, DCC{}};
+  std::string                             name0 = "FundamentalAxis";
+  std::vector<double>                     knots0{0., 3.4, 12E-15};
+  Euclid::GridContainer::GridAxis<double> axis0{name0, knots0};
+  std::string                             name1 = "DefaultConstructibleAxis";
+  std::vector<DCC>                        knots1{DCC{}, DCC{}, DCC{}};
   knots1[0].value = 0.;
   knots1[1].value = 3.4;
   knots1[2].value = 12E-15;
-  Euclid::GridContainer::GridAxis<DCC> axis1 {name1, knots1};
-  std::string name2 = "NonDefaultConstructibleAxis";
-  std::vector<NDCC> knots2 {};
+  Euclid::GridContainer::GridAxis<DCC> axis1{name1, knots1};
+  std::string                          name2 = "NonDefaultConstructibleAxis";
+  std::vector<NDCC>                    knots2{};
   knots2.push_back(NDCC{0.});
   knots2.push_back(NDCC{3.4});
   knots2.push_back(NDCC{12E-15});
-  Euclid::GridContainer::GridAxis<NDCC> axis2 {name2, knots2};
-  GridContainerType grid {axis0, axis1, axis2};
-  double value {0.};
+  Euclid::GridContainer::GridAxis<NDCC> axis2{name2, knots2};
+  GridContainerType                     grid{axis0, axis1, axis2};
+  double                                value{0.};
   for (auto& cell : grid) {
     cell = NDCC{value};
     value += 0.1;
   }
 
   // When
-  std::stringstream stream {};
+  std::stringstream stream{};
   Euclid::GridContainer::gridBinaryExport(stream, grid);
   GridContainerType result = Euclid::GridContainer::gridBinaryImport<GridContainerType>(stream);
 
   // Then
   BOOST_CHECK_EQUAL(result.axisNumber(), 3u);
   BOOST_CHECK_EQUAL(result.getAxis<0>().name(), name0);
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      result.getAxis<0>().begin(), result.getAxis<0>().end(),
-      knots0.begin(), knots0.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(result.getAxis<0>().begin(), result.getAxis<0>().end(), knots0.begin(), knots0.end());
   BOOST_CHECK_EQUAL(result.getAxis<1>().name(), name1);
   BOOST_CHECK_EQUAL(result.getAxis<1>().size(), knots1.size());
   auto result_iter1 = result.getAxis<1>().begin();
-  auto knots_iter1 = knots1.begin();
+  auto knots_iter1  = knots1.begin();
   while (result_iter1 != result.getAxis<1>().end()) {
     BOOST_CHECK_EQUAL(result_iter1->value, knots_iter1->value);
     ++result_iter1;
-    ++ knots_iter1;
+    ++knots_iter1;
   }
   BOOST_CHECK_EQUAL(result.getAxis<2>().name(), name2);
   BOOST_CHECK_EQUAL(result.getAxis<2>().size(), knots2.size());
   auto result_iter2 = result.getAxis<2>().begin();
-  auto knots_iter2 = knots2.begin();
+  auto knots_iter2  = knots2.begin();
   while (result_iter2 != result.getAxis<2>().end()) {
     BOOST_CHECK_EQUAL(result_iter2->value, knots_iter2->value);
     ++result_iter2;
-    ++ knots_iter2;
+    ++knots_iter2;
   }
   BOOST_CHECK_EQUAL(result.size(), grid.size());
   auto result_iter = result.begin();
-  auto grid_iter = grid.begin();
+  auto grid_iter   = grid.begin();
   while (result_iter != result.end()) {
     BOOST_CHECK_EQUAL((*result_iter).value, (*grid_iter).value);
     ++result_iter;
     ++grid_iter;
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -203,38 +196,38 @@ BOOST_AUTO_TEST_CASE(GridContainerSerializationFits) {
 
   using namespace Euclid::GridContainer;
   using namespace Euclid::XYDataset;
-  typedef GridContainer<std::vector<int>, std::string> SmallGridContainerType;
+  typedef GridContainer<std::vector<int>, std::string>                   SmallGridContainerType;
   typedef GridContainer<std::vector<double>, int, double, QualifiedName> BigGridContainerType;
 
   // Given
-  std::string name11 = "StringAxis";
-  std::vector<std::string> knots11 {"one", "two", "three"};
-  Euclid::GridContainer::GridAxis<std::string> axis11 {name11, knots11};
-  SmallGridContainerType grid1 {axis11};
-  int i = 0;
+  std::string                                  name11 = "StringAxis";
+  std::vector<std::string>                     knots11{"one", "two", "three"};
+  Euclid::GridContainer::GridAxis<std::string> axis11{name11, knots11};
+  SmallGridContainerType                       grid1{axis11};
+  int                                          i = 0;
   for (auto& cell : grid1) {
     cell = i;
     ++i;
   }
-  std::string name21 = "IntAxis";
-  std::vector<int> knots21 {1, 2, 3};
-  Euclid::GridContainer::GridAxis<int> axis21 {name21, knots21};
-  std::string name22 = "DoubleAxis";
-  std::vector<double> knots22 {0.1, 0.2, 0.3};
-  Euclid::GridContainer::GridAxis<double> axis22 {name22, knots22};
-  std::string name23 = "QualifiedNameAxis";
-  std::vector<QualifiedName> knots23 {{"One"}, {"Two"}, {"Three"}};
-  Euclid::GridContainer::GridAxis<QualifiedName> axis23 {name23, knots23};
-  BigGridContainerType grid2 {axis21, axis22, axis23};
-  double d = 0.;
+  std::string                                    name21 = "IntAxis";
+  std::vector<int>                               knots21{1, 2, 3};
+  Euclid::GridContainer::GridAxis<int>           axis21{name21, knots21};
+  std::string                                    name22 = "DoubleAxis";
+  std::vector<double>                            knots22{0.1, 0.2, 0.3};
+  Euclid::GridContainer::GridAxis<double>        axis22{name22, knots22};
+  std::string                                    name23 = "QualifiedNameAxis";
+  std::vector<QualifiedName>                     knots23{{"One"}, {"Two"}, {"Three"}};
+  Euclid::GridContainer::GridAxis<QualifiedName> axis23{name23, knots23};
+  BigGridContainerType                           grid2{axis21, axis22, axis23};
+  double                                         d = 0.;
   for (auto& cell : grid2) {
     cell = d;
     d += 0.1;
   }
 
   // When
-  Elements::TempDir dir {};
-  auto fits_file = dir.path() / "test.fits";
+  Elements::TempDir dir{};
+  auto              fits_file = dir.path() / "test.fits";
   gridFitsExport(fits_file, "first", grid1);
   gridFitsExport(fits_file, "second", grid2);
   auto result1 = gridFitsImport<SmallGridContainerType>(fits_file, 1);
@@ -243,31 +236,18 @@ BOOST_AUTO_TEST_CASE(GridContainerSerializationFits) {
   // Then
   BOOST_CHECK_EQUAL(result1.axisNumber(), grid1.axisNumber());
   BOOST_CHECK_EQUAL(result1.getAxis<0>().name(), name11);
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      result1.getAxis<0>().begin(), result1.getAxis<0>().end(),
-      knots11.begin(), knots11.end());
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      result1.begin(), result1.end(),
-      grid1.begin(), grid1.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(result1.getAxis<0>().begin(), result1.getAxis<0>().end(), knots11.begin(), knots11.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(result1.begin(), result1.end(), grid1.begin(), grid1.end());
   BOOST_CHECK_EQUAL(result2.axisNumber(), grid2.axisNumber());
   BOOST_CHECK_EQUAL(result2.getAxis<0>().name(), name21);
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      result2.getAxis<0>().begin(), result2.getAxis<0>().end(),
-      knots21.begin(), knots21.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(result2.getAxis<0>().begin(), result2.getAxis<0>().end(), knots21.begin(), knots21.end());
   BOOST_CHECK_EQUAL(result2.getAxis<1>().name(), name22);
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      result2.getAxis<1>().begin(), result2.getAxis<1>().end(),
-      knots22.begin(), knots22.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(result2.getAxis<1>().begin(), result2.getAxis<1>().end(), knots22.begin(), knots22.end());
   BOOST_CHECK_EQUAL(result2.getAxis<2>().name(), name23);
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      result2.getAxis<2>().begin(), result2.getAxis<2>().end(),
-      knots23.begin(), knots23.end());
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-      result2.begin(), result2.end(),
-      grid2.begin(), grid2.end());
-
+  BOOST_CHECK_EQUAL_COLLECTIONS(result2.getAxis<2>().begin(), result2.getAxis<2>().end(), knots23.begin(), knots23.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(result2.begin(), result2.end(), grid2.begin(), grid2.end());
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Histogram/Histogram/Binning/EdgeVector.h
+++ b/Histogram/Histogram/Binning/EdgeVector.h
@@ -17,10 +17,10 @@
  */
 
 /**
-* @file Histogram/Binning/EdgeVector.h
-* @date February 17, 2020
-* @author Alejandro Alvarez Ayllon
-*/
+ * @file Histogram/Binning/EdgeVector.h
+ * @date February 17, 2020
+ * @author Alejandro Alvarez Ayllon
+ */
 
 #ifndef ALEXANDRIA_HISTOGRAM_BINNING_EDGEVECTOR_H
 #define ALEXANDRIA_HISTOGRAM_BINNING_EDGEVECTOR_H
@@ -41,17 +41,17 @@ namespace Binning {
  *  \mathit{bin}_i = [\mathit{edge}_{i}, \mathit{edge}_{i+i}) \\
  *  ... \\
  * \mathit{bin}_n= [\mathit{edge}_{n}, \mathit{edge}_{n+i}]
-*  \f]
+ *  \f]
  */
-template<typename VarType>
+template <typename VarType>
 class EdgeVector : public BinStrategy<VarType> {
 public:
   virtual ~EdgeVector() = default;
 
   EdgeVector(EdgeVector&&) = default;
 
-  template<typename... Args>
-  explicit EdgeVector(Args&& ... args): m_edges(std::forward<Args>(args)...) {
+  template <typename... Args>
+  explicit EdgeVector(Args&&... args) : m_edges(std::forward<Args>(args)...) {
     m_nbins = m_edges.size() - 1;
   }
 
@@ -79,8 +79,8 @@ private:
   std::vector<VarType> m_edges;
 };
 
-} // end of namespace Binning
-} // end of namespace Histogram
-} // end of namespace Euclid
+}  // end of namespace Binning
+}  // end of namespace Histogram
+}  // end of namespace Euclid
 
-#endif // ALEXANDRIA_HISTOGRAM_BINNING_EDGEVECTOR_H
+#endif  // ALEXANDRIA_HISTOGRAM_BINNING_EDGEVECTOR_H

--- a/Histogram/Histogram/Binning/Scott.h
+++ b/Histogram/Histogram/Binning/Scott.h
@@ -17,22 +17,22 @@
  */
 
 /**
-* @file Histogram/Binning/Scott.h
-* @date February 11, 2020
-* @author Alejandro Alvarez Ayllon
-*/
+ * @file Histogram/Binning/Scott.h
+ * @date February 11, 2020
+ * @author Alejandro Alvarez Ayllon
+ */
 
 #ifndef ALEXANDRIA_HISTOGRAM_BINNING_SCOTT_H
 #define ALEXANDRIA_HISTOGRAM_BINNING_SCOTT_H
 
-#include <cmath>
 #include <algorithm>
-#include <vector>
 #include <boost/accumulators/accumulators.hpp>
-#include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/max.hpp>
 #include <boost/accumulators/statistics/min.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/variance.hpp>
+#include <cmath>
+#include <vector>
 
 #include "Histogram/Histogram.h"
 
@@ -50,11 +50,10 @@ namespace Binning {
  * @see
  *      https://en.wikipedia.org/wiki/Histogram#Scott's_normal_reference_rule
  */
-template<typename VarType>
-class Scott: public BinStrategy<VarType> {
+template <typename VarType>
+class Scott : public BinStrategy<VarType> {
 public:
-
-  template<typename Iterator>
+  template <typename Iterator>
   void computeBins(Iterator begin, Iterator end) {
     using namespace boost::accumulators;
 
@@ -64,9 +63,9 @@ public:
     size_t n = end - begin;
 
     VarType sigma = std::sqrt(variance(acc));
-    VarType h = 3.5 * sigma / std::pow(n, 1. / 3.);
-    VarType vmin = min(acc);
-    VarType vmax = max(acc);
+    VarType h     = 3.5 * sigma / std::pow(n, 1. / 3.);
+    VarType vmin  = min(acc);
+    VarType vmax  = max(acc);
 
     if (sigma == 0) {
       vmax += 0.5;
@@ -78,9 +77,9 @@ public:
 
     m_nbins = std::ceil(range / h);
 
-    m_step = range / m_nbins;
+    m_step  = range / m_nbins;
     m_start = vmin;
-    m_end = vmax;
+    m_end   = vmax;
   }
 
   ssize_t getBinIndex(VarType value) const final {
@@ -102,8 +101,8 @@ private:
   VarType m_start, m_step, m_end;
 };
 
-} // end of namespace Binning
-} // end of namespace Histogram
-} // end of namespace Euclid
+}  // end of namespace Binning
+}  // end of namespace Histogram
+}  // end of namespace Euclid
 
-#endif // ALEXANDRIA_HISTOGRAM_BINNING_SCOTT_H
+#endif  // ALEXANDRIA_HISTOGRAM_BINNING_SCOTT_H

--- a/Histogram/Histogram/Binning/Sqrt.h
+++ b/Histogram/Histogram/Binning/Sqrt.h
@@ -17,16 +17,16 @@
  */
 
 /**
-* @file Histogram/Binning/Sqrt.h
-* @date February 11, 2020
-* @author Alejandro Alvarez Ayllon
-*/
+ * @file Histogram/Binning/Sqrt.h
+ * @date February 11, 2020
+ * @author Alejandro Alvarez Ayllon
+ */
 
 #ifndef ALEXANDRIA_HISTOGRAM_BINNING_SQRT_H
 #define ALEXANDRIA_HISTOGRAM_BINNING_SQRT_H
 
-#include <cmath>
 #include <algorithm>
+#include <cmath>
 #include <numeric>
 #include <vector>
 
@@ -39,17 +39,16 @@ namespace Binning {
 /**
  * Bin strategy that estimates the number of bins as \f$ \sqrt{n} \f$
  */
-template<typename VarType>
+template <typename VarType>
 class Sqrt : public BinStrategy<VarType> {
 public:
-
-  template<typename Iterator>
+  template <typename Iterator>
   void computeBins(Iterator begin, Iterator end) {
-    m_nbins = std::ceil(std::sqrt(end - begin));
+    m_nbins     = std::ceil(std::sqrt(end - begin));
     auto minmax = std::minmax_element(begin, end);
-    m_step = (*minmax.second - *minmax.first) / m_nbins;
-    m_start = *minmax.first;
-    m_end = *minmax.second;
+    m_step      = (*minmax.second - *minmax.first) / m_nbins;
+    m_start     = *minmax.first;
+    m_end       = *minmax.second;
   }
 
   ssize_t getBinIndex(VarType value) const final {
@@ -71,8 +70,8 @@ private:
   VarType m_start, m_step, m_end;
 };
 
-} // end of namespace Binning
-} // end of namespace Histogram
-} // end of namespace Euclid
+}  // end of namespace Binning
+}  // end of namespace Histogram
+}  // end of namespace Euclid
 
-#endif // ALEXANDRIA_HISTOGRAM_BINNING_SQRT_H
+#endif  // ALEXANDRIA_HISTOGRAM_BINNING_SQRT_H

--- a/Histogram/Histogram/Histogram.h
+++ b/Histogram/Histogram/Histogram.h
@@ -17,24 +17,24 @@
  */
 
 /**
-* @file Histogram/Histogram.h
-* @date February 11, 2020
-* @author Alejandro Alvarez Ayllon
-*/
+ * @file Histogram/Histogram.h
+ * @date February 11, 2020
+ * @author Alejandro Alvarez Ayllon
+ */
 
 #ifndef ALEXANDRIA_HISTOGRAM_HISTOGRAM_H
 #define ALEXANDRIA_HISTOGRAM_HISTOGRAM_H
 
+#include <AlexandriaKernel/memory_tools.h>
+#include <ElementsKernel/Exception.h>
+#include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <algorithm>
 #include <memory>
-#include <utility>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 #include <vector>
-#include <ElementsKernel/Exception.h>
-#include <AlexandriaKernel/memory_tools.h>
 
 namespace Euclid {
 namespace Histogram {
@@ -45,10 +45,9 @@ namespace Histogram {
  * @tparam VarType
  *  The type of the continuous variable. Must be an arithmetic type (either integral or floating point)
  */
-template<typename VarType>
+template <typename VarType>
 class BinStrategy {
 public:
-
   /**
    * Constructor.
    * @details
@@ -86,7 +85,7 @@ public:
    */
   virtual std::vector<VarType> getEdges() const {
     std::vector<VarType> edges(m_nbins + 1);
-    size_t i = 0;
+    size_t               i = 0;
     std::generate(edges.begin(), edges.end(), [this, &i]() { return getEdge(i++); });
     return edges;
   }
@@ -134,10 +133,9 @@ protected:
  * @tparam WeightType
  *  The type used for the counts, which is the same as the one accepted for the weights.
  */
-template<typename VarType, typename WeightType = float>
+template <typename VarType, typename WeightType = float>
 class Histogram {
 public:
-
   static_assert(std::is_arithmetic<VarType>::value, "Histogram only supports numerical types");
   static_assert(std::is_arithmetic<WeightType>::value, "Histogram only supports numerical weights");
 
@@ -154,8 +152,8 @@ public:
    * @param bin_type
    *    An instance of BinType. It will be taken ownership of by the Histogram
    */
-  template<typename IterType, typename BinType,
-    typename=typename std::enable_if<std::is_move_constructible<BinType>::value>::type>
+  template <typename IterType, typename BinType,
+            typename = typename std::enable_if<std::is_move_constructible<BinType>::value>::type>
   Histogram(IterType begin, IterType end, BinType&& bin_type) {
     auto binning_impl = make_unique<ComputationImpl<BinType>>(std::move(bin_type));
     binning_impl->computeBins(begin, end, ConstantWeight{});
@@ -183,8 +181,8 @@ public:
    * @note
    *    The number of values and weights must match
    */
-  template<typename IterType, typename WeightIterType, typename BinType,
-    typename=typename std::enable_if<std::is_move_constructible<BinType>::value>::type>
+  template <typename IterType, typename WeightIterType, typename BinType,
+            typename = typename std::enable_if<std::is_move_constructible<BinType>::value>::type>
   Histogram(IterType begin, IterType end, WeightIterType wbegin, WeightIterType wend, BinType&& bin_type) {
     assert(wend - wbegin == end - begin);
     auto binning_impl = make_unique<ComputationImpl<BinType>>(std::move(bin_type));
@@ -247,7 +245,7 @@ public:
    */
   std::vector<VarType> getBins() const {
     std::vector<VarType> bins(m_binning_concept->m_counts->size());
-    size_t i = 0;
+    size_t               i = 0;
     std::generate(bins.begin(), bins.end(), [this, &i]() { return m_binning_concept->getBinStrategy().getBin(i++); });
     return bins;
   }
@@ -292,7 +290,6 @@ public:
     return m_binning_concept->getStats();
   }
 
-
 private:
   /**
    * Used internally when no weights are given, which is equivalent to have all weights being 1
@@ -317,12 +314,11 @@ private:
    */
   struct ComputationInterface {
     std::shared_ptr<std::vector<WeightType>> m_counts;
-    ssize_t m_clip_left, m_clip_right;
+    ssize_t                                  m_clip_left, m_clip_right;
 
     virtual ~ComputationInterface() = default;
 
-    ComputationInterface() : m_counts(new std::vector<WeightType>()), m_clip_left(0),
-                             m_clip_right(m_counts->size() - 1) {}
+    ComputationInterface() : m_counts(new std::vector<WeightType>()), m_clip_left(0), m_clip_right(m_counts->size() - 1) {}
 
     size_t size() const {
       return m_clip_right - m_clip_left + 1;
@@ -342,15 +338,14 @@ private:
    * @tparam BinType
    *    Type of the binning strategy
    */
-  template<typename BinType>
+  template <typename BinType>
   struct ComputationImpl : public ComputationInterface {
-    using ComputationInterface::m_counts;
     using ComputationInterface::m_clip_left;
     using ComputationInterface::m_clip_right;
+    using ComputationInterface::m_counts;
     BinType m_binning;
 
-    explicit ComputationImpl(BinType&& bin_type): m_binning(std::move(bin_type)) {
-    }
+    explicit ComputationImpl(BinType&& bin_type) : m_binning(std::move(bin_type)) {}
 
     ComputationImpl(const ComputationImpl& other) = default;
 
@@ -375,7 +370,7 @@ private:
      * @param wbegin
      *    Beginning of the weights
      */
-    template<typename IterType, typename WeightIterType>
+    template <typename IterType, typename WeightIterType>
     void computeBins(IterType begin, IterType end, WeightIterType wbegin);
 
     void clip(VarType min, VarType max) final;
@@ -386,9 +381,9 @@ private:
   std::unique_ptr<ComputationInterface> m_binning_concept;
 };
 
-} // end of namespace Histogram
-} // end of namespace Euclid
+}  // end of namespace Histogram
+}  // end of namespace Euclid
 
 #include "Histogram/_impl/ComputationImpl.icpp"
 
-#endif // ALEXANDRIA_HISTOGRAM_HISTOGRAM_H
+#endif  // ALEXANDRIA_HISTOGRAM_HISTOGRAM_H

--- a/Histogram/Histogram/_impl/ComputationImpl.icpp
+++ b/Histogram/Histogram/_impl/ComputationImpl.icpp
@@ -1,8 +1,8 @@
 namespace Euclid {
 namespace Histogram {
 
-template<typename VarType, typename WeightType>
-template<typename BinType>
+template <typename VarType, typename WeightType>
+template <typename BinType>
 void Histogram<VarType, WeightType>::ComputationImpl<BinType>::clip(VarType min, VarType max) {
 
   if (min > max)
@@ -15,11 +15,10 @@ void Histogram<VarType, WeightType>::ComputationImpl<BinType>::clip(VarType min,
   auto max_bin = m_binning.getBinIndex(max);
   if (max_bin >= m_clip_left && max_bin < m_clip_right)
     m_clip_right = max_bin;
-
 }
 
-template<typename VarType, typename WeightType>
-template<typename BinType>
+template <typename VarType, typename WeightType>
+template <typename BinType>
 std::tuple<VarType, VarType, VarType> Histogram<VarType, WeightType>::ComputationImpl<BinType>::getStats() const {
   VarType total = 0, total_count = 0;
   VarType sigma = 0;
@@ -33,7 +32,7 @@ std::tuple<VarType, VarType, VarType> Histogram<VarType, WeightType>::Computatio
   }
 
   VarType mean = total / total_count;
-  sigma = sigma / total_count - mean * mean;
+  sigma        = sigma / total_count - mean * mean;
   if (sigma > 0)
     sigma = std::sqrt(sigma);
   else
@@ -41,12 +40,11 @@ std::tuple<VarType, VarType, VarType> Histogram<VarType, WeightType>::Computatio
 
   // Find the median
   WeightType low_sum = 0., high_sum = 0.;
-  auto low_i = m_clip_left, high_i = m_clip_right;
+  auto       low_i = m_clip_left, high_i = m_clip_right;
   while (low_i <= high_i) {
     if (low_sum < high_sum) {
       low_sum += (*m_counts)[low_i++];
-    }
-    else {
+    } else {
       high_sum += (*m_counts)[high_i--];
     }
   }
@@ -55,12 +53,11 @@ std::tuple<VarType, VarType, VarType> Histogram<VarType, WeightType>::Computatio
 
   VarType median;
   if (high_i >= 0) {
-    auto edges = m_binning.getBinEdges(high_i + 1);
-    auto bin_width = (edges.second - edges.first);
+    auto edges      = m_binning.getBinEdges(high_i + 1);
+    auto bin_width  = (edges.second - edges.first);
     auto max_counts = std::max((*m_counts)[low_i], (*m_counts)[high_i]);
-    median = edges.first + bin_width * (high_sum - low_sum) / (2.0 * max_counts);
-  }
-  else {
+    median          = edges.first + bin_width * (high_sum - low_sum) / (2.0 * max_counts);
+  } else {
     median = m_binning.getBin(0);
   }
 
@@ -73,19 +70,21 @@ std::tuple<VarType, VarType, VarType> Histogram<VarType, WeightType>::Computatio
  * @tparam BinType
  * @tparam IterType
  */
-template<typename BinType, typename IterType>
-struct HasComputeBins
-{
-  template <typename U, typename = decltype(std::declval<U>().computeBins(std::declval<IterType>(), std::declval<IterType>()))> struct SFINAE;
-  template<typename U> static char Test(SFINAE<U>*);
-  template<typename U> static int Test(...);
+template <typename BinType, typename IterType>
+struct HasComputeBins {
+  template <typename U, typename = decltype(std::declval<U>().computeBins(std::declval<IterType>(), std::declval<IterType>()))>
+  struct SFINAE;
+  template <typename U>
+  static char Test(SFINAE<U>*);
+  template <typename U>
+  static int            Test(...);
   static constexpr bool value = sizeof(Test<BinType>(0)) == sizeof(char);
 };
 
 /**
  * This method is called if BinType has computeBins
  */
-template<typename BinType, typename IterType>
+template <typename BinType, typename IterType>
 inline void computeBinsForwarder(BinType& binning, IterType begin, IterType end, std::true_type) {
   binning.computeBins(begin, end);
 }
@@ -93,25 +92,24 @@ inline void computeBinsForwarder(BinType& binning, IterType begin, IterType end,
 /**
  * This method is called if BinType does not have computeBins
  */
-template<typename BinType, typename IterType>
-inline void computeBinsForwarder(BinType&, IterType, IterType, std::false_type) {
-}
+template <typename BinType, typename IterType>
+inline void computeBinsForwarder(BinType&, IterType, IterType, std::false_type) {}
 
-template<typename VarType, typename WeightType>
-template<typename BinType>
-template<typename IterType, typename WeightIterType>
+template <typename VarType, typename WeightType>
+template <typename BinType>
+template <typename IterType, typename WeightIterType>
 void Histogram<VarType, WeightType>::ComputationImpl<BinType>::computeBins(IterType begin, IterType end, WeightIterType wbegin) {
   // This trick should allow the compiler to know the actual binning type, so if they
   // override methods with *final*, we can skip indirections via vtable
   computeBinsForwarder(m_binning, begin, end, std::integral_constant<bool, HasComputeBins<BinType, IterType>::value>());
 
-  m_clip_left = 0;
+  m_clip_left  = 0;
   m_clip_right = m_binning.getBinCount() - 1;
   m_counts->resize(m_binning.getBinCount());
 
   ssize_t nbins = m_counts->size();
-  auto i = begin;
-  auto wi = wbegin;
+  auto    i     = begin;
+  auto    wi    = wbegin;
   for (; i != end; ++i, ++wi) {
     auto bin = m_binning.getBinIndex(*i);
     if (bin >= 0 && bin < nbins) {
@@ -120,5 +118,5 @@ void Histogram<VarType, WeightType>::ComputationImpl<BinType>::computeBins(IterT
   }
 }
 
-} // end of namespace Histogram
-} // end of namespace Euclid
+}  // end of namespace Histogram
+}  // end of namespace Euclid

--- a/Histogram/tests/src/BinEdges_test.cpp
+++ b/Histogram/tests/src/BinEdges_test.cpp
@@ -42,7 +42,7 @@ BOOST_FIXTURE_TEST_CASE(scottsBinEdges, BinEdgesFixture) {
   BOOST_CHECK_EQUAL(edges.size(), eedges.size());
 
   auto eei = eedges.begin();
-  auto ei = edges.begin();
+  auto ei  = edges.begin();
   for (; eei != eedges.end(); ++eei, ++ei) {
     BOOST_CHECK_CLOSE(*ei, *eei, 1e-4);
   }
@@ -59,7 +59,7 @@ BOOST_FIXTURE_TEST_CASE(sqrtBinEdges, BinEdgesFixture) {
   BOOST_CHECK_EQUAL(edges.size(), eedges.size());
 
   auto eei = eedges.begin();
-  auto ei = edges.begin();
+  auto ei  = edges.begin();
   for (; eei != eedges.end(); ++eei, ++ei) {
     BOOST_CHECK_CLOSE(*ei, *eei, 1e-4);
   }

--- a/Histogram/tests/src/Histogram_test.cpp
+++ b/Histogram/tests/src/Histogram_test.cpp
@@ -19,9 +19,9 @@
 #include <boost/test/unit_test.hpp>
 #include <cmath>
 
-#include "Histogram/Histogram.h"
 #include "Histogram/Binning/EdgeVector.h"
 #include "Histogram/Binning/Sqrt.h"
+#include "Histogram/Histogram.h"
 
 using namespace Euclid::Histogram;
 
@@ -32,10 +32,10 @@ BOOST_AUTO_TEST_SUITE(Histogram_test)
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(histogramInt) {
-  std::vector<int> data{1, 1, 2, 3, 5, 4, 6};
-  std::vector<int> edges{0, 1, 2, 3, 4, 5};
+  std::vector<int>   data{1, 1, 2, 3, 5, 4, 6};
+  std::vector<int>   edges{0, 1, 2, 3, 4, 5};
   std::vector<float> expected{0, 2, 1, 1, 2};
-  Histogram<int> histo(data.begin(), data.end(), Binning::EdgeVector<int>{edges});
+  Histogram<int>     histo(data.begin(), data.end(), Binning::EdgeVector<int>{edges});
 
   BOOST_CHECK_EQUAL(histo.size(), 5);
   auto counts = histo.getCounts();
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(histogramFloat) {
   std::vector<float> data{1.10, 1.60, 2.33, 3.01, 5.00, 4.99, 6.00, 5.50};
   std::vector<float> edges{0, 1, 2, 3, 4, 5};
   std::vector<float> expected{0, 2, 1, 1, 2};
-  Histogram<float> histo(data.begin(), data.end(), Binning::EdgeVector<float>{edges});
+  Histogram<float>   histo(data.begin(), data.end(), Binning::EdgeVector<float>{edges});
 
   BOOST_CHECK_EQUAL(histo.size(), 5);
   auto counts = histo.getCounts();
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(histogramWithNegatives) {
   std::vector<float> data{-1.20, -2.30, -1.33, 0.00, 1.00, 3.99, 2.00, 6.50};
   std::vector<float> edges{-2, -1, 0, 1, 2, 3};
   std::vector<float> expected{2, 0, 1, 1, 1};
-  Histogram<float> histo(data.begin(), data.end(), Binning::EdgeVector<float>{edges});
+  Histogram<float>   histo(data.begin(), data.end(), Binning::EdgeVector<float>{edges});
 
   BOOST_CHECK_EQUAL(histo.size(), 5);
   auto counts = histo.getCounts();
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(histogramWeights) {
   std::vector<float> weights{1.00, 5.00, 1.10, 0.00, 0.50, 1.00, 2.00, 0.00};
   std::vector<float> edges{0, 1, 2, 3, 4, 5};
   std::vector<float> expected{0.0, 6.0, 1.1, 0.0, 1.5};
-  Histogram<float> histo(data.begin(), data.end(), weights.begin(), weights.end(), Binning::EdgeVector<float>{edges});
+  Histogram<float>   histo(data.begin(), data.end(), weights.begin(), weights.end(), Binning::EdgeVector<float>{edges});
 
   BOOST_CHECK_EQUAL(histo.size(), 5);
   auto counts = histo.getCounts();
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(histogramBinsCenter) {
   std::vector<float> centers{0.5, 1.5, 2.5, 3.5, 4.5};
 
   Histogram<float> histo(data.begin(), data.end(), Binning::EdgeVector<float>{edges});
-  auto bins = histo.getBins();
+  auto             bins = histo.getBins();
   BOOST_CHECK_EQUAL_COLLECTIONS(centers.begin(), centers.end(), bins.begin(), bins.end());
 }
 
@@ -108,14 +108,14 @@ BOOST_AUTO_TEST_CASE(histogramBinsCenter) {
 
 BOOST_AUTO_TEST_CASE(histogramFunctor) {
   std::vector<float> data{1.10, 1.60, 2.33, 3.01, 5.00, 4.99, 6.00, 5.50};
-  Histogram<float> histo(data.begin(), data.end(), Binning::Sqrt<float>{});
+  Histogram<float>   histo(data.begin(), data.end(), Binning::Sqrt<float>{});
   std::vector<float> expected{3, 1, 4};
   std::vector<float> expected_edges{1.1, 2.73333333, 4.36666667, 6};
 
   BOOST_CHECK_EQUAL(histo.size(), 3);
   auto counts = histo.getCounts();
   BOOST_CHECK_EQUAL_COLLECTIONS(expected.begin(), expected.end(), counts.begin(), counts.end());
-  auto ei = expected_edges.begin();
+  auto ei    = expected_edges.begin();
   auto edges = histo.getEdges();
 
   BOOST_CHECK_EQUAL(expected_edges.size(), edges.size());
@@ -130,28 +130,28 @@ BOOST_AUTO_TEST_CASE(histogramFunctor) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(histogramStats) {
-/* You can use the following python snipped to verify the values on this test
-import numpy as np
+  /* You can use the following python snipped to verify the values on this test
+  import numpy as np
 
-values = [1.10, 1.60, 2.33, 3.01, 5.00, 4.99, 6.00, 5.50]
-counts, edges = np.histogram(values, bins='sqrt')
-centers = 0.5*(edges[1:] + edges[:-1])
+  values = [1.10, 1.60, 2.33, 3.01, 5.00, 4.99, 6.00, 5.50]
+  counts, edges = np.histogram(values, bins='sqrt')
+  centers = 0.5*(edges[1:] + edges[:-1])
 
-mean = np.average(centers, weights=counts)
-sigma = np.sqrt(np.sum(counts * (centers - mean)**2) / np.sum(counts))
+  mean = np.average(centers, weights=counts)
+  sigma = np.sqrt(np.sum(counts * (centers - mean)**2) / np.sum(counts))
 
-As for the median, as long as half the values are below, we consider it good
-*/
+  As for the median, as long as half the values are below, we consider it good
+  */
 
   std::vector<float> data{1.10, 1.60, 2.33, 3.01, 5.00, 4.99, 6.00, 5.50};
-  Histogram<float> histo(data.begin(), data.end(), Binning::Sqrt<float>{});
+  Histogram<float>   histo(data.begin(), data.end(), Binning::Sqrt<float>{});
 
   float mean, median, sigma;
   std::tie(mean, median, sigma) = histo.getStats();
 
   BOOST_CHECK_CLOSE(mean, 3.7541667, 1e-4);
   auto centers = histo.getBins();
-  auto values = histo.getCounts();
+  auto values  = histo.getCounts();
   std::transform(centers.begin(), centers.end(), values.begin(), centers.begin(),
                  [median](float v, float c) { return (v < median) * c; });
   auto less_than_median = std::accumulate(centers.begin(), centers.end(), 0);
@@ -170,7 +170,6 @@ BOOST_AUTO_TEST_CASE(clipBadValues) {
 
   Histogram<float> histo(data.begin(), data.end(), Binning::EdgeVector<float>{edges});
   BOOST_CHECK_THROW(histo.clip(4, 1), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -211,7 +210,7 @@ BOOST_AUTO_TEST_CASE(histogramZeroSigma) {
   std::vector<float> edges{-0.5, +0.5};
 
   Histogram<float> histo(data.begin(), data.end(), Binning::EdgeVector<float>{edges});
-  float mean, median, sigma;
+  float            mean, median, sigma;
   std::tie(mean, median, sigma) = histo.getStats();
   BOOST_CHECK_SMALL(mean, std::numeric_limits<float>::epsilon());
   BOOST_CHECK_SMALL(median, std::numeric_limits<float>::epsilon());
@@ -242,8 +241,6 @@ BOOST_AUTO_TEST_CASE(histogramCopy) {
   BOOST_CHECK_SMALL(mean, std::numeric_limits<float>::epsilon());
   BOOST_CHECK_SMALL(median, std::numeric_limits<float>::epsilon());
   BOOST_CHECK_CLOSE(sigma, 0.70710678, 1e-5);
-
-
 }
 
 //-----------------------------------------------------------------------------

--- a/MathUtils/MathUtils/PDF/Cumulative.h
+++ b/MathUtils/MathUtils/PDF/Cumulative.h
@@ -25,9 +25,9 @@
 #ifndef _FUNCTIONUTILS_CUMULATIVE_H
 #define _FUNCTIONUTILS_CUMULATIVE_H
 
-#include <vector>
-#include <utility>
 #include "XYDataset/XYDataset.h"
+#include <utility>
+#include <vector>
 
 namespace Euclid {
 namespace MathUtils {
@@ -41,124 +41,122 @@ namespace MathUtils {
 class Cumulative {
 
 public:
-/**
- * @enum TrayPosition
- *
- * @brief when looking for the position having a given value, one may encounter
- * tray where the value is constant on an interval. This enum allow to specify
- * if one want an extremity or the middle of the tray.
- */
+  /**
+   * @enum TrayPosition
+   *
+   * @brief when looking for the position having a given value, one may encounter
+   * tray where the value is constant on an interval. This enum allow to specify
+   * if one want an extremity or the middle of the tray.
+   */
   enum TrayPosition { begin, middle, end };
 
   /**
-  * @brief move constructor
-  */
-  Cumulative ( Cumulative && other);
+   * @brief move constructor
+   */
+  Cumulative(Cumulative&& other);
 
   /**
-  * @brief move assignation operator
-  */
-  Cumulative & operator = ( Cumulative && other);
+   * @brief move assignation operator
+   */
+  Cumulative& operator=(Cumulative&& other);
 
   /**
-  * @brief copy constructor
-  */
-  Cumulative(const Cumulative & other);
+   * @brief copy constructor
+   */
+  Cumulative(const Cumulative& other);
 
   /**
-  * @brief copy assignation operator
-  */
-  Cumulative & operator = ( const Cumulative & other);
+   * @brief copy assignation operator
+   */
+  Cumulative& operator=(const Cumulative& other);
 
   /**
-  * @brief Constructor from the sampling of a cumulative
-  *
-  * @param x_sampling horizontal sampling.
-  * @param y_sampling vertical sampling.
-  * @throw Exception if the 2 axis have not the same length
-  */
+   * @brief Constructor from the sampling of a cumulative
+   *
+   * @param x_sampling horizontal sampling.
+   * @param y_sampling vertical sampling.
+   * @throw Exception if the 2 axis have not the same length
+   */
   Cumulative(std::vector<double>& x_sampling, std::vector<double>& y_sampling);
 
   /**
-  * @brief Constructor from the sampling of a cumulative
-  *
-  * @param sampling cumulative sampling.
-  */
-  explicit Cumulative(const XYDataset::XYDataset & sampling);
+   * @brief Constructor from the sampling of a cumulative
+   *
+   * @param sampling cumulative sampling.
+   */
+  explicit Cumulative(const XYDataset::XYDataset& sampling);
 
   /**
-  * @brief Factory from the sampling of a PDF. The Cumulative vertical samples
-  * are build as the sum of the the pdf vertical sample with horizontal value
-  * smaller or equal to the cumulative horizontal value
-  *
-  * @param x_sampling pdf horizontal sampling.
-  * @param y_sampling pdf vertical sampling.
-  * @throw Exception if the 2 axis have not the same length
-  */
+   * @brief Factory from the sampling of a PDF. The Cumulative vertical samples
+   * are build as the sum of the the pdf vertical sample with horizontal value
+   * smaller or equal to the cumulative horizontal value
+   *
+   * @param x_sampling pdf horizontal sampling.
+   * @param y_sampling pdf vertical sampling.
+   * @throw Exception if the 2 axis have not the same length
+   */
   static Cumulative fromPdf(std::vector<double>& x_sampling, std::vector<double>& pdf_sampling);
 
   /**
-  * @brief Factory from the sampling of a PDF. The Cumulative vertical samples
-  * are build as the sum of the the pdf vertical sample with horizontal value
-  * smaller or equal to the cumulative horizontal value
-  *
-  * @param sampling pdf sampling.
-  */
-  static Cumulative fromPdf(const XYDataset::XYDataset &  sampling);
+   * @brief Factory from the sampling of a PDF. The Cumulative vertical samples
+   * are build as the sum of the the pdf vertical sample with horizontal value
+   * smaller or equal to the cumulative horizontal value
+   *
+   * @param sampling pdf sampling.
+   */
+  static Cumulative fromPdf(const XYDataset::XYDataset& sampling);
 
   /**
-  * @brief Normalize the Cumulative. After calling this function the last vertical value is 1.0.
-  */
+   * @brief Normalize the Cumulative. After calling this function the last vertical value is 1.0.
+   */
   void normalize();
 
   /**
-  * @brief Find the first horizontal sample which vertical value is bigger or equal to the ratio value.
-  * If the Cumulative is not normalize the searched value is the last vertical value of the Cumulative time the ratio.
-  * If the selected sample is part of a tray (next sample(s) have the same vertical value),
-  * the position param allow to specify if the first, the last or the average of the point with the same value
-  * has to be returned
-  *
-  *
-  * @param ratio The value to be searched,
-  * @param position Selection of the returned value in case of tray,
-  * @return the horizontal value for which the Cumulative has the vertical value ratio.
-  */
-  double findValue(double ratio, TrayPosition position=TrayPosition::middle) const;
+   * @brief Find the first horizontal sample which vertical value is bigger or equal to the ratio value.
+   * If the Cumulative is not normalize the searched value is the last vertical value of the Cumulative time the ratio.
+   * If the selected sample is part of a tray (next sample(s) have the same vertical value),
+   * the position param allow to specify if the first, the last or the average of the point with the same value
+   * has to be returned
+   *
+   *
+   * @param ratio The value to be searched,
+   * @param position Selection of the returned value in case of tray,
+   * @return the horizontal value for which the Cumulative has the vertical value ratio.
+   */
+  double findValue(double ratio, TrayPosition position = TrayPosition::middle) const;
 
   /**
-  * @brief Scan the horizontal axis looking for the smallest x-interval for which
-  * the vertical interval is at least rate*Last Value of the Cumulative.
-  *
-  * @param rate Vertical interval,
-  * @return a pair of number the first is the horizontal value of the begining of the interval, the second the end.
-  */
-  std::pair<double,double> findMinInterval(double rate) const;
+   * @brief Scan the horizontal axis looking for the smallest x-interval for which
+   * the vertical interval is at least rate*Last Value of the Cumulative.
+   *
+   * @param rate Vertical interval,
+   * @return a pair of number the first is the horizontal value of the begining of the interval, the second the end.
+   */
+  std::pair<double, double> findMinInterval(double rate) const;
 
   /**
-  * @brief return the horizontal interval starting where the Cumulative has value
-  * (1-ratio)/2 and ending where the Cumulative has value (1+ratio)/2.
-  * If the Cumulative is not normalized the searched value are multiplied by the
-  * last cumulative vertical value.
-  *
-  * @param rate Vertical interval,
-  * @return a pair of number the first is the horizontal value of the begining of the interval, the second the end.
-  */
-  std::pair<double,double> findCenteredInterval(double rate) const;
+   * @brief return the horizontal interval starting where the Cumulative has value
+   * (1-ratio)/2 and ending where the Cumulative has value (1+ratio)/2.
+   * If the Cumulative is not normalized the searched value are multiplied by the
+   * last cumulative vertical value.
+   *
+   * @param rate Vertical interval,
+   * @return a pair of number the first is the horizontal value of the begining of the interval, the second the end.
+   */
+  std::pair<double, double> findCenteredInterval(double rate) const;
 
   /**
    * @brief Destructor
    */
   virtual ~Cumulative() = default;
 
-
 private:
   std::vector<double> m_x_sampling;
   std::vector<double> m_y_sampling;
 
-
 }; /* End of Cumulative class */
 
 } /* namespace MathUtils */
-}
+}  // namespace Euclid
 
 #endif

--- a/MathUtils/MathUtils/PDF/PdfModeExtraction.h
+++ b/MathUtils/MathUtils/PDF/PdfModeExtraction.h
@@ -25,130 +25,125 @@
 #ifndef _MATHUTILS_PDF_PDFMODEEXTRACTION_H
 #define _MATHUTILS_PDF_PDFMODEEXTRACTION_H
 
-#include <vector>
-#include <tuple>
-#include <cstddef>
-#include <utility>
 #include "XYDataset/XYDataset.h"
-
+#include <cstddef>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 namespace Euclid {
 namespace MathUtils {
-   /**
-     * @Class ModeInfo
-     *
-     * @brief Class for storing the information of a PDF mode
-     *
-     * @details
-     * The Mode info contains the mode area and the mode location. The mode location
-     * is stored as the highest point in the PDF sampling, the mean
-     * over the mode and a quadratic fitting around the highest point.
-     */
-    class ModeInfo {
-        public:
-        ModeInfo(double highest_sample, double mean, double interpolated, double area):
-            m_sample{highest_sample}, m_mean{mean}, m_interp{interpolated}, m_area{area} {}
+/**
+ * @Class ModeInfo
+ *
+ * @brief Class for storing the information of a PDF mode
+ *
+ * @details
+ * The Mode info contains the mode area and the mode location. The mode location
+ * is stored as the highest point in the PDF sampling, the mean
+ * over the mode and a quadratic fitting around the highest point.
+ */
+class ModeInfo {
+public:
+  ModeInfo(double highest_sample, double mean, double interpolated, double area)
+      : m_sample{highest_sample}, m_mean{mean}, m_interp{interpolated}, m_area{area} {}
 
-        double getHighestSamplePosition() const {
-            return m_sample;
-        }
+  double getHighestSamplePosition() const {
+    return m_sample;
+  }
 
-        double getMeanPosition() const {
-            return m_mean;
-        }
+  double getMeanPosition() const {
+    return m_mean;
+  }
 
-        double getInterpolatedMaxPosition() const {
-            return m_interp;
-        }
+  double getInterpolatedMaxPosition() const {
+    return m_interp;
+  }
 
-        double getModeArea() const {
-            return m_area;
-        }
+  double getModeArea() const {
+    return m_area;
+  }
 
-        private:
-        double m_sample;
-        double m_mean;
-        double m_interp;
-        double m_area;
-    };
+private:
+  double m_sample;
+  double m_mean;
+  double m_interp;
+  double m_area;
+};
 
-    /**
-     * Extract the n highest modes in the provided pdf and compute for each of them
-     * the location of the mode and its area.
-     * A mode is discovered as the highest
-     * point of the pdf, then, on both sides, samples are added until the pdf
-     * starts to rise again. In order to avoid truncating the mode due to a noisy
-     * pdf it is possible to specify a merge_ratio. In this case the samples are
-     * added until their values is below the hight of the peak times the merge ratio,
-     * then additional point are added until the pdf rise again.
-     *
-     * @param pdf The sampling of the pdf to be analysed.
-     * @param merge_ratio The parameter for mode cutting.
-     * @param n The (maximum) number of modes to be returned.
-     * @return A vector of ModeInfo containing the position and the area of the modes.
-     */
-    std::vector<ModeInfo> extractNHighestModes(const XYDataset::XYDataset& pdf, double merge_ratio, size_t n);
+/**
+ * Extract the n highest modes in the provided pdf and compute for each of them
+ * the location of the mode and its area.
+ * A mode is discovered as the highest
+ * point of the pdf, then, on both sides, samples are added until the pdf
+ * starts to rise again. In order to avoid truncating the mode due to a noisy
+ * pdf it is possible to specify a merge_ratio. In this case the samples are
+ * added until their values is below the hight of the peak times the merge ratio,
+ * then additional point are added until the pdf rise again.
+ *
+ * @param pdf The sampling of the pdf to be analysed.
+ * @param merge_ratio The parameter for mode cutting.
+ * @param n The (maximum) number of modes to be returned.
+ * @return A vector of ModeInfo containing the position and the area of the modes.
+ */
+std::vector<ModeInfo> extractNHighestModes(const XYDataset::XYDataset& pdf, double merge_ratio, size_t n);
 
-    /**
-     * Extract the n highest modes in the provided pdf and compute for each of them
-     * the location of the mode and its area.
-     * A mode is discovered as the highest
-     * point of the pdf, then, on both sides, samples are added until the pdf
-     * starts to rise again. In order to avoid truncating the mode due to a noisy
-     * pdf it is possible to specify a merge_ratio. In this case the samples are
-     * added until their values is below the hight of the peak times the merge ratio,
-     * then additional point are added until the pdf rise again.
-     *
-     * @param x_sampling The horizontal sampling of the pdf to be analysed.
-     * @param pdf_sampling The sampling of the pdf to be analysed.
-     * @param merge_ratio The parameter for mode cutting.
-     * @param n The (maximum) number of modes to be returned.
-     * @return A vector of ModeInfo containing the position and the area of the modes.
-     */
-    std::vector<ModeInfo>
-    extractNHighestModes(std::vector<double>& x_sampling, std::vector<double>& pdf_sampling, double merge_ratio,
-                         size_t n);
+/**
+ * Extract the n highest modes in the provided pdf and compute for each of them
+ * the location of the mode and its area.
+ * A mode is discovered as the highest
+ * point of the pdf, then, on both sides, samples are added until the pdf
+ * starts to rise again. In order to avoid truncating the mode due to a noisy
+ * pdf it is possible to specify a merge_ratio. In this case the samples are
+ * added until their values is below the hight of the peak times the merge ratio,
+ * then additional point are added until the pdf rise again.
+ *
+ * @param x_sampling The horizontal sampling of the pdf to be analysed.
+ * @param pdf_sampling The sampling of the pdf to be analysed.
+ * @param merge_ratio The parameter for mode cutting.
+ * @param n The (maximum) number of modes to be returned.
+ * @return A vector of ModeInfo containing the position and the area of the modes.
+ */
+std::vector<ModeInfo> extractNHighestModes(std::vector<double>& x_sampling, std::vector<double>& pdf_sampling, double merge_ratio,
+                                           size_t n);
 
-    /**
-     * Extract the n modes with biggest area in the provided pdf and compute for
-     * each of them the location of the mode and its area.
-     * A mode is discovered as the highest
-     * point of the pdf, then, on both sides, samples are added until the pdf
-     * starts to rise again. In order to avoid truncating the mode due to a noisy
-     * pdf it is possible to specify a merge_ratio. In this case the samples are
-     * added until their values is below the hight of the peak times the merge ratio,
-     * then additional point are added until the pdf rise again.
-     *
-     * @param pdf The sampling of the pdf to be analysed.
-     * @param merge_ratio The parameter for mode cutting.
-     * @param n The (maximum) number of modes to be returned.
-     * @return A vector of ModeInfo containing the position and the area of the modes.
-     */
-    std::vector<ModeInfo> extractNBigestModes(const XYDataset::XYDataset& pdf, double merge_ratio, size_t n);
+/**
+ * Extract the n modes with biggest area in the provided pdf and compute for
+ * each of them the location of the mode and its area.
+ * A mode is discovered as the highest
+ * point of the pdf, then, on both sides, samples are added until the pdf
+ * starts to rise again. In order to avoid truncating the mode due to a noisy
+ * pdf it is possible to specify a merge_ratio. In this case the samples are
+ * added until their values is below the hight of the peak times the merge ratio,
+ * then additional point are added until the pdf rise again.
+ *
+ * @param pdf The sampling of the pdf to be analysed.
+ * @param merge_ratio The parameter for mode cutting.
+ * @param n The (maximum) number of modes to be returned.
+ * @return A vector of ModeInfo containing the position and the area of the modes.
+ */
+std::vector<ModeInfo> extractNBigestModes(const XYDataset::XYDataset& pdf, double merge_ratio, size_t n);
 
-    /**
-     * Extract the n modes with biggest area in the provided pdf and compute for
-     * each of them the location of the mode and its area.
-     * A mode is discovered as the highest
-     * point of the pdf, then, on both sides, samples are added until the pdf
-     * starts to rise again. In order to avoid truncating the mode due to a noisy
-     * pdf it is possible to specify a merge_ratio. In this case the samples are
-     * added until their values is below the hight of the peak times the merge ratio,
-     * then additional point are added until the pdf rise again.
-     *
-     * @param x_sampling The horizontal sampling of the pdf to be analysed.
-     * @param pdf_sampling The sampling of the pdf to be analysed.
-     * @param merge_ratio The parameter for mode cutting.
-     * @param n The (maximum) number of modes to be returned.
-     * @return A vector of ModeInfo containing the position and the area of the modes.
-     */
-    std::vector<ModeInfo> extractNBigestModes(std::vector<double>& x_sampling,
-                                              std::vector<double>& pdf_sampling,
-                                              double merge_ratio,
-                                              size_t n);
-
+/**
+ * Extract the n modes with biggest area in the provided pdf and compute for
+ * each of them the location of the mode and its area.
+ * A mode is discovered as the highest
+ * point of the pdf, then, on both sides, samples are added until the pdf
+ * starts to rise again. In order to avoid truncating the mode due to a noisy
+ * pdf it is possible to specify a merge_ratio. In this case the samples are
+ * added until their values is below the hight of the peak times the merge ratio,
+ * then additional point are added until the pdf rise again.
+ *
+ * @param x_sampling The horizontal sampling of the pdf to be analysed.
+ * @param pdf_sampling The sampling of the pdf to be analysed.
+ * @param merge_ratio The parameter for mode cutting.
+ * @param n The (maximum) number of modes to be returned.
+ * @return A vector of ModeInfo containing the position and the area of the modes.
+ */
+std::vector<ModeInfo> extractNBigestModes(std::vector<double>& x_sampling, std::vector<double>& pdf_sampling, double merge_ratio,
+                                          size_t n);
 
 } /* namespace MathUtils */
-}
+}  // namespace Euclid
 
 #endif

--- a/MathUtils/MathUtils/function/Differentiable.h
+++ b/MathUtils/MathUtils/function/Differentiable.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file MathUtils/function/Differentiable.h
  * @date February 18, 2014
  * @author Nikolaos Apostolakos
@@ -67,7 +67,7 @@ public:
   double integrate(const double x1, const double x2) const final;
 };
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid
 
-#endif  /* MATHUTILS_DIFFERENTIABLE_H */
+#endif /* MATHUTILS_DIFFERENTIABLE_H */

--- a/MathUtils/MathUtils/function/Function.h
+++ b/MathUtils/MathUtils/function/Function.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file MathUtils/function/Function.h
  * @date February 18, 2014
  * @author Nikolaos Apostolakos
@@ -25,8 +25,8 @@
 #ifndef MATHUTILS_FUNCTION_H
 #define MATHUTILS_FUNCTION_H
 
-#include <memory>
 #include "ElementsKernel/Exception.h"
+#include <memory>
 
 namespace Euclid {
 namespace MathUtils {
@@ -46,7 +46,6 @@ namespace MathUtils {
 class Function {
 
 public:
-
   /// Default destructor
   virtual ~Function() = default;
 
@@ -66,8 +65,7 @@ public:
   virtual std::unique_ptr<Function> clone() const = 0;
 };
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid
 
-#endif  /* MATHUTILS_FUNCTION_H */
-
+#endif /* MATHUTILS_FUNCTION_H */

--- a/MathUtils/MathUtils/function/FunctionAdapter.h
+++ b/MathUtils/MathUtils/function/FunctionAdapter.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file MathUtils/function/FunctionAdapter.h
  * @date November 2, 2015
  * @author Florian Dubath
@@ -25,8 +25,8 @@
 #ifndef MATHUTILS_FUNCTIONADAPTER_H_
 #define MATHUTILS_FUNCTIONADAPTER_H_
 
-#include <functional>
 #include "MathUtils/function/Function.h"
+#include <functional>
 
 namespace Euclid {
 namespace MathUtils {
@@ -41,7 +41,7 @@ namespace MathUtils {
  * This class provide this functionality. In particular it allows to build a
  * Function out of a Lamda expression.
  */
-class FunctionAdapter: public Function {
+class FunctionAdapter : public Function {
 public:
   /**
    * @brief Constructor
@@ -51,28 +51,27 @@ public:
   explicit FunctionAdapter(std::function<double(double)> function);
 
   /// Default destructor
-  virtual ~FunctionAdapter()=default;
+  virtual ~FunctionAdapter() = default;
 
   /**
-    * Converts the value x from the input domain to the output domain by calling
-    * the internal std::function<double(double)>.
-    * @param x The value to convert
-    * @return The value of the output domain
-    */
+   * Converts the value x from the input domain to the output domain by calling
+   * the internal std::function<double(double)>.
+   * @param x The value to convert
+   * @return The value of the output domain
+   */
   double operator()(const double x) const override;
 
   /**
-    * Creates a clone of the function adapter object.
-    * @return A copy of the FunctionAdapter object
-    */
+   * Creates a clone of the function adapter object.
+   * @return A copy of the FunctionAdapter object
+   */
   std::unique_ptr<Function> clone() const override;
-
 
 private:
   std::function<double(double)> m_function;
 };
 
-}
-}
+}  // namespace MathUtils
+}  // namespace Euclid
 
 #endif /* MATHUTILS_FUNCTIONADAPTER_H_ */

--- a/MathUtils/MathUtils/function/Integrable.h
+++ b/MathUtils/MathUtils/function/Integrable.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file MathUtils/function/Integrable.h
  * @date February 18, 2014
  * @author Nikolaos Apostolakos
@@ -44,7 +44,6 @@ namespace MathUtils {
 class Integrable : public Function {
 
 public:
-
   /// Default destructor
   virtual ~Integrable() = default;
 
@@ -57,8 +56,7 @@ public:
   virtual double integrate(const double a, const double b) const = 0;
 };
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid
 
-#endif  /* MATHUTILS_INTEGRABLE_H */
-
+#endif /* MATHUTILS_INTEGRABLE_H */

--- a/MathUtils/MathUtils/function/Piecewise.h
+++ b/MathUtils/MathUtils/function/Piecewise.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file MathUtils/function/Piecewise.h
  * @date February 20, 2014
  * @author Nikolaos Apostolakos
@@ -25,8 +25,8 @@
 #ifndef MATHUTILS_PIECEWISE_H
 #define MATHUTILS_PIECEWISE_H
 
-#include <vector>
 #include <memory>
+#include <vector>
 
 #include "ElementsKernel/Export.h"
 
@@ -48,7 +48,6 @@ namespace MathUtils {
 class ELEMENTS_API Piecewise : public Integrable {
 
 public:
-
   /**
    * Creates a new Piecewise instance with the given knots and functions between
    * them. The functions vector must have size one less than the knots. The
@@ -93,16 +92,13 @@ public:
   double integrate(const double x1, const double x2) const override;
 
 private:
-
   /// A vector where the knots are kept
   std::vector<double> m_knots;
   /// A vector where the sub-functions are kept
   std::vector<std::unique_ptr<Function>> m_functions;
-
 };
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid
 
-#endif  /* MATHUTILS_PIECEWISE_H */
-
+#endif /* MATHUTILS_PIECEWISE_H */

--- a/MathUtils/MathUtils/function/Polynomial.h
+++ b/MathUtils/MathUtils/function/Polynomial.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file MathUtils/function/Polynomial.h
  * @date February 19, 2014
  * @author Nikolaos Apostolakos
@@ -29,8 +29,8 @@
 
 #include "ElementsKernel/Export.h"
 
-#include "MathUtils/function/Function.h"
 #include "MathUtils/function/Differentiable.h"
+#include "MathUtils/function/Function.h"
 
 namespace Euclid {
 namespace MathUtils {
@@ -43,7 +43,6 @@ namespace MathUtils {
 class ELEMENTS_API Polynomial : public Differentiable {
 
 public:
-
   /**
    * Constructs a new Polynomial function with the given coefficients. The
    * index of the coefficients in the given vector corresponds to the degree of
@@ -72,18 +71,16 @@ public:
   std::shared_ptr<Function> indefiniteIntegral() const override;
 
 private:
-
   /// The vector where the polynomial coefficients are stored
   std::vector<double> m_coef;
   /// The function representing the derivative (uses lazy initialization)
-  mutable std::shared_ptr<Function> m_derivative {};
+  mutable std::shared_ptr<Function> m_derivative{};
   /// The function representing the indefinite integral (uses lazy initialization)
-  mutable std::shared_ptr<Function> m_indefIntegral {};
+  mutable std::shared_ptr<Function> m_indefIntegral{};
 
-}; // End of Polynomial
+};  // End of Polynomial
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid
 
-#endif  /* MATHUTILS_POLYNOMIAL_H */
-
+#endif /* MATHUTILS_POLYNOMIAL_H */

--- a/MathUtils/MathUtils/function/function_tools.h
+++ b/MathUtils/MathUtils/function/function_tools.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file MathUtils/function/function_tools.h
  * @date February 19, 2014
  * @author Nikolaos Apostolakos
@@ -70,9 +70,7 @@ public:
  * integration (if the function do not implement the Integrable interface).
  * @return The integral in the range [min,max]
  */
-ELEMENTS_API double integrate(const Function& function,
-                              const double min,
-                              const double max,
+ELEMENTS_API double integrate(const Function& function, const double min, const double max,
                               std::unique_ptr<NumericalIntegrationScheme> numericalIntegrationScheme = nullptr);
 
 /**
@@ -85,8 +83,7 @@ ELEMENTS_API double integrate(const Function& function,
  */
 ELEMENTS_API std::unique_ptr<Function> multiply(const Function& f1, const Function& f2);
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid
 
-#endif  /* MATHUTILS_FUNCTION_TOOLS_H */
-
+#endif /* MATHUTILS_FUNCTION_TOOLS_H */

--- a/MathUtils/MathUtils/function/multiplication.h
+++ b/MathUtils/MathUtils/function/multiplication.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file MathUtils/function/multiplication.h
  * @date February 19, 2014
  * @author Nikolaos Apostolakos
@@ -26,10 +26,12 @@
 #define MATHUTILS_MULTIPLICATION_H
 
 #include <map>
-#include <utility>
+#include <memory>
 #include <typeindex>
+#include <utility>
 
 #include "ElementsKernel/Export.h"
+#include "MathUtils/function/Function.h"
 
 namespace Euclid {
 namespace MathUtils {
@@ -43,7 +45,7 @@ typedef std::unique_ptr<Function> (*MultiplyFunction)(const Function&, const Fun
  * map is the function which can be used for performing this multiplication in
  * an efficient way.
  */
-ELEMENTS_API extern std::map<std::pair<std::type_index,std::type_index>, MultiplyFunction> multiplySpecificSpecificMap;
+ELEMENTS_API extern std::map<std::pair<std::type_index, std::type_index>, MultiplyFunction> multiplySpecificSpecificMap;
 
 /**
  * A map for retrieving specific function multiplication implementations. The
@@ -53,8 +55,7 @@ ELEMENTS_API extern std::map<std::pair<std::type_index,std::type_index>, Multipl
  */
 ELEMENTS_API extern std::map<std::type_index, MultiplyFunction> multiplySpecificGenericMap;
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid
 
-#endif  /* MATHUTILS_MULTIPLICATION_H */
-
+#endif /* MATHUTILS_MULTIPLICATION_H */

--- a/MathUtils/MathUtils/interpolation/interpolation.h
+++ b/MathUtils/MathUtils/interpolation/interpolation.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file MathUtils/interpolation/interpolation.h
  * @date February 20, 2014
  * @author Nikolaos Apostolakos
@@ -28,19 +28,17 @@
 #include <memory>
 #include <vector>
 
-#include "ElementsKernel/Export.h"
 #include "ElementsKernel/Exception.h"
+#include "ElementsKernel/Export.h"
 
-#include "XYDataset/XYDataset.h"
 #include "MathUtils/function/Function.h"
+#include "XYDataset/XYDataset.h"
 
 namespace Euclid {
 namespace MathUtils {
 
 /// Enumeration of the different supported interpolation types
-enum class InterpolationType {
-  LINEAR, CUBIC_SPLINE
-};
+enum class InterpolationType { LINEAR, CUBIC_SPLINE };
 
 struct InterpolationException : public Elements::Exception {
   using Elements::Exception::Exception;
@@ -61,7 +59,7 @@ struct InterpolationException : public Elements::Exception {
  *    if there are (X,Y) pairs with same X value but different Y value (step functions)
  */
 ELEMENTS_API std::unique_ptr<Function> interpolate(const std::vector<double>& x, const std::vector<double>& y,
-                                                   InterpolationType type, bool extrapolate=false);
+                                                   InterpolationType type, bool extrapolate = false);
 
 /**
  * Returns a Function which performs interpolation for the data points of the
@@ -75,9 +73,9 @@ ELEMENTS_API std::unique_ptr<Function> interpolate(const std::vector<double>& x,
  *    if there are (X,Y) pairs with same X value but different Y value (step functions)
  */
 ELEMENTS_API std::unique_ptr<Function> interpolate(const Euclid::XYDataset::XYDataset& dataset, InterpolationType type,
-                                                   bool extrapolate=false);
+                                                   bool extrapolate = false);
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid
 
-#endif  /* INTERPOLATION_H */
+#endif /* INTERPOLATION_H */

--- a/MathUtils/MathUtils/numericalDifferentiation/FiniteDifference.h
+++ b/MathUtils/MathUtils/numericalDifferentiation/FiniteDifference.h
@@ -64,7 +64,7 @@ double derivative(const Function& f, const double x);
  */
 double derivative2nd(const Function& f, const double x);
 
-} // end namespace MathUtils
-} // end namespace Euclid
+}  // end namespace MathUtils
+}  // end namespace Euclid
 
-#endif // MATHUTILS_MATHUTILS_NUMERICALDIFFERENTIATION_FINITEDIFFERENCE_H_
+#endif  // MATHUTILS_MATHUTILS_NUMERICALDIFFERENTIATION_FINITEDIFFERENCE_H_

--- a/MathUtils/MathUtils/numericalIntegration/AdaptativeIntegration.h
+++ b/MathUtils/MathUtils/numericalIntegration/AdaptativeIntegration.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file MathUtils/numericalIntegration/AdaptativeIntegration.h
  * @date July 2, 2015
  * @author Florian Dubath
@@ -24,10 +24,10 @@
 
 #ifndef MATHUTILS_MATHUTILS_NUMERCALINTEGRATION_ADAPTATIVEINTEGRATION_H_
 #define MATHUTILS_MATHUTILS_NUMERCALINTEGRATION_ADAPTATIVEINTEGRATION_H_
-#include <cmath>
 #include "ElementsKernel/Real.h"
 #include "MathUtils/function/Function.h"
 #include "MathUtils/function/function_tools.h"
+#include <cmath>
 
 namespace Euclid {
 namespace MathUtils {
@@ -48,8 +48,8 @@ namespace MathUtils {
  * @tparam quadrature The numerical quadrature used to compute the integral
  * approximation.
  */
-template<typename Quadrature>
-class AdaptativeIntegration: public NumericalIntegrationScheme {
+template <typename Quadrature>
+class AdaptativeIntegration : public NumericalIntegrationScheme {
 
 public:
   /**
@@ -79,13 +79,13 @@ public:
   double operator()(const Function& function, double min, double max) override;
 
 private:
-  Quadrature m_quadrature { };
-  double m_relative_precion;
-  int m_initial_order;
+  Quadrature m_quadrature{};
+  double     m_relative_precion;
+  int        m_initial_order;
 };
 
-}
-}
+}  // namespace MathUtils
+}  // namespace Euclid
 
 #include "MathUtils/numericalIntegration/_impl/AdaptativeIntegration.icpp"
 

--- a/MathUtils/MathUtils/numericalIntegration/SimpsonsRule.h
+++ b/MathUtils/MathUtils/numericalIntegration/SimpsonsRule.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file MathUtils/numericalIntegration/SimpsonsRule.h
  * @date July 2, 2015
  * @author Florian Dubath
@@ -89,12 +89,10 @@ public:
    * @param previous_value
    * The value of the integration at the previous order.
    */
-  double operator()(const Function& function, double min, double max,
-      double previous_value, int order);
-
+  double operator()(const Function& function, double min, double max, double previous_value, int order);
 };
 
-}
-}
+}  // namespace MathUtils
+}  // namespace Euclid
 
 #endif /* MATHUTILS_MATHUTILS_NUMERCALINTEGRATION_SIMPSONSRULE_H_ */

--- a/MathUtils/MathUtils/numericalIntegration/_impl/AdaptativeIntegration.icpp
+++ b/MathUtils/MathUtils/numericalIntegration/_impl/AdaptativeIntegration.icpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file MathUtils/numericalIntegration/_impl/AdaptativeIntegration.icpp
  * @date July 2, 2015
  * @author Florian Dubath
@@ -25,29 +25,25 @@
 namespace Euclid {
 namespace MathUtils {
 
-template<typename Quadrature>
-AdaptativeIntegration<Quadrature>::AdaptativeIntegration(
-    double relative_precion, int initial_order) :
-    m_relative_precion { relative_precion }, m_initial_order { initial_order } {
-}
+template <typename Quadrature>
+AdaptativeIntegration<Quadrature>::AdaptativeIntegration(double relative_precion, int initial_order)
+    : m_relative_precion{relative_precion}, m_initial_order{initial_order} {}
 
-template<typename Quadrature>
-double AdaptativeIntegration<Quadrature>::operator()(const Function& function,
-    double min, double max) {
-  int m = m_initial_order;
-  double value_order_m = 0.;
+template <typename Quadrature>
+double AdaptativeIntegration<Quadrature>::operator()(const Function& function, double min, double max) {
+  int    m               = m_initial_order;
+  double value_order_m   = 0.;
   double value_order_m_1 = m_quadrature(function, min, max, m);
-  double diff = 0.;
+  double diff            = 0.;
   do {
     ++m;
-    value_order_m = value_order_m_1;
+    value_order_m   = value_order_m_1;
     value_order_m_1 = m_quadrature(function, min, max, value_order_m, m);
-    diff = value_order_m_1 - value_order_m;
+    diff            = value_order_m_1 - value_order_m;
   } while (std::abs(diff / value_order_m) > m_relative_precion);
 
   return value_order_m_1;
 }
 
-}
-}
-
+}  // namespace MathUtils
+}  // namespace Euclid

--- a/MathUtils/src/lib/PDF/Cumulative.cpp
+++ b/MathUtils/src/lib/PDF/Cumulative.cpp
@@ -23,185 +23,169 @@
  */
 
 #include "MathUtils/PDF/Cumulative.h"
-#include <cstdlib> // for size_t
 #include "ElementsKernel/Exception.h"
 #include "XYDataset/XYDataset.h"
+#include <cstdlib>  // for size_t
 
 namespace Euclid {
 namespace MathUtils {
 
+Cumulative::Cumulative(Cumulative&& other)
+    : m_x_sampling(std::move(other.m_x_sampling)), m_y_sampling(std::move(other.m_y_sampling)) {}
 
-  Cumulative::Cumulative(Cumulative&& other)
-    : m_x_sampling(std::move(other.m_x_sampling)),
-      m_y_sampling(std::move(other.m_y_sampling)) {}
+Cumulative& Cumulative::operator=(Cumulative&& other) {
+  m_x_sampling = std::move(other.m_x_sampling);
+  m_y_sampling = std::move(other.m_y_sampling);
+  return *this;
+}
 
-  Cumulative& Cumulative::operator = ( Cumulative && other){
-    m_x_sampling=std::move(other.m_x_sampling);
-    m_y_sampling=std::move(other.m_y_sampling);
-    return *this;
+Cumulative::Cumulative(const Cumulative& other) : m_x_sampling(other.m_x_sampling), m_y_sampling(other.m_y_sampling) {}
+
+Cumulative& Cumulative ::operator=(const Cumulative& other) {
+  m_x_sampling = other.m_x_sampling;
+  m_y_sampling = other.m_y_sampling;
+  return *this;
+}
+
+Cumulative::Cumulative(std::vector<double>& x_sampling, std::vector<double>& y_sampling)
+    : m_x_sampling(x_sampling), m_y_sampling(y_sampling) {
+  if (x_sampling.size() != y_sampling.size()) {
+    throw Elements::Exception("Cumulative: X and Y sampling do not have the same length.");
+  }
+}
+
+Cumulative::Cumulative(const XYDataset::XYDataset& sampling) : m_x_sampling{}, m_y_sampling{} {
+  auto iter = sampling.begin();
+  while (iter != sampling.end()) {
+    m_x_sampling.push_back((*iter).first);
+    m_y_sampling.push_back((*iter).second);
+    ++iter;
+  }
+}
+
+Cumulative Cumulative::fromPdf(const XYDataset::XYDataset& sampling) {
+  std::vector<double> xs{};
+  std::vector<double> ys{};
+  auto                iter = sampling.begin();
+  while (iter != sampling.end()) {
+    xs.push_back((*iter).first);
+    ys.push_back((*iter).second);
+    ++iter;
+  }
+  return Cumulative::fromPdf(xs, ys);
+}
+
+Cumulative Cumulative::fromPdf(std::vector<double>& x_sampling, std::vector<double>& pdf_sampling) {
+  double              total = 0.;
+  std::vector<double> cumul{};
+  auto                iter_pdf = pdf_sampling.cbegin();
+
+  while (iter_pdf != pdf_sampling.cend()) {
+    total += *(iter_pdf);
+    cumul.push_back(total);
+    ++iter_pdf;
   }
 
-  Cumulative::Cumulative(const Cumulative& other)
-    : m_x_sampling(other.m_x_sampling), m_y_sampling(other.m_y_sampling) {}
+  return Cumulative(x_sampling, cumul);
+}
 
-  Cumulative& Cumulative :: operator = ( const Cumulative & other){
-     m_x_sampling=other.m_x_sampling;
-     m_y_sampling=other.m_y_sampling;
-     return *this;
+void Cumulative::normalize() {
+  double              total = m_y_sampling.back();
+  std::vector<double> cumul{};
+  auto                iter = m_y_sampling.begin();
+  while (iter != m_y_sampling.end()) {
+    cumul.push_back(*iter / total);
+    ++iter;
   }
 
-  Cumulative::Cumulative(std::vector<double>& x_sampling, std::vector<double>& y_sampling)
-    : m_x_sampling(x_sampling),
-      m_y_sampling(y_sampling) {
-    if (x_sampling.size()!=y_sampling.size()){
-      throw  Elements::Exception("Cumulative: X and Y sampling do not have the same length.");
-    }
-  }
-
-
-  Cumulative::Cumulative(const XYDataset::XYDataset& sampling)
-    : m_x_sampling{}, m_y_sampling{} {
-    auto iter = sampling.begin();
-    while (iter != sampling.end()) {
-      m_x_sampling.push_back((*iter).first);
-      m_y_sampling.push_back((*iter).second);
-        ++iter;
-    }
-  }
-
-
-
-Cumulative Cumulative::fromPdf(const XYDataset::XYDataset &  sampling) {
-    std::vector<double> xs{};
-    std::vector<double> ys{};
-    auto iter = sampling.begin();
-    while (iter != sampling.end()) {
-      xs.push_back((*iter).first);
-      ys.push_back((*iter).second);
-        ++iter;
-    }
-    return Cumulative::fromPdf(xs, ys);
-  }
-
-
-  Cumulative Cumulative::fromPdf(std::vector<double>& x_sampling, std::vector<double>& pdf_sampling) {
-    double total = 0.;
-    std::vector<double> cumul{};
-    auto iter_pdf = pdf_sampling.cbegin();
-
-    while (iter_pdf != pdf_sampling.cend()) {
-      total += *(iter_pdf);
-      cumul.push_back(total);
-      ++iter_pdf;
-    }
-
-    return Cumulative(x_sampling, cumul);
-  }
-
-
-  void Cumulative::normalize() {
-    double total = m_y_sampling.back();
-    std::vector<double> cumul{};
-    auto iter = m_y_sampling.begin();
-    while (iter != m_y_sampling.end()) {
-      cumul.push_back(*iter / total);
-      ++iter;
-    }
-
-    m_y_sampling = std::move(cumul);
-  }
-
+  m_y_sampling = std::move(cumul);
+}
 
 double Cumulative::findValue(double ratio, TrayPosition position) const {
   if (ratio > 1. || ratio < 0.) {
     throw Elements::Exception("Cumulative::findValue : ratio parameter must be in range [0,1]");
   }
-  double value = m_y_sampling.back() * ratio;
-  auto iter_x = m_x_sampling.cbegin();
-  auto iter_y = m_y_sampling.cbegin();
+  double value  = m_y_sampling.back() * ratio;
+  auto   iter_x = m_x_sampling.cbegin();
+  auto   iter_y = m_y_sampling.cbegin();
   while (iter_y != m_y_sampling.cend() && (*iter_y) < value) {
     ++iter_x;
     ++iter_y;
   }
   double begin_value = *iter_x;
-    double tray = *iter_y;
-    while (iter_y != m_y_sampling.cend() && (*iter_y) == tray) {
-      ++iter_x;
-      ++iter_y;
-    }
-
-    double end_value = *(--iter_x);
-
-    double result = 0;
-    switch (position) {
-      case TrayPosition::begin:
-        result = begin_value;
-        break;
-      case TrayPosition::middle:
-        result = 0.5 * (begin_value + end_value);
-        break;
-      case TrayPosition::end:
-        result = end_value;
-        break;
-    }
-
-    return result;
+  double tray        = *iter_y;
+  while (iter_y != m_y_sampling.cend() && (*iter_y) == tray) {
+    ++iter_x;
+    ++iter_y;
   }
 
+  double end_value = *(--iter_x);
 
-  std::pair<double,double> Cumulative::findMinInterval(double rate) const{
-
-    if (rate > 1. || rate <= 0.) {
-      throw Elements::Exception("Cumulative::findMinInterval : rate parameter must be in range ]0,1]");
-    }
-
-    rate *= m_y_sampling.back();
-
-    double first_correction = m_y_sampling.front();
-
-    auto iter_1_x = m_x_sampling.cbegin();
-    auto iter_2_x = ++(m_x_sampling.cbegin());
-    auto iter_1_y = m_y_sampling.cbegin();
-    auto iter_2_y = ++(m_y_sampling.cbegin());
-    auto min_x = m_x_sampling.cbegin();
-    auto max_x = --(m_x_sampling.cend());
-    while (iter_1_x != m_x_sampling.cend()) {
-      while (iter_2_x != m_x_sampling.cend() && (*iter_2_y - *iter_1_y + first_correction) < rate) {
-        ++iter_2_x;
-        ++iter_2_y;
-      }
-      if (iter_2_x == m_x_sampling.cend()) {
-        break;
-      }
-      if ((*iter_2_x - *iter_1_x) <= (*max_x - *min_x)) {
-        max_x = iter_2_x;
-        min_x = iter_1_x;
-      }
-      ++iter_1_x;
-      ++iter_1_y;
-      first_correction = 0.;
-    }
-
-    return std::make_pair(*min_x, *max_x);
-
+  double result = 0;
+  switch (position) {
+  case TrayPosition::begin:
+    result = begin_value;
+    break;
+  case TrayPosition::middle:
+    result = 0.5 * (begin_value + end_value);
+    break;
+  case TrayPosition::end:
+    result = end_value;
+    break;
   }
 
-
-  std::pair<double,double> Cumulative::findCenteredInterval( double rate) const{
-    if (rate>1. || rate<=0.){
-         throw  Elements::Exception("Cumulative::findCenteredInterval : rate parameter must be in range ]0,1]");
-    }
-
-    double min_rate = 0.5 - rate/2.0;
-    double max_rate = 0.5 + rate/2.0;
-
-    double min_x = findValue(min_rate, TrayPosition::end);
-    double max_x = findValue(max_rate, TrayPosition::begin);
-
-    return std::make_pair(min_x, max_x);
-  }
-
-} // MathUtils namespace
+  return result;
 }
 
+std::pair<double, double> Cumulative::findMinInterval(double rate) const {
 
+  if (rate > 1. || rate <= 0.) {
+    throw Elements::Exception("Cumulative::findMinInterval : rate parameter must be in range ]0,1]");
+  }
+
+  rate *= m_y_sampling.back();
+
+  double first_correction = m_y_sampling.front();
+
+  auto iter_1_x = m_x_sampling.cbegin();
+  auto iter_2_x = ++(m_x_sampling.cbegin());
+  auto iter_1_y = m_y_sampling.cbegin();
+  auto iter_2_y = ++(m_y_sampling.cbegin());
+  auto min_x    = m_x_sampling.cbegin();
+  auto max_x    = --(m_x_sampling.cend());
+  while (iter_1_x != m_x_sampling.cend()) {
+    while (iter_2_x != m_x_sampling.cend() && (*iter_2_y - *iter_1_y + first_correction) < rate) {
+      ++iter_2_x;
+      ++iter_2_y;
+    }
+    if (iter_2_x == m_x_sampling.cend()) {
+      break;
+    }
+    if ((*iter_2_x - *iter_1_x) <= (*max_x - *min_x)) {
+      max_x = iter_2_x;
+      min_x = iter_1_x;
+    }
+    ++iter_1_x;
+    ++iter_1_y;
+    first_correction = 0.;
+  }
+
+  return std::make_pair(*min_x, *max_x);
+}
+
+std::pair<double, double> Cumulative::findCenteredInterval(double rate) const {
+  if (rate > 1. || rate <= 0.) {
+    throw Elements::Exception("Cumulative::findCenteredInterval : rate parameter must be in range ]0,1]");
+  }
+
+  double min_rate = 0.5 - rate / 2.0;
+  double max_rate = 0.5 + rate / 2.0;
+
+  double min_x = findValue(min_rate, TrayPosition::end);
+  double max_x = findValue(max_rate, TrayPosition::begin);
+
+  return std::make_pair(min_x, max_x);
+}
+
+}  // namespace MathUtils
+}  // namespace Euclid

--- a/MathUtils/src/lib/PDF/PdfModeExtraction.cpp
+++ b/MathUtils/src/lib/PDF/PdfModeExtraction.cpp
@@ -23,39 +23,37 @@
  */
 
 #include "MathUtils/PDF/PdfModeExtraction.h"
-#include <cstddef>
-#include <utility>
-#include <iterator>
-#include <vector>
-#include <tuple>
 #include "ElementsKernel/Exception.h"
+#include <cstddef>
+#include <iterator>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 namespace Euclid {
 namespace MathUtils {
 
-
-
 std::pair<std::vector<double>, std::vector<double>> getXYs(const XYDataset::XYDataset& pdf) {
-    std::vector<double> xs{};
-    std::vector<double> ys{};
+  std::vector<double> xs{};
+  std::vector<double> ys{};
 
-    auto iter = pdf.begin();
-    while (iter != pdf.end()) {
-        xs.push_back((*iter).first);
-        ys.push_back((*iter).second);
-        ++iter;
-    }
+  auto iter = pdf.begin();
+  while (iter != pdf.end()) {
+    xs.push_back((*iter).first);
+    ys.push_back((*iter).second);
+    ++iter;
+  }
 
-    return std::make_pair(xs, ys);
+  return std::make_pair(xs, ys);
 }
 
 size_t findMaximumIndex(const std::vector<double>& pdf) {
-  double max = -1;
-  size_t index = 0;
+  double max       = -1;
+  size_t index     = 0;
   size_t max_index = 0;
   for (auto iter = pdf.begin(); iter != pdf.end(); ++iter) {
     if (*iter > max) {
-      max = *iter;
+      max       = *iter;
       max_index = index;
     }
     ++index;
@@ -64,33 +62,30 @@ size_t findMaximumIndex(const std::vector<double>& pdf) {
   return max_index;
 }
 
-
-
 std::pair<size_t, size_t> catchPeak(const std::vector<double>& pdf, size_t center_index, double merge_ratio) {
 
   double peak_value = pdf[center_index];
-  double threshold = (1.0-merge_ratio)*peak_value;
-  size_t min_x = 0;
-  size_t max_x = pdf.size()-1;
+  double threshold  = (1.0 - merge_ratio) * peak_value;
+  size_t min_x      = 0;
+  size_t max_x      = pdf.size() - 1;
 
   for (size_t index = 0; index <= center_index; ++index) {
-    size_t position = center_index-index;
+    size_t position = center_index - index;
     if (position == 0 || pdf[position] == 0) {
-       break;
+      break;
     }
-    if ((pdf[position] < threshold &&  pdf[position-1] >= pdf[position])) {
-        min_x = position;
-        break;
+    if ((pdf[position] < threshold && pdf[position - 1] >= pdf[position])) {
+      min_x = position;
+      break;
     }
     min_x = position;
   }
 
-
   for (size_t position = center_index; position <= pdf.size(); ++position) {
-    if (position == pdf.size()-1 || pdf[position] == 0) {
+    if (position == pdf.size() - 1 || pdf[position] == 0) {
       break;
     }
-    if ((pdf[position] < threshold && pdf[position+1] >= pdf[position] )) {
+    if ((pdf[position] < threshold && pdf[position + 1] >= pdf[position])) {
       max_x = position;
       break;
     }
@@ -101,62 +96,61 @@ std::pair<size_t, size_t> catchPeak(const std::vector<double>& pdf, size_t cente
 }
 
 // basic integration may be refined
-std::pair<double, double>
-avgArea(std::pair<std::vector<double>, std::vector<double>>& pdf, size_t min_x, size_t max_x) {
+std::pair<double, double> avgArea(std::pair<std::vector<double>, std::vector<double>>& pdf, size_t min_x, size_t max_x) {
 
-  double num = 0.;
+  double num  = 0.;
   double area = 0.;
   for (size_t index = min_x; index <= max_x; ++index) {
     double dx = 0.;
     if (index == 0) {
-      dx = pdf.first[index+1] - pdf.first[index];
-    } else if (index == pdf.first.size()-1) {
-      dx = pdf.first[index] - pdf.first[index-1];
+      dx = pdf.first[index + 1] - pdf.first[index];
+    } else if (index == pdf.first.size() - 1) {
+      dx = pdf.first[index] - pdf.first[index - 1];
     } else {
-      dx = (pdf.first[index+1] - pdf.first[index-1])/2.0;
+      dx = (pdf.first[index + 1] - pdf.first[index - 1]) / 2.0;
     }
 
-    num += pdf.first[index]*pdf.second[index]*dx;
-    area += pdf.second[index]*dx;
+    num += pdf.first[index] * pdf.second[index] * dx;
+    area += pdf.second[index] * dx;
   }
 
-  return std::make_pair(num/area, area);
+  return std::make_pair(num / area, area);
 }
 
 double getInterpolationAround(const std::pair<std::vector<double>, std::vector<double>>& pdf, size_t x_index) {
-   /*
-   without assuming equi-distant sampling
+  /*
+  without assuming equi-distant sampling
 
-   x_max= ((x1^2-x0^2)*y2 - (x2^2-x0^2)*y1+(x2^2-x1^2)*y0)/(2*((x1-x0)*y2-(x2-x0)*y1+(x2-x1)*y0))
+  x_max= ((x1^2-x0^2)*y2 - (x2^2-x0^2)*y1+(x2^2-x1^2)*y0)/(2*((x1-x0)*y2-(x2-x0)*y1+(x2-x1)*y0))
 
-   */
-  if (x_index>= pdf.first.size()) {
-    throw  Elements::Exception("getInterpolationAround: x_index out of range.");
+  */
+  if (x_index >= pdf.first.size()) {
+    throw Elements::Exception("getInterpolationAround: x_index out of range.");
   }
 
   // ensure we are not on the border
   if (x_index == 0) {
-    x_index+=1;
-  } else if (x_index +1 == pdf.first.size()) {
+    x_index += 1;
+  } else if (x_index + 1 == pdf.first.size()) {
     x_index -= 1;
   }
 
-  double x0 = pdf.first[x_index-1];
-  double y0 = pdf.second[x_index-1];
+  double x0 = pdf.first[x_index - 1];
+  double y0 = pdf.second[x_index - 1];
 
   double x1 = pdf.first[x_index];
   double y1 = pdf.second[x_index];
 
-  double x2 = pdf.first[x_index+1];
-  double y2 = pdf.second[x_index+1];
+  double x2 = pdf.first[x_index + 1];
+  double y2 = pdf.second[x_index + 1];
 
-  double denom = 2*((x1-x0)*y2 - (x2-x0)*y1 + (x2-x1)*y0);
-  double num = (x1*x1-x0*x0)*y2 - (x2*x2-x0*x0)*y1 + (x2*x2-x1*x1)*y0;
+  double denom = 2 * ((x1 - x0) * y2 - (x2 - x0) * y1 + (x2 - x1) * y0);
+  double num   = (x1 * x1 - x0 * x0) * y2 - (x2 * x2 - x0 * x0) * y1 + (x2 * x2 - x1 * x1) * y0;
 
   double x_max = x1;
   // protect against division by 0 (flat interval)
   if (denom != 0) {
-      x_max = num/denom;
+    x_max = num / denom;
   }
 
   // check in interval
@@ -169,12 +163,8 @@ double getInterpolationAround(const std::pair<std::vector<double>, std::vector<d
   return x_max;
 }
 
-
-std::pair<std::vector<double>, std::vector<double>> flatternPeak(const std::pair<std::vector<double>,
-                                                                std::vector<double>>& pdf,
-                                                                size_t min_x,
-                                                                size_t max_x,
-                                                                double value) {
+std::pair<std::vector<double>, std::vector<double>> flatternPeak(const std::pair<std::vector<double>, std::vector<double>>& pdf,
+                                                                 size_t min_x, size_t max_x, double value) {
   std::vector<double> flatterned{pdf.second};
   for (size_t index = min_x; index <= max_x; ++index) {
     flatterned[index] = value;
@@ -182,19 +172,16 @@ std::pair<std::vector<double>, std::vector<double>> flatternPeak(const std::pair
   return std::make_pair(pdf.first, flatterned);
 }
 
-
-std::vector<ModeInfo> extractNHighestModes(std::vector<double>& x_sampling,
-                                           std::vector<double>& pdf_sampling,
-                                           double merge_ratio,
+std::vector<ModeInfo> extractNHighestModes(std::vector<double>& x_sampling, std::vector<double>& pdf_sampling, double merge_ratio,
                                            size_t n) {
   std::vector<ModeInfo> result{};
-  auto pdf_xy = std::make_pair(x_sampling, pdf_sampling);
+  auto                  pdf_xy = std::make_pair(x_sampling, pdf_sampling);
 
   for (size_t idx = 0; idx < n; ++idx) {
     auto peak_index = findMaximumIndex(pdf_xy.second);
-    auto min_max = catchPeak(pdf_xy.second, peak_index, merge_ratio);
-    auto mean_area = avgArea(pdf_xy, min_max.first, min_max.second);
-    auto max_inter = getInterpolationAround(pdf_xy, peak_index);
+    auto min_max    = catchPeak(pdf_xy.second, peak_index, merge_ratio);
+    auto mean_area  = avgArea(pdf_xy, min_max.first, min_max.second);
+    auto max_inter  = getInterpolationAround(pdf_xy, peak_index);
 
     result.push_back(ModeInfo(pdf_xy.first[peak_index], mean_area.first, max_inter, mean_area.second));
     pdf_xy = flatternPeak(pdf_xy, min_max.first, min_max.second, 0.0);
@@ -202,64 +189,56 @@ std::vector<ModeInfo> extractNHighestModes(std::vector<double>& x_sampling,
   return result;
 }
 
-
 std::vector<ModeInfo> extractNHighestModes(const XYDataset::XYDataset& pdf, double merge_ratio, size_t n) {
   auto pdf_xy = getXYs(pdf);
   return extractNHighestModes(pdf_xy.first, pdf_xy.second, merge_ratio, n);
 }
 
-
-std::vector<ModeInfo> extractNBigestModes(std::vector<double>& x_sampling,
-                                              std::vector<double>& pdf_sampling,
-                                              double merge_ratio,
-                                              size_t n) {
-  auto pdf_xy = std::make_pair(x_sampling, pdf_sampling);
-  double total_area = avgArea(pdf_xy, 0, x_sampling.size() -1).second;
+std::vector<ModeInfo> extractNBigestModes(std::vector<double>& x_sampling, std::vector<double>& pdf_sampling, double merge_ratio,
+                                          size_t n) {
+  auto   pdf_xy     = std::make_pair(x_sampling, pdf_sampling);
+  double total_area = avgArea(pdf_xy, 0, x_sampling.size() - 1).second;
 
   std::vector<ModeInfo> result{};
 
-  bool out = false;
+  bool   out  = false;
   size_t loop = 0;
   while (!out) {
 
-   auto peak_index = findMaximumIndex(pdf_xy.second);
-   auto min_max = catchPeak(pdf_xy.second, peak_index, merge_ratio);
-   auto mean_area = avgArea(pdf_xy, min_max.first, min_max.second);
-   auto max_sample = pdf_xy.first[peak_index];
-   double interp_max_value =  getInterpolationAround(pdf_xy, peak_index);
-   auto new_mode = ModeInfo(max_sample, mean_area.first, interp_max_value, mean_area.second);
+    auto   peak_index       = findMaximumIndex(pdf_xy.second);
+    auto   min_max          = catchPeak(pdf_xy.second, peak_index, merge_ratio);
+    auto   mean_area        = avgArea(pdf_xy, min_max.first, min_max.second);
+    auto   max_sample       = pdf_xy.first[peak_index];
+    double interp_max_value = getInterpolationAround(pdf_xy, peak_index);
+    auto   new_mode         = ModeInfo(max_sample, mean_area.first, interp_max_value, mean_area.second);
 
-   auto iter_mode = result.begin();
-   while (iter_mode != result.end()) {
-     if ((*iter_mode).getModeArea() < mean_area.second) {
-       break;
-     }
-     ++iter_mode;
-   }
+    auto iter_mode = result.begin();
+    while (iter_mode != result.end()) {
+      if ((*iter_mode).getModeArea() < mean_area.second) {
+        break;
+      }
+      ++iter_mode;
+    }
 
-   if (iter_mode != result.end()) {
-     result.insert(iter_mode, new_mode);
-   } else if (result.size() < n) {
+    if (iter_mode != result.end()) {
+      result.insert(iter_mode, new_mode);
+    } else if (result.size() < n) {
       result.push_back(new_mode);
-   }
-   total_area -= mean_area.second;
-   out = result.size() >= n && (result.back().getModeArea() > total_area || loop > 3*n);
+    }
+    total_area -= mean_area.second;
+    out = result.size() >= n && (result.back().getModeArea() > total_area || loop > 3 * n);
 
-   pdf_xy = flatternPeak(pdf_xy, min_max.first, min_max.second, 0.0);
-   ++loop;
+    pdf_xy = flatternPeak(pdf_xy, min_max.first, min_max.second, 0.0);
+    ++loop;
   }
 
-   return result;
+  return result;
 }
-
 
 std::vector<ModeInfo> extractNBigestModes(const XYDataset::XYDataset& pdf, double merge_ratio, size_t n) {
-   auto pdf_xy = getXYs(pdf);
-   return extractNBigestModes(pdf_xy.first, pdf_xy.second, merge_ratio, n);
+  auto pdf_xy = getXYs(pdf);
+  return extractNBigestModes(pdf_xy.first, pdf_xy.second, merge_ratio, n);
 }
 
-
-} // MathUtils namespace
-}
-
-
+}  // namespace MathUtils
+}  // namespace Euclid

--- a/MathUtils/src/lib/function/Differentiable.cpp
+++ b/MathUtils/src/lib/function/Differentiable.cpp
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/function/Differentiable.cpp
  * @date February 18, 2014
  * @author Nikolaos Apostolakos
@@ -32,5 +32,5 @@ double Differentiable::integrate(const double x1, const double x2) const {
   return (*antiderivative)(x2) - (*antiderivative)(x1);
 }
 
-} // end of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid

--- a/MathUtils/src/lib/function/FunctionAdapter.cpp
+++ b/MathUtils/src/lib/function/FunctionAdapter.cpp
@@ -1,46 +1,42 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /*
+
+/*
  * FunctionAdapter.cpp
  *
  *  Created on: Nov 2, 2015
  *      Author: fdubath
  */
 
-
 #include "MathUtils/function/FunctionAdapter.h"
 
 namespace Euclid {
 namespace MathUtils {
 
-FunctionAdapter::FunctionAdapter(std::function<double(double)> function) :
-    m_function { function } {
-}
+FunctionAdapter::FunctionAdapter(std::function<double(double)> function) : m_function{function} {}
 
-double FunctionAdapter::operator()(const double x) const  {
+double FunctionAdapter::operator()(const double x) const {
   return m_function(x);
 }
 
-std::unique_ptr<Function> FunctionAdapter::clone() const  {
-  return std::unique_ptr<Function> { new FunctionAdapter(m_function) };
+std::unique_ptr<Function> FunctionAdapter::clone() const {
+  return std::unique_ptr<Function>{new FunctionAdapter(m_function)};
 }
 
-}
-}
-
+}  // namespace MathUtils
+}  // namespace Euclid

--- a/MathUtils/src/lib/function/Piecewise.cpp
+++ b/MathUtils/src/lib/function/Piecewise.cpp
@@ -16,25 +16,23 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/function/Piecewise.cpp
  * @date February 20, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <algorithm>
-#include "ElementsKernel/Exception.h"
 #include "MathUtils/function/Piecewise.h"
+#include "ElementsKernel/Exception.h"
 #include "MathUtils/function/function_tools.h"
+#include <algorithm>
 
 namespace Euclid {
 namespace MathUtils {
 
-Piecewise::Piecewise(std::vector<double> knots, std::vector<std::shared_ptr<Function> > functions)
-                    : m_knots{std::move(knots)} {
+Piecewise::Piecewise(std::vector<double> knots, std::vector<std::shared_ptr<Function>> functions) : m_knots{std::move(knots)} {
   if (m_knots.size() - functions.size() != 1) {
-    throw Elements::Exception() << "Invalid number of knots(" << m_knots.size()
-                              << ")-functions(" << m_functions.size() << ")";
+    throw Elements::Exception() << "Invalid number of knots(" << m_knots.size() << ")-functions(" << m_functions.size() << ")";
   }
 
   m_functions.reserve(functions.size());
@@ -43,21 +41,20 @@ Piecewise::Piecewise(std::vector<double> knots, std::vector<std::shared_ptr<Func
 
   auto knotsIter = m_knots.begin();
   while (++knotsIter != m_knots.end()) {
-    if (*knotsIter <= *(knotsIter-1)) {
+    if (*knotsIter <= *(knotsIter - 1)) {
       throw Elements::Exception("knots must be strictly increasing");
     }
   }
 }
 
 Piecewise::Piecewise(std::vector<double> knots, std::vector<std::unique_ptr<Function>>&& functions)
-                    : m_knots{std::move(knots)}, m_functions{std::move(functions)} {
+    : m_knots{std::move(knots)}, m_functions{std::move(functions)} {
   if (m_knots.size() - m_functions.size() != 1) {
-    throw Elements::Exception() << "Invalid number of knots(" << m_knots.size()
-                                << ")-functions(" << m_functions.size() << ")";
+    throw Elements::Exception() << "Invalid number of knots(" << m_knots.size() << ")-functions(" << m_functions.size() << ")";
   }
   auto knotsIter = m_knots.begin();
   while (++knotsIter != m_knots.end()) {
-    if (*knotsIter <= *(knotsIter-1)) {
+    if (*knotsIter <= *(knotsIter - 1)) {
       throw Elements::Exception("knots must be strictly increasing");
     }
   }
@@ -80,36 +77,36 @@ double Piecewise::operator()(const double x) const {
     return (*m_functions[0])(x);
   }
   auto knotsEnd = m_knots.end();
-  auto findX = std::lower_bound(knotsBegin, knotsEnd, x);
+  auto findX    = std::lower_bound(knotsBegin, knotsEnd, x);
   if (findX == knotsEnd) {
     return 0;
   }
-  return (*m_functions[findX-knotsBegin-1])(x);
+  return (*m_functions[findX - knotsBegin - 1])(x);
 }
 
 std::unique_ptr<Function> Piecewise::clone() const {
   std::vector<std::unique_ptr<Function>> cloned_functions;
   cloned_functions.reserve(m_functions.size());
-  for (auto& f: m_functions) {
+  for (auto& f : m_functions) {
     cloned_functions.emplace_back(f->clone());
   }
-  return std::unique_ptr<Function> {new Piecewise(m_knots, std::move(cloned_functions))};
+  return std::unique_ptr<Function>{new Piecewise(m_knots, std::move(cloned_functions))};
 }
 
 double Piecewise::integrate(const double x1, const double x2) const {
   if (x1 == x2) {
     return 0;
   }
-  int direction = 1;
-  double min = x1;
-  double max = x2;
+  int    direction = 1;
+  double min       = x1;
+  double max       = x2;
   if (min > max) {
     direction = -1;
-    min = x2;
-    max = x1;
+    min       = x2;
+    max       = x1;
   }
-  double result = 0;
-  auto knotIter = std::upper_bound(m_knots.begin(), m_knots.end(), min);
+  double result   = 0;
+  auto   knotIter = std::upper_bound(m_knots.begin(), m_knots.end(), min);
   if (knotIter != m_knots.begin()) {
     --knotIter;
   }
@@ -121,7 +118,7 @@ double Piecewise::integrate(const double x1, const double x2) const {
     }
     if (min < *knotIter) {
       double down = (min > *prevKnotIter) ? min : *prevKnotIter;
-      double up = (max < *knotIter) ? max : *knotIter;
+      double up   = (max < *knotIter) ? max : *knotIter;
       result += Euclid::MathUtils::integrate(**functionIter, down, up);
     }
     ++functionIter;
@@ -129,5 +126,5 @@ double Piecewise::integrate(const double x1, const double x2) const {
   return direction * result;
 }
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid

--- a/MathUtils/src/lib/function/Polynomial.cpp
+++ b/MathUtils/src/lib/function/Polynomial.cpp
@@ -1,45 +1,44 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file src/lib/function/Polynomial.cpp
  * @date February 19, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <utility>
+#include "MathUtils/function/Polynomial.h"
 #include <cmath>
 #include <memory>
-#include "MathUtils/function/Polynomial.h"
+#include <utility>
 
 namespace Euclid {
 namespace MathUtils {
 
-Polynomial::Polynomial(std::vector<double> coefficients) : m_coef{std::move(coefficients)} {
-}
+Polynomial::Polynomial(std::vector<double> coefficients) : m_coef{std::move(coefficients)} {}
 
 const std::vector<double>& Polynomial::getCoefficients() const {
   return m_coef;
 }
 
 double Polynomial::operator()(const double x) const {
-  double result {};
-  double xPow {1};
+  double result{};
+  double xPow{1};
   for (double coef : m_coef) {
     result += coef * xPow;
     xPow *= x;
@@ -48,14 +47,14 @@ double Polynomial::operator()(const double x) const {
 }
 
 std::unique_ptr<Function> Polynomial::clone() const {
-  return std::unique_ptr<Function> {new Polynomial(m_coef)};
+  return std::unique_ptr<Function>{new Polynomial(m_coef)};
 }
 
 std::shared_ptr<Function> Polynomial::derivative() const {
   if (!m_derivative) {
-    std::vector<double> derivCoef {};
+    std::vector<double> derivCoef{};
     for (size_t i = 1; i < m_coef.size(); i++) {
-        derivCoef.push_back(i * this->m_coef[i]);
+      derivCoef.push_back(i * this->m_coef[i]);
     }
     m_derivative.reset(new Polynomial{std::move(derivCoef)});
   }
@@ -64,15 +63,15 @@ std::shared_ptr<Function> Polynomial::derivative() const {
 
 std::shared_ptr<Function> Polynomial::indefiniteIntegral() const {
   if (!m_indefIntegral) {
-    std::vector<double> indefIntegCoef {};
+    std::vector<double> indefIntegCoef{};
     indefIntegCoef.push_back(0.);
     for (size_t i = 0; i < m_coef.size(); i++) {
-        indefIntegCoef.push_back(m_coef[i] / (i+1));
+      indefIntegCoef.push_back(m_coef[i] / (i + 1));
     }
     m_indefIntegral.reset(new Polynomial{std::move(indefIntegCoef)});
   }
   return m_indefIntegral;
 }
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid

--- a/MathUtils/src/lib/function/function_tools.cpp
+++ b/MathUtils/src/lib/function/function_tools.cpp
@@ -1,50 +1,48 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file src/lib/function/function_tools.cpp
  * @date February 19, 2014
  * @author Nikolaos Apostolakos
  */
 
+#include "MathUtils/function/function_tools.h"
 #include "ElementsKernel/Exception.h"
 #include "MathUtils/function/Integrable.h"
-#include "MathUtils/function/function_tools.h"
 #include "MathUtils/function/multiplication.h"
 
 namespace Euclid {
 namespace MathUtils {
 
-double integrate(const Function& function,
-                 const double min,
-                 const double max,
+double integrate(const Function& function, const double min, const double max,
                  std::unique_ptr<NumericalIntegrationScheme> numericalIntegrationScheme) {
   const Integrable* integrable = dynamic_cast<const Integrable*>(&function);
   if (integrable) {
     return integrable->integrate(min, max);
   }
 
-  if (numericalIntegrationScheme!=nullptr){
-    return (*numericalIntegrationScheme)(function,min,max);
+  if (numericalIntegrationScheme != nullptr) {
+    return (*numericalIntegrationScheme)(function, min, max);
   }
 
   throw Elements::Exception() << "Numerical integration of non-Integrable Functions "
-                            << "requiere that you provide a NumericalIntegrationScheme";
+                              << "requiere that you provide a NumericalIntegrationScheme";
 }
 
 class DefaultMultiplication : public Function {
@@ -54,8 +52,9 @@ public:
     return (*m_f1)(x) * (*m_f2)(x);
   }
   std::unique_ptr<Function> clone() const override {
-    return std::unique_ptr<Function> {new DefaultMultiplication{*m_f1, *m_f2}};
+    return std::unique_ptr<Function>{new DefaultMultiplication{*m_f1, *m_f2}};
   }
+
 private:
   std::unique_ptr<Function> m_f1;
   std::unique_ptr<Function> m_f2;
@@ -63,28 +62,28 @@ private:
 
 std::unique_ptr<Function> multiply(const Function& f1, const Function& f2) {
   // First we check if we have specific function for multiplying the two types with each other
-  auto iter = multiplySpecificSpecificMap.find(std::pair<std::type_index,std::type_index>(typeid(f1),typeid(f2)));
+  auto iter = multiplySpecificSpecificMap.find(std::pair<std::type_index, std::type_index>(typeid(f1), typeid(f2)));
   if (iter != multiplySpecificSpecificMap.end()) {
-    return iter->second(f1,f2);
+    return iter->second(f1, f2);
   }
-  iter = multiplySpecificSpecificMap.find(std::pair<std::type_index,std::type_index>(typeid(f2),typeid(f1)));
+  iter = multiplySpecificSpecificMap.find(std::pair<std::type_index, std::type_index>(typeid(f2), typeid(f1)));
   if (iter != multiplySpecificSpecificMap.end()) {
-    return iter->second(f2,f1);
+    return iter->second(f2, f1);
   }
   // Now we check if we have a specific function for multiplying one of the
   // parameters with a generic function
   auto iter2 = multiplySpecificGenericMap.find(typeid(f1));
   if (iter2 != multiplySpecificGenericMap.end()) {
-    return iter2->second(f1,f2);
+    return iter2->second(f1, f2);
   }
   iter2 = multiplySpecificGenericMap.find(typeid(f2));
   if (iter2 != multiplySpecificGenericMap.end()) {
-    return iter2->second(f2,f1);
+    return iter2->second(f2, f1);
   }
   // We couldn't find any specific function for handling the multiplication of
   // the f1 and f2, so return the default
-  return std::unique_ptr<Function> {new DefaultMultiplication(f1, f2)};
+  return std::unique_ptr<Function>{new DefaultMultiplication(f1, f2)};
 }
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid

--- a/MathUtils/src/lib/function/multiplication.cpp
+++ b/MathUtils/src/lib/function/multiplication.cpp
@@ -16,28 +16,28 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/function/multiplication.cpp
  * @date February 19, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <memory>
-#include <vector>
-#include <set>
-#include "MathUtils/function/Polynomial.h"
-#include "MathUtils/function/Piecewise.h"
 #include "MathUtils/function/multiplication.h"
+#include "MathUtils/function/Piecewise.h"
+#include "MathUtils/function/Polynomial.h"
 #include "MathUtils/function/function_tools.h"
 #include "MathUtils/interpolation/interpolation.h"
+#include <memory>
+#include <set>
+#include <vector>
 
 namespace Euclid {
 namespace MathUtils {
 
 /// Function for multiplying two Polynomial%s. It multiplies their coefficients.
 std::unique_ptr<Function> multiplyPolynomials(const Function& f1, const Function& f2) {
-  const Polynomial& p1 = dynamic_cast<const Polynomial&>(f1);
-  const Polynomial& p2 = dynamic_cast<const Polynomial&>(f2);
+  const Polynomial&   p1 = dynamic_cast<const Polynomial&>(f1);
+  const Polynomial&   p2 = dynamic_cast<const Polynomial&>(f2);
   std::vector<double> c1 = p1.getCoefficients();
   std::vector<double> c2 = p2.getCoefficients();
   std::vector<double> resultCoef(c1.size() + c2.size() - 1, 0.);
@@ -50,20 +50,20 @@ std::unique_ptr<Function> multiplyPolynomials(const Function& f1, const Function
 /// Function for multiplying a Piecewise with any other type. It multiplies each
 /// sub-function of the Piecewise with the other function.
 std::unique_ptr<Function> multiplyPiecewiseWithGeneric(const Function& f1, const Function& f2) {
-  const Piecewise& piecewise = dynamic_cast<const Piecewise&>(f1);
-  std::vector<std::shared_ptr<Function>> functions {};
+  const Piecewise&                       piecewise = dynamic_cast<const Piecewise&>(f1);
+  std::vector<std::shared_ptr<Function>> functions{};
   for (auto& original : piecewise.getFunctions()) {
     functions.push_back(std::shared_ptr<Function>{Euclid::MathUtils::multiply(*original, f2).release()});
   }
-  return std::unique_ptr<Function>(new Piecewise {piecewise.getKnots(), functions});
+  return std::unique_ptr<Function>(new Piecewise{piecewise.getKnots(), functions});
 }
 
 /// Returns a vector of the overlapping knots from the given vectors
 std::vector<double> overlappingKnots(const std::vector<double>& knots1, const std::vector<double>& knots2) {
-  std::set<double> knotSet {};
-  auto p1Iter = knots1.begin();
-  auto p2Iter = knots2.begin();
-  bool started = false;
+  std::set<double> knotSet{};
+  auto             p1Iter  = knots1.begin();
+  auto             p2Iter  = knots2.begin();
+  bool             started = false;
   while (p1Iter != knots1.end() && p2Iter != knots2.end()) {
     if (!started) {
       if (*p1Iter < *p2Iter) {
@@ -85,7 +85,7 @@ std::vector<double> overlappingKnots(const std::vector<double>& knots1, const st
       ++p2Iter;
     }
   }
-  return std::vector<double> {knotSet.begin(), knotSet.end()};
+  return std::vector<double>{knotSet.begin(), knotSet.end()};
 }
 
 // Multiply two Piecewise Function%s by multiplying all their sub-functions
@@ -96,22 +96,22 @@ std::unique_ptr<Function> multiplyPiecewises(const Function& f1, const Function&
   auto knots = overlappingKnots(p1.getKnots(), p2.getKnots());
 
   if (knots.empty()) {
-    return std::unique_ptr<Function> {new Polynomial{{0.}}};
+    return std::unique_ptr<Function>{new Polynomial{{0.}}};
   }
 
-  std::vector<std::shared_ptr<Function>> functions {};
-  auto& p1func = p1.getFunctions();
-  auto& p2func = p2.getFunctions();
-  int i1 {};
-  int i2 {};
+  std::vector<std::shared_ptr<Function>> functions{};
+  auto&                                  p1func = p1.getFunctions();
+  auto&                                  p2func = p2.getFunctions();
+  int                                    i1{};
+  int                                    i2{};
   for (double knot : knots) {
     if (knot == knots.back()) {
       break;
     }
-    while (p1.getKnots()[i1+1] <= knot) {
+    while (p1.getKnots()[i1 + 1] <= knot) {
       ++i1;
     }
-    while (p2.getKnots()[i2+1] <= knot) {
+    while (p2.getKnots()[i2 + 1] <= knot) {
       ++i2;
     }
     functions.push_back(std::shared_ptr<Function>{Euclid::MathUtils::multiply(*p1func[i1], *p2func[i2]).release()});
@@ -120,14 +120,11 @@ std::unique_ptr<Function> multiplyPiecewises(const Function& f1, const Function&
   return std::unique_ptr<Function>{new Piecewise{knots, functions}};
 }
 
-std::map<std::pair<std::type_index,std::type_index>, MultiplyFunction> multiplySpecificSpecificMap {
-  {std::pair<std::type_index,std::type_index>(typeid(Polynomial),typeid(Polynomial)), multiplyPolynomials},
-  {std::pair<std::type_index,std::type_index>(typeid(Piecewise),typeid(Piecewise)), multiplyPiecewises}
-};
+std::map<std::pair<std::type_index, std::type_index>, MultiplyFunction> multiplySpecificSpecificMap{
+    {std::pair<std::type_index, std::type_index>(typeid(Polynomial), typeid(Polynomial)), multiplyPolynomials},
+    {std::pair<std::type_index, std::type_index>(typeid(Piecewise), typeid(Piecewise)), multiplyPiecewises}};
 
-std::map<std::type_index, MultiplyFunction> multiplySpecificGenericMap {
-  {typeid(Piecewise), multiplyPiecewiseWithGeneric}
-};
+std::map<std::type_index, MultiplyFunction> multiplySpecificGenericMap{{typeid(Piecewise), multiplyPiecewiseWithGeneric}};
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid

--- a/MathUtils/src/lib/interpolation/implementations.h
+++ b/MathUtils/src/lib/interpolation/implementations.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/interpolation/implementations.h
  * @date February 21, 2014
  * @author Nikolaos Apostolakos
@@ -29,15 +29,12 @@ namespace Euclid {
 namespace MathUtils {
 
 /// Performs linear interpolation for the given set of data points
-std::unique_ptr<Function> linearInterpolation(const std::vector<double>& x, const std::vector<double>& y,
-                                              bool extrapolate);
+std::unique_ptr<Function> linearInterpolation(const std::vector<double>& x, const std::vector<double>& y, bool extrapolate);
 
 /// Performs cubic spline interpolation for the given set of data points
-std::unique_ptr<Function> splineInterpolation(const std::vector<double>& x, const std::vector<double>& y,
-                                              bool extrapolate);
+std::unique_ptr<Function> splineInterpolation(const std::vector<double>& x, const std::vector<double>& y, bool extrapolate);
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid
 
 #endif /* MATHUTILS_IMPLEMENTATIONS_H */
-

--- a/MathUtils/src/lib/interpolation/interpolation.cpp
+++ b/MathUtils/src/lib/interpolation/interpolation.cpp
@@ -16,17 +16,17 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/interpolation/interpolation.cpp
  * @date February 21, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <AlexandriaKernel/memory_tools.h>
-#include "ElementsKernel/Logging.h"
 #include "MathUtils/interpolation/interpolation.h"
+#include "ElementsKernel/Logging.h"
 #include "MathUtils/function/FunctionAdapter.h"
 #include "implementations.h"
+#include <AlexandriaKernel/memory_tools.h>
 
 namespace Euclid {
 namespace MathUtils {
@@ -35,19 +35,19 @@ namespace {
 
 Elements::Logging logger = Elements::Logging::getLogger("Interpolation");
 
-} // Anonymous namespace
+}  // Anonymous namespace
 
-std::unique_ptr<Function> interpolate(const std::vector<double>& x, const std::vector<double>& y,
-                                      InterpolationType type, bool extrapolate) {
+std::unique_ptr<Function> interpolate(const std::vector<double>& x, const std::vector<double>& y, InterpolationType type,
+                                      bool extrapolate) {
 
   if (x.size() != y.size()) {
     throw InterpolationException() << "Interpolation using vectors of incompatible "
-            << "size: X=" << x.size() << ", Y=" << y.size();
+                                   << "size: X=" << x.size() << ", Y=" << y.size();
   }
 
   if (x.size() == 1 && extrapolate) {
     auto c = y.front();
-    return make_unique<FunctionAdapter>([c](double){return c;});
+    return make_unique<FunctionAdapter>([c](double) { return c; });
   }
 
   // We remove any duplicate lines and we check that we have only increasing
@@ -61,20 +61,19 @@ std::unique_ptr<Function> interpolate(const std::vector<double>& x, const std::v
   final_x.emplace_back(x[0]);
   final_y.emplace_back(y[0]);
   for (std::size_t i = 1; i < x.size(); ++i) {
-    if (x[i] == x[i-1]) {
-      if (y[i] == y[i-1]) {
-        logger.warn() << "Ignoring duplicate pair (" << x[i] << ", " << y[i]
-                << ") during interpolation";
+    if (x[i] == x[i - 1]) {
+      if (y[i] == y[i - 1]) {
+        logger.warn() << "Ignoring duplicate pair (" << x[i] << ", " << y[i] << ") during interpolation";
         continue;
       } else {
         throw InterpolationException() << "Interpolation of step functions is not "
-                << "supported. Entries: (" << x[i] << ", " << y[i] << ") and ("
-                << x[i-1] << ", " << y[i-1] << ")";
+                                       << "supported. Entries: (" << x[i] << ", " << y[i] << ") and (" << x[i - 1] << ", "
+                                       << y[i - 1] << ")";
       }
     }
-    if (x[i] < x[i-1]) {
+    if (x[i] < x[i - 1]) {
       throw InterpolationException() << "Only increasing X values are supported "
-              << "but found " << x[i] << " after " << x[i-1];
+                                     << "but found " << x[i] << " after " << x[i - 1];
     }
     final_x.emplace_back(x[i]);
     final_y.emplace_back(y[i]);
@@ -89,8 +88,7 @@ std::unique_ptr<Function> interpolate(const std::vector<double>& x, const std::v
   return nullptr;
 }
 
-std::unique_ptr<Function> interpolate(const Euclid::XYDataset::XYDataset& dataset, InterpolationType type,
-                                      bool extrapolate) {
+std::unique_ptr<Function> interpolate(const Euclid::XYDataset::XYDataset& dataset, InterpolationType type, bool extrapolate) {
   std::vector<double> x;
   std::vector<double> y;
   x.reserve(dataset.size());
@@ -102,5 +100,5 @@ std::unique_ptr<Function> interpolate(const Euclid::XYDataset::XYDataset& datase
   return interpolate(x, y, type, extrapolate);
 }
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid

--- a/MathUtils/src/lib/interpolation/linear.cpp
+++ b/MathUtils/src/lib/interpolation/linear.cpp
@@ -16,24 +16,23 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/interpolation/linear.cpp
  * @date February 20, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <limits>
 #include "ElementsKernel/Exception.h"
-#include "MathUtils/interpolation/interpolation.h"
-#include "MathUtils/function/Polynomial.h"
 #include "MathUtils/function/Piecewise.h"
+#include "MathUtils/function/Polynomial.h"
+#include "MathUtils/interpolation/interpolation.h"
+#include <limits>
 
 namespace Euclid {
 namespace MathUtils {
 
-std::unique_ptr<Function> linearInterpolation(const std::vector<double>& x, const std::vector<double>& y,
-                                              bool extrapolate) {
-  std::vector<std::shared_ptr<Function>> functions {};
+std::unique_ptr<Function> linearInterpolation(const std::vector<double>& x, const std::vector<double>& y, bool extrapolate) {
+  std::vector<std::shared_ptr<Function>> functions{};
   for (size_t i = 0; i < x.size() - 1; i++) {
     double coef1 = (y[i + 1] - y[i]) / (x[i + 1] - x[i]);
     double coef0 = y[i] - coef1 * x[i];
@@ -43,12 +42,12 @@ std::unique_ptr<Function> linearInterpolation(const std::vector<double>& x, cons
   if (extrapolate) {
     std::vector<double> x_copy(x);
     x_copy.front() = std::numeric_limits<double>::lowest();
-    x_copy.back() = std::numeric_limits<double>::max();
+    x_copy.back()  = std::numeric_limits<double>::max();
     return std::unique_ptr<Function>(new Piecewise{x_copy, std::move(functions)});
   }
 
   return std::unique_ptr<Function>(new Piecewise{x, std::move(functions)});
 }
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid

--- a/MathUtils/src/lib/interpolation/spline.cpp
+++ b/MathUtils/src/lib/interpolation/spline.cpp
@@ -16,45 +16,45 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/interpolation/spline.cpp
  * @date February 20, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <limits>
 #include "ElementsKernel/Exception.h"
-#include "MathUtils/interpolation/interpolation.h"
-#include "MathUtils/function/Polynomial.h"
 #include "MathUtils/function/Piecewise.h"
+#include "MathUtils/function/Polynomial.h"
+#include "MathUtils/interpolation/interpolation.h"
+#include <limits>
 
 namespace Euclid {
 namespace MathUtils {
 
-std::unique_ptr<Function> splineInterpolation(const std::vector<double>& x, const std::vector<double>& y,
-                                              bool extrapolate) {
+std::unique_ptr<Function> splineInterpolation(const std::vector<double>& x, const std::vector<double>& y, bool extrapolate) {
 
   // Number of intervals
   int n = x.size() - 1;
 
   // Differences between knot points
-  std::vector<double> h (n, 0.);
-  for(int i=0; i<n; i++)
-    h[i] = x[i+1] - x[i];
+  std::vector<double> h(n, 0.);
+  for (int i = 0; i < n; i++)
+    h[i] = x[i + 1] - x[i];
 
-  std::vector<double> mu (n, 0.);
-  std::vector<double> z (n+1, 0.);
+  std::vector<double> mu(n, 0.);
+  std::vector<double> z(n + 1, 0.);
   for (int i = 1; i < n; ++i) {
     double g = 2. * (x[i + 1] - x[i - 1]) - h[i - 1] * mu[i - 1];
-    mu[i] = h[i] / g;
-    z[i] = (3.*(y[i+1]*h[i-1] - y[i]*(x[i+1]-x[i-1])+ y[i-1]*h[i]) / (h[i-1]*h[i]) - h[i-1] * z[i-1]) / g;
+    mu[i]    = h[i] / g;
+    z[i] =
+        (3. * (y[i + 1] * h[i - 1] - y[i] * (x[i + 1] - x[i - 1]) + y[i - 1] * h[i]) / (h[i - 1] * h[i]) - h[i - 1] * z[i - 1]) / g;
   }
 
   // cubic spline coefficients --  b is linear, c quadratic, d is cubic (original y's are constants)
-  std::vector<double> a (n, 0.);
-  std::vector<double> b (n, 0.);
-  std::vector<double> c (n+1, 0.);
-  std::vector<double> d (n, 0.);
+  std::vector<double> a(n, 0.);
+  std::vector<double> b(n, 0.);
+  std::vector<double> c(n + 1, 0.);
+  std::vector<double> d(n, 0.);
 
   z[n] = 0.;
   c[n] = 0.;
@@ -72,9 +72,9 @@ std::unique_ptr<Function> splineInterpolation(const std::vector<double>& x, cons
     double x_1 = -x[i];
     double x_2 = x_1 * x_1;
     double x_3 = x_1 * x_2;
-    a[i] = a[i] + b[i] * x_1 + c[i] * x_2 + d[i] * x_3;
-    b[i] = b[i] + 2. * c[i] * x_1 + 3. * d[i] * x_2;
-    c[i] = c[i] + 3. * d[i] * x_1;
+    a[i]       = a[i] + b[i] * x_1 + c[i] * x_2 + d[i] * x_3;
+    b[i]       = b[i] + 2. * c[i] * x_1 + 3. * d[i] * x_2;
+    c[i]       = c[i] + 3. * d[i] * x_1;
     // d[i] keeps the same value
   }
 
@@ -87,12 +87,12 @@ std::unique_ptr<Function> splineInterpolation(const std::vector<double>& x, cons
   if (extrapolate) {
     std::vector<double> x_copy(x);
     x_copy.front() = std::numeric_limits<double>::lowest();
-    x_copy.back() = std::numeric_limits<double>::max();
+    x_copy.back()  = std::numeric_limits<double>::max();
     return std::unique_ptr<Function>(new Piecewise{x_copy, std::move(functions)});
   }
 
   return std::unique_ptr<Function>(new Piecewise{x, std::move(functions)});
 }
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid

--- a/MathUtils/src/lib/numericalDifferentiation/FiniteDifference.cpp
+++ b/MathUtils/src/lib/numericalDifferentiation/FiniteDifference.cpp
@@ -31,7 +31,7 @@ namespace MathUtils {
 
 static double guess_h(double initial_h, double x) {
   volatile double xh = x + initial_h;
-  volatile double h = xh - x;
+  volatile double h  = xh - x;
   if (h == 0) {
     h = std::nextafter(x, std::numeric_limits<double>::max()) - x;
   }
@@ -40,7 +40,7 @@ static double guess_h(double initial_h, double x) {
 
 double derivative(const Function& f, const double x) {
   double h = std::sqrt(std::numeric_limits<double>::epsilon()) * 2;
-  h = guess_h(h, x);
+  h        = guess_h(h, x);
 
   double yh = f(x + h);
   double y0 = f(x);
@@ -49,14 +49,14 @@ double derivative(const Function& f, const double x) {
 
 double derivative2nd(const Function& f, const double x) {
   double h = std::sqrt(std::sqrt(std::numeric_limits<double>::epsilon())) * 2;
-  h = guess_h(h, x);
+  h        = guess_h(h, x);
 
   double ymh = f(x - h);
-  double y = f(x);
+  double y   = f(x);
   double yph = f(x + h);
 
   return (yph - 2 * y + ymh) / (h * h);
 }
 
-} // end namespace MathUtils
-} // end namespace Euclid
+}  // end namespace MathUtils
+}  // end namespace Euclid

--- a/MathUtils/src/lib/numericalIntegration/SimpsonsRule.cpp
+++ b/MathUtils/src/lib/numericalIntegration/SimpsonsRule.cpp
@@ -1,42 +1,40 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file MathUtils/src/lib/numericalIntegration/SimpsonsRule.cpp
  * @date July 2, 2015
  * @author Florian Dubath
  */
 
-#include  <cmath>
 #include "MathUtils/numericalIntegration/SimpsonsRule.h"
 #include "ElementsKernel/Exception.h"
+#include <cmath>
 
 namespace Euclid {
 namespace MathUtils {
 
-double SimpsonsRule::operator()(const Function& function, double min,
-    double max, int order) {
+double SimpsonsRule::operator()(const Function& function, double min, double max, int order) {
   if (order < 3) {
-    throw Elements::Exception()
-        << "Simpson's Rule integration is define only for order bigger than 2";
+    throw Elements::Exception() << "Simpson's Rule integration is define only for order bigger than 2";
   }
 
-  int N = pow(2, order);
+  int    N = pow(2, order);
   double h = (max - min) / N;
 
   double partial_sum = 0;
@@ -49,17 +47,14 @@ double SimpsonsRule::operator()(const Function& function, double min,
   partial_sum += 23. * (function(min + 2. * h) + function(max - 2 * h)) / 24.;
 
   return partial_sum * h;
-
 }
 
-double SimpsonsRule::operator()(const Function& function, double min,
-    double max, double previous_value, int order) {
+double SimpsonsRule::operator()(const Function& function, double min, double max, double previous_value, int order) {
   if (order < 4) {
-    throw Elements::Exception()
-        << "Simpson's Rule integration with recursion is define only for order bigger than 3";
+    throw Elements::Exception() << "Simpson's Rule integration with recursion is define only for order bigger than 3";
   }
 
-  int N = pow(2, order);
+  int    N = pow(2, order);
   double h = (max - min) / N;
 
   double partial_sum = 0;
@@ -75,5 +70,5 @@ double SimpsonsRule::operator()(const Function& function, double min,
   return partial_sum * h + previous_value / 2.;
 }
 
-} // End of MathUtils
-} // end of namespace Euclid
+}  // namespace MathUtils
+}  // end of namespace Euclid

--- a/MathUtils/tests/src/PDF/Cumulative_test.cpp
+++ b/MathUtils/tests/src/PDF/Cumulative_test.cpp
@@ -24,227 +24,208 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include "MathUtils/PDF/Cumulative.h"
-#include <vector>
-#include <utility>
 #include "ElementsKernel/Exception.h"
+#include "MathUtils/PDF/Cumulative.h"
 #include "XYDataset/XYDataset.h"
+#include <utility>
+#include <vector>
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (Cumulative_test)
-
+BOOST_AUTO_TEST_SUITE(Cumulative_test)
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_CASE( constructor_test ) {
-  std::vector<double> x={0., 1., 2., 3., 4., 5., 6.,7.,8.,9.,10.};
-  std::vector<double> y={0.,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0};
+BOOST_AUTO_TEST_CASE(constructor_test) {
+  std::vector<double> x = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10.};
+  std::vector<double> y = {0., 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
 
-  BOOST_CHECK_NO_THROW(Euclid::MathUtils::Cumulative(x,y));
-  auto cumul = Euclid::MathUtils::Cumulative(x,y);
-  for (size_t i=0; i<x.size();++i){   
+  BOOST_CHECK_NO_THROW(Euclid::MathUtils::Cumulative(x, y));
+  auto cumul = Euclid::MathUtils::Cumulative(x, y);
+  for (size_t i = 0; i < x.size(); ++i) {
     BOOST_CHECK_CLOSE(cumul.findValue(y[i]), x[i], 0.0001);
   }
 
-  std::vector<double> yy={0.,0.1,0.2,0.3,0.4,0.5};
-  BOOST_CHECK_THROW(Euclid::MathUtils::Cumulative(x,yy),Elements::Exception);
-
+  std::vector<double> yy = {0., 0.1, 0.2, 0.3, 0.4, 0.5};
+  BOOST_CHECK_THROW(Euclid::MathUtils::Cumulative(x, yy), Elements::Exception);
 }
 
-BOOST_AUTO_TEST_CASE( normalize_test ) {
-  std::vector<double> x={0.,1.,2.,3.,4.,5.,6.};
-  std::vector<double> y={0.,0.1,0.2,0.3,0.4,0.5,0.6};
+BOOST_AUTO_TEST_CASE(normalize_test) {
+  std::vector<double> x = {0., 1., 2., 3., 4., 5., 6.};
+  std::vector<double> y = {0., 0.1, 0.2, 0.3, 0.4, 0.5, 0.6};
 
-  std::vector<double> ynorm={0.,1./6.,1./3.,1./2.,2./3.,5./6.,1.};
+  std::vector<double> ynorm = {0., 1. / 6., 1. / 3., 1. / 2., 2. / 3., 5. / 6., 1.};
 
-  Euclid::MathUtils::Cumulative cumul{x,y};
+  Euclid::MathUtils::Cumulative cumul{x, y};
   BOOST_CHECK_NO_THROW(cumul.normalize());
-  
-  for (size_t i=0; i<x.size();++i){   
+
+  for (size_t i = 0; i < x.size(); ++i) {
     BOOST_CHECK_CLOSE(cumul.findValue(ynorm[i]), x[i], 0.0001);
   }
-
 }
 
-BOOST_AUTO_TEST_CASE( normalize_XY_test ) {
-  std::vector<double> x={0.,1.,2.,3.,4.,5.,6.};
-  std::vector<double> y={0.,0.1,0.2,0.3,0.4,0.5,0.6};
-  Euclid::XYDataset::XYDataset  xy = Euclid::XYDataset::XYDataset::factory(x,y);
+BOOST_AUTO_TEST_CASE(normalize_XY_test) {
+  std::vector<double>          x  = {0., 1., 2., 3., 4., 5., 6.};
+  std::vector<double>          y  = {0., 0.1, 0.2, 0.3, 0.4, 0.5, 0.6};
+  Euclid::XYDataset::XYDataset xy = Euclid::XYDataset::XYDataset::factory(x, y);
 
-  std::vector<double> ynorm={0.,1./6.,1./3.,1./2.,2./3.,5./6.,1.};
+  std::vector<double> ynorm = {0., 1. / 6., 1. / 3., 1. / 2., 2. / 3., 5. / 6., 1.};
 
   Euclid::MathUtils::Cumulative cumul{xy};
   BOOST_CHECK_NO_THROW(cumul.normalize());
 
-  for (size_t i=0; i<x.size();++i){
+  for (size_t i = 0; i < x.size(); ++i) {
     BOOST_CHECK_CLOSE(cumul.findValue(ynorm[i]), x[i], 0.0001);
   }
-
 }
 
-BOOST_AUTO_TEST_CASE( findValue_test ) {
-  std::vector<double> x={0.,1., 2., 3., 4., 5., 6.};
-  std::vector<double> y={0.,0.1,0.2,0.3,0.4,0.5,0.6};
-  double expected_x = 0.;
+BOOST_AUTO_TEST_CASE(findValue_test) {
+  std::vector<double> x          = {0., 1., 2., 3., 4., 5., 6.};
+  std::vector<double> y          = {0., 0.1, 0.2, 0.3, 0.4, 0.5, 0.6};
+  double              expected_x = 0.;
 
-
-  Euclid::MathUtils::Cumulative cumul{x,y};
-  double res_x=cumul.findValue(0.);
+  Euclid::MathUtils::Cumulative cumul{x, y};
+  double                        res_x = cumul.findValue(0.);
   BOOST_CHECK_CLOSE(res_x, expected_x, 0.0001);
 
   expected_x = 3.;
-  res_x=cumul.findValue(0.5);
+  res_x      = cumul.findValue(0.5);
   BOOST_CHECK_CLOSE(res_x, expected_x, 0.0001);
 
-  BOOST_CHECK_THROW(cumul.findValue(-1.),Elements::Exception);
-  BOOST_CHECK_THROW(cumul.findValue(1.1),Elements::Exception);
+  BOOST_CHECK_THROW(cumul.findValue(-1.), Elements::Exception);
+  BOOST_CHECK_THROW(cumul.findValue(1.1), Elements::Exception);
 }
 
-BOOST_AUTO_TEST_CASE( findValue_tray_test ) {
-  std::vector<double> x={0.,1., 2., 3., 4., 5., 6.};
-  std::vector<double> y={0.,0.1,0.3,0.3,0.3,0.5,0.6};
-  Euclid::MathUtils::Cumulative cumul{x,y};
+BOOST_AUTO_TEST_CASE(findValue_tray_test) {
+  std::vector<double>           x = {0., 1., 2., 3., 4., 5., 6.};
+  std::vector<double>           y = {0., 0.1, 0.3, 0.3, 0.3, 0.5, 0.6};
+  Euclid::MathUtils::Cumulative cumul{x, y};
 
   double expected_x = 2.;
-  double res_x=cumul.findValue(0.5, Euclid::MathUtils::Cumulative::TrayPosition::begin);
+  double res_x      = cumul.findValue(0.5, Euclid::MathUtils::Cumulative::TrayPosition::begin);
   BOOST_CHECK_CLOSE(res_x, expected_x, 0.0001);
 
   expected_x = 3.;
-  res_x=cumul.findValue(0.5, Euclid::MathUtils::Cumulative::TrayPosition::middle);
+  res_x      = cumul.findValue(0.5, Euclid::MathUtils::Cumulative::TrayPosition::middle);
   BOOST_CHECK_CLOSE(res_x, expected_x, 0.0001);
-  
+
   expected_x = 4.;
-  res_x=cumul.findValue(0.5, Euclid::MathUtils::Cumulative::TrayPosition::end);
+  res_x      = cumul.findValue(0.5, Euclid::MathUtils::Cumulative::TrayPosition::end);
   BOOST_CHECK_CLOSE(res_x, expected_x, 0.0001);
 }
 
+BOOST_AUTO_TEST_CASE(findMinInterval_test) {
+  std::vector<double> x = {0., 1., 2., 3., 4., 5., 6.};
+  std::vector<double> y = {0., 0.1, 0.2, 0.7, 0.9, 0.95, 1.};
 
+  Euclid::MathUtils::Cumulative cumul{x, y};
 
-
-BOOST_AUTO_TEST_CASE( findMinInterval_test ) {
-  std::vector<double> x={0.,1., 2., 3., 4., 5., 6.};
-  std::vector<double> y={0.,0.1,0.2,0.7,0.9,0.95,1.};
-
-
-  Euclid::MathUtils::Cumulative cumul{x,y};
-
-  std::pair<double,double> interval= cumul.findMinInterval(0.45);
+  std::pair<double, double> interval = cumul.findMinInterval(0.45);
 
   BOOST_CHECK_CLOSE(interval.first, 2., 0.0001);
   BOOST_CHECK_CLOSE(interval.second, 3., 0.0001);
 
-  interval= cumul.findMinInterval(1.0);
+  interval = cumul.findMinInterval(1.0);
 
   BOOST_CHECK_CLOSE(interval.first, 0., 0.0001);
   BOOST_CHECK_CLOSE(interval.second, 6., 0.0001);
-
 }
 
-BOOST_AUTO_TEST_CASE(fromPDF_test){
-  std::vector<double>        x={0., 1., 2., 3.,  4.,  5.,  6.};
-  std::vector<double>        y={0.,0.5,0.2,0.07,0.08, 0.1,0.05};
-  std::vector<double> expected={0.,0.5,0.7,0.77,0.85,0.95, 1.0};
+BOOST_AUTO_TEST_CASE(fromPDF_test) {
+  std::vector<double> x        = {0., 1., 2., 3., 4., 5., 6.};
+  std::vector<double> y        = {0., 0.5, 0.2, 0.07, 0.08, 0.1, 0.05};
+  std::vector<double> expected = {0., 0.5, 0.7, 0.77, 0.85, 0.95, 1.0};
 
   auto cumul = Euclid::MathUtils::Cumulative::fromPdf(x, y);
-  
-  for (size_t i=0; i<x.size();++i){   
+
+  for (size_t i = 0; i < x.size(); ++i) {
     BOOST_CHECK_CLOSE(cumul.findValue(expected[i]), x[i], 0.0001);
   }
 }
 
-BOOST_AUTO_TEST_CASE(fromPDF_XY_test){
-  std::vector<double>        x={0., 1., 2., 3.,  4.,  5.,  6.};
-  std::vector<double>        y={0.,0.5,0.2,0.07,0.08, 0.1,0.05};
-  Euclid::XYDataset::XYDataset  xy = Euclid::XYDataset::XYDataset::factory(x,y);
-  std::vector<double> expected={0.,0.5,0.7,0.77,0.85,0.95, 1.0};
+BOOST_AUTO_TEST_CASE(fromPDF_XY_test) {
+  std::vector<double>          x        = {0., 1., 2., 3., 4., 5., 6.};
+  std::vector<double>          y        = {0., 0.5, 0.2, 0.07, 0.08, 0.1, 0.05};
+  Euclid::XYDataset::XYDataset xy       = Euclid::XYDataset::XYDataset::factory(x, y);
+  std::vector<double>          expected = {0., 0.5, 0.7, 0.77, 0.85, 0.95, 1.0};
 
   auto cumul = Euclid::MathUtils::Cumulative::fromPdf(xy);
 
-  for (size_t i=0; i<x.size();++i){
+  for (size_t i = 0; i < x.size(); ++i) {
     BOOST_CHECK_CLOSE(cumul.findValue(expected[i]), x[i], 0.0001);
   }
 }
 
-BOOST_AUTO_TEST_CASE( findMinInterval_throw_test ) {
-  std::vector<double> x={0.,1., 2., 3., 4., 5., 6.};
-  std::vector<double> y={0.,0,100,100,100,100,100};
+BOOST_AUTO_TEST_CASE(findMinInterval_throw_test) {
+  std::vector<double> x = {0., 1., 2., 3., 4., 5., 6.};
+  std::vector<double> y = {0., 0, 100, 100, 100, 100, 100};
 
-  Euclid::MathUtils::Cumulative cumul{x,y};
-  BOOST_CHECK_THROW(cumul.findMinInterval(-0.1),Elements::Exception);
-  BOOST_CHECK_THROW(cumul.findMinInterval(0),Elements::Exception);
+  Euclid::MathUtils::Cumulative cumul{x, y};
+  BOOST_CHECK_THROW(cumul.findMinInterval(-0.1), Elements::Exception);
+  BOOST_CHECK_THROW(cumul.findMinInterval(0), Elements::Exception);
   BOOST_CHECK_NO_THROW(cumul.findMinInterval(0.5));
   BOOST_CHECK_NO_THROW(cumul.findMinInterval(1.0));
-  BOOST_CHECK_THROW(cumul.findMinInterval(1.1),Elements::Exception);
+  BOOST_CHECK_THROW(cumul.findMinInterval(1.1), Elements::Exception);
 }
 
-BOOST_AUTO_TEST_CASE( findMinInterval_prob_test ) {
-  std::vector<double> x={0.,1., 2., 3., 4., 5., 6.};
-  std::vector<double> y={0.,0,100,100,100,100,100};
+BOOST_AUTO_TEST_CASE(findMinInterval_prob_test) {
+  std::vector<double> x = {0., 1., 2., 3., 4., 5., 6.};
+  std::vector<double> y = {0., 0, 100, 100, 100, 100, 100};
 
+  Euclid::MathUtils::Cumulative cumul{x, y};
 
-  Euclid::MathUtils::Cumulative cumul{x,y};
-
-  std::pair<double,double> interval= cumul.findMinInterval(0.7);
+  std::pair<double, double> interval = cumul.findMinInterval(0.7);
 
   BOOST_CHECK_CLOSE(interval.first, 1., 0.0001);
   BOOST_CHECK_CLOSE(interval.second, 2., 0.0001);
 }
 
-BOOST_AUTO_TEST_CASE( findMinInterval_prob2_test ) {
-  std::vector<double> x={0.,1., 2., 3., 4., 5., 6.};
-  std::vector<double> y={99.,100,100,100,100,100,100};
+BOOST_AUTO_TEST_CASE(findMinInterval_prob2_test) {
+  std::vector<double> x = {0., 1., 2., 3., 4., 5., 6.};
+  std::vector<double> y = {99., 100, 100, 100, 100, 100, 100};
 
+  Euclid::MathUtils::Cumulative cumul{x, y};
 
-  Euclid::MathUtils::Cumulative cumul{x,y};
-
-  std::pair<double,double> interval= cumul.findMinInterval(0.7);
+  std::pair<double, double> interval = cumul.findMinInterval(0.7);
 
   BOOST_CHECK_CLOSE(interval.first, 0., 0.0001);
   BOOST_CHECK_CLOSE(interval.second, 1., 0.0001);
 }
 
+BOOST_AUTO_TEST_CASE(findCenteredInterval_throw_test) {
+  std::vector<double> x = {0., 1., 2., 3., 4., 5., 6.};
+  std::vector<double> y = {0., 0, 100, 100, 100, 100, 100};
 
-BOOST_AUTO_TEST_CASE( findCenteredInterval_throw_test ) {
-  std::vector<double> x={0.,1., 2., 3., 4., 5., 6.};
-  std::vector<double> y={0.,0,100,100,100,100,100};
-
-  Euclid::MathUtils::Cumulative cumul{x,y};
-  BOOST_CHECK_THROW(cumul.findCenteredInterval(-0.1),Elements::Exception);
-  BOOST_CHECK_THROW(cumul.findCenteredInterval(0),Elements::Exception);
+  Euclid::MathUtils::Cumulative cumul{x, y};
+  BOOST_CHECK_THROW(cumul.findCenteredInterval(-0.1), Elements::Exception);
+  BOOST_CHECK_THROW(cumul.findCenteredInterval(0), Elements::Exception);
   BOOST_CHECK_NO_THROW(cumul.findCenteredInterval(0.5));
   BOOST_CHECK_NO_THROW(cumul.findCenteredInterval(1.0));
-  BOOST_CHECK_THROW(cumul.findCenteredInterval(1.1),Elements::Exception);
+  BOOST_CHECK_THROW(cumul.findCenteredInterval(1.1), Elements::Exception);
 }
 
+BOOST_AUTO_TEST_CASE(findCenteredInterval_test) {
+  std::vector<double> x = {0., 1., 2., 3., 4., 5., 6.};
+  std::vector<double> y = {0., 10, 30, 50, 80, 90, 100};
 
-BOOST_AUTO_TEST_CASE(findCenteredInterval_test ) {
-  std::vector<double> x={0.,1., 2., 3., 4., 5., 6.};
-  std::vector<double> y={0.,10,30, 50, 80, 90, 100};
+  Euclid::MathUtils::Cumulative cumul{x, y};
 
-  Euclid::MathUtils::Cumulative cumul{x,y};
-
-  std::pair<double,double> interval= cumul.findCenteredInterval(0.8);
+  std::pair<double, double> interval = cumul.findCenteredInterval(0.8);
   BOOST_CHECK_CLOSE(interval.first, 1., 0.0001);
   BOOST_CHECK_CLOSE(interval.second, 5., 0.0001);
-
 }
 
-BOOST_AUTO_TEST_CASE(findCenteredInterval_tray_test ) {
-  std::vector<double> x={0.,1., 2., 3., 4., 5., 6.};
-  std::vector<double> y={0.,10,10, 50, 90, 90, 100};
+BOOST_AUTO_TEST_CASE(findCenteredInterval_tray_test) {
+  std::vector<double> x = {0., 1., 2., 3., 4., 5., 6.};
+  std::vector<double> y = {0., 10, 10, 50, 90, 90, 100};
 
-  Euclid::MathUtils::Cumulative cumul{x,y};
+  Euclid::MathUtils::Cumulative cumul{x, y};
 
-  std::pair<double,double> interval= cumul.findCenteredInterval(0.8);
+  std::pair<double, double> interval = cumul.findCenteredInterval(0.8);
   BOOST_CHECK_CLOSE(interval.first, 2., 0.0001);
   BOOST_CHECK_CLOSE(interval.second, 4., 0.0001);
-
 }
-
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/MathUtils/tests/src/PDF/PdfModeExtraction_test.cpp
+++ b/MathUtils/tests/src/PDF/PdfModeExtraction_test.cpp
@@ -24,241 +24,221 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include "MathUtils/PDF/PdfModeExtraction.h"
 #include "ElementsKernel/Exception.h"
-#include <vector>
-#include <tuple>
-#include <cstddef>
-#include <utility>
+#include "MathUtils/PDF/PdfModeExtraction.h"
 #include "XYDataset/XYDataset.h"
+#include <cstddef>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (ModeExtraction_test)
+BOOST_AUTO_TEST_SUITE(ModeExtraction_test)
 
 //-----------------------------------------------------------------------------
 
+BOOST_AUTO_TEST_CASE(nominal_vector_delta_test) {
 
-
-BOOST_AUTO_TEST_CASE( nominal_vector_delta_test ) {
-
-  std::vector<double> sampling{0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0};
-  std::vector<double>      pdf{0.0,0.0,5.0,0.0,0.0,4.0,0.0,0.0,1.0,0.0,0.0};
+  std::vector<double> sampling{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+  std::vector<double> pdf{0.0, 0.0, 5.0, 0.0, 0.0, 4.0, 0.0, 0.0, 1.0, 0.0, 0.0};
 
   auto modes = Euclid::MathUtils::extractNHighestModes(sampling, pdf, 0.8, 3);
 
   // position
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.2,0.000001);
-  BOOST_CHECK_CLOSE(modes[1].getMeanPosition(),0.5,0.000001);
-  BOOST_CHECK_CLOSE(modes[2].getMeanPosition(),0.8,0.000001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.2, 0.000001);
+  BOOST_CHECK_CLOSE(modes[1].getMeanPosition(), 0.5, 0.000001);
+  BOOST_CHECK_CLOSE(modes[2].getMeanPosition(), 0.8, 0.000001);
 
   // area
-  BOOST_CHECK_CLOSE(modes[0].getModeArea(),0.5,0.000001);
-  BOOST_CHECK_CLOSE(modes[1].getModeArea(),0.4,0.000001);
-  BOOST_CHECK_CLOSE(modes[2].getModeArea(),0.1,0.000001);
-
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 0.5, 0.000001);
+  BOOST_CHECK_CLOSE(modes[1].getModeArea(), 0.4, 0.000001);
+  BOOST_CHECK_CLOSE(modes[2].getModeArea(), 0.1, 0.000001);
 
   modes = Euclid::MathUtils::extractNBigestModes(sampling, pdf, 0.8, 3);
 
   // position
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.2,0.000001);
-  BOOST_CHECK_CLOSE(modes[1].getMeanPosition(),0.5,0.000001);
-  BOOST_CHECK_CLOSE(modes[2].getMeanPosition(),0.8,0.000001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.2, 0.000001);
+  BOOST_CHECK_CLOSE(modes[1].getMeanPosition(), 0.5, 0.000001);
+  BOOST_CHECK_CLOSE(modes[2].getMeanPosition(), 0.8, 0.000001);
 
   // area
-  BOOST_CHECK_CLOSE(modes[0].getModeArea(),0.5,0.000001);
-  BOOST_CHECK_CLOSE(modes[1].getModeArea(),0.4,0.000001);
-  BOOST_CHECK_CLOSE(modes[2].getModeArea(),0.1,0.000001);
-
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 0.5, 0.000001);
+  BOOST_CHECK_CLOSE(modes[1].getModeArea(), 0.4, 0.000001);
+  BOOST_CHECK_CLOSE(modes[2].getModeArea(), 0.1, 0.000001);
 }
 
+BOOST_AUTO_TEST_CASE(nominal_delta_test) {
 
-BOOST_AUTO_TEST_CASE( nominal_delta_test ) {
-
-  std::vector<double> sampling{0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0};
-  std::vector<double>      pdf{0.0,0.0,5.0,0.0,0.0,4.0,0.0,0.0,1.0,0.0,0.0};
-  auto full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
+  std::vector<double> sampling{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+  std::vector<double> pdf{0.0, 0.0, 5.0, 0.0, 0.0, 4.0, 0.0, 0.0, 1.0, 0.0, 0.0};
+  auto                full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
 
   auto modes = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.8, 3);
 
   // position
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.2,0.000001);
-  BOOST_CHECK_CLOSE(modes[1].getMeanPosition(),0.5,0.000001);
-  BOOST_CHECK_CLOSE(modes[2].getMeanPosition(),0.8,0.000001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.2, 0.000001);
+  BOOST_CHECK_CLOSE(modes[1].getMeanPosition(), 0.5, 0.000001);
+  BOOST_CHECK_CLOSE(modes[2].getMeanPosition(), 0.8, 0.000001);
 
   // area
-  BOOST_CHECK_CLOSE(modes[0].getModeArea(),0.5,0.000001);
-  BOOST_CHECK_CLOSE(modes[1].getModeArea(),0.4,0.000001);
-  BOOST_CHECK_CLOSE(modes[2].getModeArea(),0.1,0.000001);
-
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 0.5, 0.000001);
+  BOOST_CHECK_CLOSE(modes[1].getModeArea(), 0.4, 0.000001);
+  BOOST_CHECK_CLOSE(modes[2].getModeArea(), 0.1, 0.000001);
 
   modes = Euclid::MathUtils::extractNBigestModes(full_pdf, 0.8, 3);
 
   // position
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.2,0.000001);
-  BOOST_CHECK_CLOSE(modes[1].getMeanPosition(),0.5,0.000001);
-  BOOST_CHECK_CLOSE(modes[2].getMeanPosition(),0.8,0.000001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.2, 0.000001);
+  BOOST_CHECK_CLOSE(modes[1].getMeanPosition(), 0.5, 0.000001);
+  BOOST_CHECK_CLOSE(modes[2].getMeanPosition(), 0.8, 0.000001);
 
   // area
-  BOOST_CHECK_CLOSE(modes[0].getModeArea(),0.5,0.000001);
-  BOOST_CHECK_CLOSE(modes[1].getModeArea(),0.4,0.000001);
-  BOOST_CHECK_CLOSE(modes[2].getModeArea(),0.1,0.000001);
-
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 0.5, 0.000001);
+  BOOST_CHECK_CLOSE(modes[1].getModeArea(), 0.4, 0.000001);
+  BOOST_CHECK_CLOSE(modes[2].getModeArea(), 0.1, 0.000001);
 }
 
-
-BOOST_AUTO_TEST_CASE( peak_location_test ) {
-  std::vector<double> sampling{0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0};
-  std::vector<double>      pdf{0.0,0.2,0.5,0.3,0.0,0.0,0.2,0.5,1.0,0.0,0.0};
-  auto full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
-  auto modes = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.8, 2);
+BOOST_AUTO_TEST_CASE(peak_location_test) {
+  std::vector<double> sampling{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+  std::vector<double> pdf{0.0, 0.2, 0.5, 0.3, 0.0, 0.0, 0.2, 0.5, 1.0, 0.0, 0.0};
+  auto                full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
+  auto                modes    = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.8, 2);
 
   /// max sampling
-  BOOST_CHECK_CLOSE(modes[0].getHighestSamplePosition(),0.8,0.000001);
-  BOOST_CHECK_CLOSE(modes[1].getHighestSamplePosition(),0.2,0.000001);
+  BOOST_CHECK_CLOSE(modes[0].getHighestSamplePosition(), 0.8, 0.000001);
+  BOOST_CHECK_CLOSE(modes[1].getHighestSamplePosition(), 0.2, 0.000001);
 
   // mean
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.7470588235294118,0.000001);
-  BOOST_CHECK_CLOSE(modes[1].getMeanPosition(),0.21,0.000001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.7470588235294118, 0.000001);
+  BOOST_CHECK_CLOSE(modes[1].getMeanPosition(), 0.21, 0.000001);
 
   // fitted
-  BOOST_CHECK_CLOSE(modes[0].getInterpolatedMaxPosition(),0.783333333333,0.000001);
-  BOOST_CHECK_CLOSE(modes[1].getInterpolatedMaxPosition(),0.21,0.000001);
+  BOOST_CHECK_CLOSE(modes[0].getInterpolatedMaxPosition(), 0.783333333333, 0.000001);
+  BOOST_CHECK_CLOSE(modes[1].getInterpolatedMaxPosition(), 0.21, 0.000001);
 }
 
+BOOST_AUTO_TEST_CASE(area_test) {
 
-BOOST_AUTO_TEST_CASE( area_test ) {
+  std::vector<double> sampling{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+  std::vector<double> pdf{0.0, 10., 9.0, 8.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+  auto                full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
+  auto                modes    = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.8, 1);
 
-  std::vector<double> sampling{0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0};
-  std::vector<double>      pdf{0.0,10.,9.0,8.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0};
-  auto full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
-  auto modes = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.8, 1);
-  
   // position
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.19259259,0.001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.19259259, 0.001);
   // area
-  BOOST_CHECK_CLOSE(modes[0].getModeArea(),2.7,0.001);
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 2.7, 0.001);
 }
 
-BOOST_AUTO_TEST_CASE( order_test ) {
+BOOST_AUTO_TEST_CASE(order_test) {
 
-  std::vector<double> sampling{0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0};
-  std::vector<double>      pdf{0.0,10.,0.0,0.0,0.0,0.0,5.0,6.0,5.0,0.0,0.0};
-  auto full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
-  auto modes = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.8, 1);
-  
+  std::vector<double> sampling{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+  std::vector<double> pdf{0.0, 10., 0.0, 0.0, 0.0, 0.0, 5.0, 6.0, 5.0, 0.0, 0.0};
+  auto                full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
+  auto                modes    = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.8, 1);
+
   // position
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.1,0.001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.1, 0.001);
   // area
-  BOOST_CHECK_CLOSE(modes[0].getModeArea(),1,0.001);
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 1, 0.001);
 
   modes = Euclid::MathUtils::extractNBigestModes(full_pdf, 0.8, 1);
   // position
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.7,0.001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.7, 0.001);
   // area
-  BOOST_CHECK_CLOSE(modes[0].getModeArea(),1.6,0.001);
-
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 1.6, 0.001);
 }
 
-BOOST_AUTO_TEST_CASE( merge_ratio_square_test ) {
+BOOST_AUTO_TEST_CASE(merge_ratio_square_test) {
 
-  std::vector<double> sampling{0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0};
-  std::vector<double>      pdf{0.0,0.0,4.0,2.0,5.0,6.0,5.0,2.0,4.0,0.0,0.0};
-  auto full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
-  auto modes = Euclid::MathUtils::extractNHighestModes(full_pdf, 1.0, 1);
+  std::vector<double> sampling{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+  std::vector<double> pdf{0.0, 0.0, 4.0, 2.0, 5.0, 6.0, 5.0, 2.0, 4.0, 0.0, 0.0};
+  auto                full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
+  auto                modes    = Euclid::MathUtils::extractNHighestModes(full_pdf, 1.0, 1);
   // position
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.5,0.0001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.5, 0.0001);
   // area
-  BOOST_CHECK_CLOSE(modes[0].getModeArea(),2.8,0.0001);
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 2.8, 0.0001);
 
   modes = Euclid::MathUtils::extractNBigestModes(full_pdf, 1.0, 1);
   // position
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.5,0.0001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.5, 0.0001);
   // area
-  BOOST_CHECK_CLOSE(modes[0].getModeArea(),2.8,0.0001);
-
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 2.8, 0.0001);
 }
 
-BOOST_AUTO_TEST_CASE( merge_ratio_right_test ) {
+BOOST_AUTO_TEST_CASE(merge_ratio_right_test) {
 
-  std::vector<double> sampling{0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0};
-  std::vector<double>      pdf{0.0,10.,9.0,8.5,8.0,8.1,7.0,7.1,0.0,0.0,0.0};
-  auto full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
-  auto modes = Euclid::MathUtils::extractNHighestModes(full_pdf, 1.0, 1);
+  std::vector<double> sampling{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+  std::vector<double> pdf{0.0, 10., 9.0, 8.5, 8.0, 8.1, 7.0, 7.1, 0.0, 0.0, 0.0};
+  auto                full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
+  auto                modes    = Euclid::MathUtils::extractNHighestModes(full_pdf, 1.0, 1);
 
   // position
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.37729636,0.0001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.37729636, 0.0001);
   // area
-  BOOST_CHECK_CLOSE(modes[0].getModeArea(),5.77,0.0001);
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 5.77, 0.0001);
 
   modes = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.0, 1);
   // position
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.240845,0.0001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.240845, 0.0001);
   // area
-  BOOST_CHECK_CLOSE(modes[0].getModeArea(),3.55,0.0001);
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 3.55, 0.0001);
 
   modes = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.19, 1);
   // position
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.240845,0.0001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.240845, 0.0001);
   // area
-  BOOST_CHECK_CLOSE(modes[0].getModeArea(),3.55,0.0001);
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 3.55, 0.0001);
 
- modes = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.29, 1);
- // position
- BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.3320158,0.0001);
- // area
- BOOST_CHECK_CLOSE(modes[0].getModeArea(),5.06,0.0001);
-
-
+  modes = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.29, 1);
+  // position
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.3320158, 0.0001);
+  // area
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 5.06, 0.0001);
 }
 
-BOOST_AUTO_TEST_CASE( merge_ratio_left_test ) {
+BOOST_AUTO_TEST_CASE(merge_ratio_left_test) {
 
-  std::vector<double> sampling{0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0};
-  std::vector<double>      pdf{0.0,8.1,8.0,8.5,9.0,10.0,0.0,0.0,0.0,0.0,0.0};
-  auto full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
+  std::vector<double> sampling{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+  std::vector<double> pdf{0.0, 8.1, 8.0, 8.5, 9.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+  auto                full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
 
   auto modes = Euclid::MathUtils::extractNHighestModes(full_pdf, 1.0, 1);
   // position
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.3110092,0.0001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.3110092, 0.0001);
   // area
-  BOOST_CHECK_CLOSE(modes[0].getModeArea(),4.36,0.0001);
-
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 4.36, 0.0001);
 
   modes = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.0, 1);
   // position
-  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(),0.3591549,0.0001);
+  BOOST_CHECK_CLOSE(modes[0].getMeanPosition(), 0.3591549, 0.0001);
   // area
-  BOOST_CHECK_CLOSE(modes[0].getModeArea(),3.55,0.0001);
+  BOOST_CHECK_CLOSE(modes[0].getModeArea(), 3.55, 0.0001);
 }
 
-
 BOOST_AUTO_TEST_CASE(getInterpolationAround_nominal_case_test) {
-  std::vector<double> sampling{0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0};
-  std::vector<double>      pdf{0.0,1.0,0.0,0.0,1.0,3.0,2.0,0.0,0.0,0.0,0.0};
-  auto full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
+  std::vector<double> sampling{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+  std::vector<double> pdf{0.0, 1.0, 0.0, 0.0, 1.0, 3.0, 2.0, 0.0, 0.0, 0.0, 0.0};
+  auto                full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
 
   auto modes = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.8, 2);
-  
-  BOOST_CHECK_CLOSE(modes[0].getInterpolatedMaxPosition(),0.5166666666666,0.0001);
-  BOOST_CHECK_CLOSE(modes[1].getInterpolatedMaxPosition(),0.1,0.0001);
+
+  BOOST_CHECK_CLOSE(modes[0].getInterpolatedMaxPosition(), 0.5166666666666, 0.0001);
+  BOOST_CHECK_CLOSE(modes[1].getInterpolatedMaxPosition(), 0.1, 0.0001);
 }
 
 BOOST_AUTO_TEST_CASE(getInterpolationAround_border_case_test) {
-  std::vector<double> sampling{0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0};
-  std::vector<double>      pdf{3.0,2.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,1.1};
-  auto full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
-  auto modes = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.8, 2);
-  
-  BOOST_CHECK_CLOSE(modes[0].getInterpolatedMaxPosition(),0.0,0.0001);
-  BOOST_CHECK_CLOSE(modes[1].getInterpolatedMaxPosition(),0.96111111111,0.0001);
+  std::vector<double> sampling{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+  std::vector<double> pdf{3.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.1};
+  auto                full_pdf = Euclid::XYDataset::XYDataset::factory(sampling, pdf);
+  auto                modes    = Euclid::MathUtils::extractNHighestModes(full_pdf, 0.8, 2);
+
+  BOOST_CHECK_CLOSE(modes[0].getInterpolatedMaxPosition(), 0.0, 0.0001);
+  BOOST_CHECK_CLOSE(modes[1].getInterpolatedMaxPosition(), 0.96111111111, 0.0001);
 }
-
-
-
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/MathUtils/tests/src/function/Differentiable_test.cpp
+++ b/MathUtils/tests/src/function/Differentiable_test.cpp
@@ -1,64 +1,63 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file tests/src/function/Differentiable_test.cpp
  * @date February 19, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
-#include "MathUtils/function/Function.h"
 #include "MathUtils/function/Differentiable.h"
+#include "MathUtils/function/Function.h"
 #include "mocks.h"
+#include <boost/test/unit_test.hpp>
 
 struct Differentiable_Fixture {
-  double close_tolerance {1E-10};
-  double small_tolerance {1E-40};
+  double close_tolerance{1E-10};
+  double small_tolerance{1E-40};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (Differentiable_test)
+BOOST_AUTO_TEST_SUITE(Differentiable_test)
 
 //-----------------------------------------------------------------------------
 // Test that the integration uses the indefinite integral
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Constructor, Differentiable_Fixture) {
-  
+
   // Given
-  DifferentiableMock differentiable {};
-  
+  DifferentiableMock differentiable{};
+
   // When
-  double integral1 = differentiable.integrate(-1,5);
-  double integral2 = differentiable.integrate(-1,15);
-  double integral3 = differentiable.integrate(-1,-4);
-  double integral4 = differentiable.integrate(1,5);
-  
+  double integral1 = differentiable.integrate(-1, 5);
+  double integral2 = differentiable.integrate(-1, 15);
+  double integral3 = differentiable.integrate(-1, -4);
+  double integral4 = differentiable.integrate(1, 5);
+
   // Then
   BOOST_CHECK_CLOSE(integral1, 1., close_tolerance);
   BOOST_CHECK_CLOSE(integral2, 1., close_tolerance);
   BOOST_CHECK_SMALL(integral3, small_tolerance);
   BOOST_CHECK_SMALL(integral4, small_tolerance);
-  
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/MathUtils/tests/src/function/FunctionAdapter_test_mock.cpp
+++ b/MathUtils/tests/src/function/FunctionAdapter_test_mock.cpp
@@ -1,35 +1,34 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file tests/src/function/FunctionAdapter_test_mock.cpp
  * @date November 2, 2015
  * @author FLorian Dubath
  */
 
-#include <boost/test/unit_test.hpp>
-#include <boost/test/test_tools.hpp>
 #include "ElementsKernel/EnableGMock.h"
+#include <boost/test/test_tools.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include "MathUtils/function/FunctionAdapter.h"
 
 using namespace testing;
-
 
 class MockStdFunction {
 public:
@@ -37,8 +36,7 @@ public:
   MOCK_METHOD1(FunctorCall, double(double));
 };
 
-
-std::unique_ptr<MockStdFunction> mock_std_function_singleton {};
+std::unique_ptr<MockStdFunction> mock_std_function_singleton{};
 
 class TestFunction {
 public:
@@ -50,10 +48,9 @@ public:
   }
 };
 
-
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (FunctionAdapter_test)
+BOOST_AUTO_TEST_SUITE(FunctionAdapter_test)
 
 BOOST_AUTO_TEST_CASE(DirectCall) {
   mock_std_function_singleton.reset(new MockStdFunction{});
@@ -61,7 +58,7 @@ BOOST_AUTO_TEST_CASE(DirectCall) {
 
   Euclid::MathUtils::FunctionAdapter adapter{TestFunction()};
 
-  BOOST_CHECK_EQUAL(adapter(1.0),3.14);
+  BOOST_CHECK_EQUAL(adapter(1.0), 3.14);
   mock_std_function_singleton.reset(nullptr);
 }
 
@@ -70,14 +67,12 @@ BOOST_AUTO_TEST_CASE(CloneCall) {
   EXPECT_CALL(*mock_std_function_singleton, FunctorCall(1.0)).Times(1).WillOnce(Return(3.14));
 
   Euclid::MathUtils::FunctionAdapter adapter{TestFunction()};
-  auto cloned = adapter.clone();
+  auto                               cloned = adapter.clone();
 
-  BOOST_CHECK_EQUAL((*cloned)(1.0),3.14);
+  BOOST_CHECK_EQUAL((*cloned)(1.0), 3.14);
   mock_std_function_singleton.reset(nullptr);
-
 }
-
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/MathUtils/tests/src/function/Multiplication_test.cpp
+++ b/MathUtils/tests/src/function/Multiplication_test.cpp
@@ -1,58 +1,58 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file tests/src/function/Multiplication_test.cpp
  * @date February 19, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
-#include <boost/test/test_tools.hpp>
-#include <memory>
-#include "MathUtils/function/function_tools.h"
-#include "MathUtils/function/Polynomial.h"
 #include "MathUtils/function/Piecewise.h"
+#include "MathUtils/function/Polynomial.h"
+#include "MathUtils/function/function_tools.h"
 #include "mocks.h"
+#include <boost/test/test_tools.hpp>
+#include <boost/test/unit_test.hpp>
+#include <memory>
 
 struct Multiplication_Fixture {
-  double close_tolerance {1E-10};
-  double small_tolerance {1E-20};
+  double close_tolerance{1E-10};
+  double small_tolerance{1E-20};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (Multiplication_test)
+BOOST_AUTO_TEST_SUITE(Multiplication_test)
 
 //-----------------------------------------------------------------------------
 // Test multiplication between two polynomials
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(PolynomialWithPolynomial, Multiplication_Fixture) {
-  
+
   // Given
-  Euclid::MathUtils::Polynomial p1 {{1., 0.5, -2.}};
-  Euclid::MathUtils::Polynomial p2 {{3., 0., 2.}};
-  std::vector<double> expectedCoef {3., 1.5, -4., 1., -4.};
-  
+  Euclid::MathUtils::Polynomial p1{{1., 0.5, -2.}};
+  Euclid::MathUtils::Polynomial p2{{3., 0., 2.}};
+  std::vector<double>           expectedCoef{3., 1.5, -4., 1., -4.};
+
   // When
   auto multPointer = Euclid::MathUtils::multiply(p1, p2);
-  
+
   // Then
   BOOST_CHECK(multPointer);
   Euclid::MathUtils::Polynomial* polPointer = dynamic_cast<Euclid::MathUtils::Polynomial*>(multPointer.get());
@@ -66,25 +66,25 @@ BOOST_FIXTURE_TEST_CASE(PolynomialWithPolynomial, Multiplication_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(PiecewiseWithGeneric, Multiplication_Fixture) {
-  
+
   // Given
-  std::vector<double> knots {-1.,0.,1.,2.};
-  std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
+  std::vector<double>                                       knots{-1., 0., 1., 2.};
+  std::vector<std::shared_ptr<Euclid::MathUtils::Function>> functions{};
   functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(1.)));
   functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(2.)));
   functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(1.)));
   Euclid::MathUtils::Piecewise piecewise{knots, functions};
-  IntegrableMock generic {5.};
-  
+  IntegrableMock               generic{5.};
+
   // When
   auto multPointer = Euclid::MathUtils::multiply(piecewise, generic);
-  
+
   // Then
   BOOST_CHECK(multPointer);
   Euclid::MathUtils::Piecewise* piecePointer = dynamic_cast<Euclid::MathUtils::Piecewise*>(multPointer.get());
   BOOST_CHECK(piecePointer);
-  for (double x=-2.;x<= 3.; x+=.1) {
-    BOOST_CHECK_CLOSE((*multPointer)(x), piecewise(x)*generic(x), close_tolerance);
+  for (double x = -2.; x <= 3.; x += .1) {
+    BOOST_CHECK_CLOSE((*multPointer)(x), piecewise(x) * generic(x), close_tolerance);
   }
 }
 
@@ -93,50 +93,50 @@ BOOST_FIXTURE_TEST_CASE(PiecewiseWithGeneric, Multiplication_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(PiecewiseWithPiecewise, Multiplication_Fixture) {
-  
+
   // Given
-  std::vector<double> knots1 {-1.,0.,1.,2.};
-  std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions1 {};
+  std::vector<double>                                       knots1{-1., 0., 1., 2.};
+  std::vector<std::shared_ptr<Euclid::MathUtils::Function>> functions1{};
   functions1.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(1.)));
   functions1.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(2.)));
   functions1.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(1.)));
-  Euclid::MathUtils::Piecewise p1{knots1, functions1};
-  std::vector<double> knots2 {.5,.7,1.,1.5,4.,6};
-  std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions2 {};
+  Euclid::MathUtils::Piecewise                              p1{knots1, functions1};
+  std::vector<double>                                       knots2{.5, .7, 1., 1.5, 4., 6};
+  std::vector<std::shared_ptr<Euclid::MathUtils::Function>> functions2{};
   functions2.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(3.)));
   functions2.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(2.)));
   functions2.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(1.)));
   functions2.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(3.)));
   functions2.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(4.)));
   Euclid::MathUtils::Piecewise p2{knots2, functions2};
-  
+
   // When
   auto multPointer = Euclid::MathUtils::multiply(p1, p2);
-  
+
   // Then
   BOOST_CHECK(multPointer);
   Euclid::MathUtils::Piecewise* piecePointer = dynamic_cast<Euclid::MathUtils::Piecewise*>(multPointer.get());
   BOOST_CHECK(piecePointer);
-  auto resKnots = piecePointer->getKnots();
-  std::vector<double> expectedKnots {.5,.7,1.,1.5,2.};
+  auto                resKnots = piecePointer->getKnots();
+  std::vector<double> expectedKnots{.5, .7, 1., 1.5, 2.};
   BOOST_CHECK_EQUAL_COLLECTIONS(resKnots.begin(), resKnots.end(), expectedKnots.begin(), expectedKnots.end());
-  for (double x=-2.;x<= 7.; x+=.1) {
-    BOOST_CHECK_CLOSE((*multPointer)(x), p1(x)*p2(x), close_tolerance);
+  for (double x = -2.; x <= 7.; x += .1) {
+    BOOST_CHECK_CLOSE((*multPointer)(x), p1(x) * p2(x), close_tolerance);
   }
-  
+
   // When
   // Multiplication order should not matter
   multPointer = Euclid::MathUtils::multiply(p2, p1);
-  
+
   // Then
   BOOST_CHECK(multPointer);
   piecePointer = dynamic_cast<Euclid::MathUtils::Piecewise*>(multPointer.get());
   BOOST_CHECK(piecePointer);
-  resKnots = piecePointer->getKnots();
-  expectedKnots = {.5,.7,1.,1.5,2.};
+  resKnots      = piecePointer->getKnots();
+  expectedKnots = {.5, .7, 1., 1.5, 2.};
   BOOST_CHECK_EQUAL_COLLECTIONS(resKnots.begin(), resKnots.end(), expectedKnots.begin(), expectedKnots.end());
-  for (double x=-2.;x<= 7.; x+=.1) {
-    BOOST_CHECK_CLOSE((*multPointer)(x), p1(x)*p2(x), close_tolerance);
+  for (double x = -2.; x <= 7.; x += .1) {
+    BOOST_CHECK_CLOSE((*multPointer)(x), p1(x) * p2(x), close_tolerance);
   }
 }
 
@@ -145,47 +145,47 @@ BOOST_FIXTURE_TEST_CASE(PiecewiseWithPiecewise, Multiplication_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(PiecewiseWithPiecewiseDiffRanges, Multiplication_Fixture) {
-  
+
   // Given
-  std::vector<double> knots1 {-1.,0.,1.,2.};
-  std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions1 {};
+  std::vector<double>                                       knots1{-1., 0., 1., 2.};
+  std::vector<std::shared_ptr<Euclid::MathUtils::Function>> functions1{};
   functions1.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(1.)));
   functions1.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(2.)));
   functions1.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(1.)));
-  Euclid::MathUtils::Piecewise p1{knots1, functions1};
-  std::vector<double> knots2 {3.,4.,5.,6.,7.,8.};
-  std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions2 {};
+  Euclid::MathUtils::Piecewise                              p1{knots1, functions1};
+  std::vector<double>                                       knots2{3., 4., 5., 6., 7., 8.};
+  std::vector<std::shared_ptr<Euclid::MathUtils::Function>> functions2{};
   functions2.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(3.)));
   functions2.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(2.)));
   functions2.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(1.)));
   functions2.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(3.)));
   functions2.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(4.)));
   Euclid::MathUtils::Piecewise p2{knots2, functions2};
-  
+
   // When
   auto multPointer = Euclid::MathUtils::multiply(p1, p2);
-  
+
   // Then
   BOOST_CHECK(multPointer);
   Euclid::MathUtils::Polynomial* ppolyPointer = dynamic_cast<Euclid::MathUtils::Polynomial*>(multPointer.get());
   BOOST_CHECK(ppolyPointer);
-  auto resCoeff = ppolyPointer->getCoefficients();
-  std::vector<double> expectedCoeff {.0};
+  auto                resCoeff = ppolyPointer->getCoefficients();
+  std::vector<double> expectedCoeff{.0};
   BOOST_CHECK_EQUAL_COLLECTIONS(resCoeff.begin(), resCoeff.end(), expectedCoeff.begin(), expectedCoeff.end());
-  
+
   // When
   // Multiplication order should not matter
   multPointer = Euclid::MathUtils::multiply(p2, p1);
-  
+
   // Then
   BOOST_CHECK(multPointer);
   ppolyPointer = dynamic_cast<Euclid::MathUtils::Polynomial*>(multPointer.get());
   BOOST_CHECK(ppolyPointer);
-  resCoeff = ppolyPointer->getCoefficients();
+  resCoeff      = ppolyPointer->getCoefficients();
   expectedCoeff = {.0};
   BOOST_CHECK_EQUAL_COLLECTIONS(resCoeff.begin(), resCoeff.end(), expectedCoeff.begin(), expectedCoeff.end());
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/MathUtils/tests/src/function/Piecewise_test.cpp
+++ b/MathUtils/tests/src/function/Piecewise_test.cpp
@@ -16,28 +16,28 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/function/Piecewise_test.cpp
  * @date February 20, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
 #include "ElementsKernel/Exception.h"
-#include <memory>
 #include "MathUtils/function/Function.h"
 #include "MathUtils/function/Integrable.h"
 #include "MathUtils/function/Piecewise.h"
 #include "mocks.h"
+#include <boost/test/unit_test.hpp>
+#include <memory>
 
 struct Piecewise_Fixture {
-  double close_tolerance {1E-10};
-  double small_tolerance {1E-20};
+  double close_tolerance{1E-10};
+  double small_tolerance{1E-20};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (Piecewise_test)
+BOOST_AUTO_TEST_SUITE(Piecewise_test)
 
 //-----------------------------------------------------------------------------
 // Test that the constructor sets the knots and the functions correctly
@@ -46,8 +46,8 @@ BOOST_AUTO_TEST_SUITE (Piecewise_test)
 BOOST_FIXTURE_TEST_CASE(Constructor, Piecewise_Fixture) {
 
   // Given
-  std::vector<double> knots {-1.,-0.5,0.25,10.};
-  std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
+  std::vector<double>                                       knots{-1., -0.5, 0.25, 10.};
+  std::vector<std::shared_ptr<Euclid::MathUtils::Function>> functions{};
   for (double knot : knots) {
     functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(knot)));
   }
@@ -55,7 +55,7 @@ BOOST_FIXTURE_TEST_CASE(Constructor, Piecewise_Fixture) {
 
   // When
   Euclid::MathUtils::Piecewise piecewise{knots, functions};
-  auto resKnots = piecewise.getKnots();
+  auto                         resKnots = piecewise.getKnots();
 
   // Then
   BOOST_CHECK_EQUAL_COLLECTIONS(resKnots.begin(), resKnots.end(), knots.begin(), knots.end());
@@ -68,8 +68,8 @@ BOOST_FIXTURE_TEST_CASE(Constructor, Piecewise_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ConstructorUnorderedKnots, Piecewise_Fixture) {
 
   // Given
-  std::vector<double> knots {-1.,0.5,0.25,10.};
-  std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
+  std::vector<double>                                       knots{-1., 0.5, 0.25, 10.};
+  std::vector<std::shared_ptr<Euclid::MathUtils::Function>> functions{};
   for (double knot : knots) {
     functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(knot)));
   }
@@ -77,7 +77,6 @@ BOOST_FIXTURE_TEST_CASE(ConstructorUnorderedKnots, Piecewise_Fixture) {
 
   // Then
   BOOST_CHECK_THROW(Euclid::MathUtils::Piecewise(knots, functions), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -87,15 +86,14 @@ BOOST_FIXTURE_TEST_CASE(ConstructorUnorderedKnots, Piecewise_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ConstructorWrongSizes, Piecewise_Fixture) {
 
   // Given
-  std::vector<double> knots {-1.,-0.5,0.25,10.};
-  std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
+  std::vector<double>                                       knots{-1., -0.5, 0.25, 10.};
+  std::vector<std::shared_ptr<Euclid::MathUtils::Function>> functions{};
   for (double knot : knots) {
     functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(knot)));
   }
 
   // Then
   BOOST_CHECK_THROW(Euclid::MathUtils::Piecewise(knots, functions), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -105,8 +103,8 @@ BOOST_FIXTURE_TEST_CASE(ConstructorWrongSizes, Piecewise_Fixture) {
 BOOST_FIXTURE_TEST_CASE(Clone, Piecewise_Fixture) {
 
   // Given
-  std::vector<double> knots {-1.,-0.5,0.25,10.};
-  std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
+  std::vector<double>                                       knots{-1., -0.5, 0.25, 10.};
+  std::vector<std::shared_ptr<Euclid::MathUtils::Function>> functions{};
   for (double knot : knots) {
     functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(knot)));
   }
@@ -131,8 +129,8 @@ BOOST_FIXTURE_TEST_CASE(Clone, Piecewise_Fixture) {
 BOOST_FIXTURE_TEST_CASE(FunctionOperator, Piecewise_Fixture) {
 
   // Given
-  std::vector<double> knots {-1.,-0.5,0.25,10.};
-  std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
+  std::vector<double>                                       knots{-1., -0.5, 0.25, 10.};
+  std::vector<std::shared_ptr<Euclid::MathUtils::Function>> functions{};
   for (double knot : knots) {
     functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(knot)));
   }
@@ -151,7 +149,6 @@ BOOST_FIXTURE_TEST_CASE(FunctionOperator, Piecewise_Fixture) {
   BOOST_CHECK_CLOSE(piecewise(5.), .25, close_tolerance);
   BOOST_CHECK_CLOSE(piecewise(10.), .25, close_tolerance);
   BOOST_CHECK_SMALL(piecewise(11.), small_tolerance);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -161,23 +158,23 @@ BOOST_FIXTURE_TEST_CASE(FunctionOperator, Piecewise_Fixture) {
 BOOST_FIXTURE_TEST_CASE(IntegrateInRange, Piecewise_Fixture) {
 
   // Given
-  std::vector<double> knots {-1.,0.,1.,2.};
-  std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
+  std::vector<double>                                       knots{-1., 0., 1., 2.};
+  std::vector<std::shared_ptr<Euclid::MathUtils::Function>> functions{};
   functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(1.)));
   functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(2.)));
   functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(1.)));
   Euclid::MathUtils::Piecewise piecewise{knots, functions};
 
   // When
-  double integral1 = piecewise.integrate(-1., 2.);
-  double integral2 = piecewise.integrate(-.5, .5);
-  double integral3 = piecewise.integrate(-.5, 1.5);
-  double integral4 = piecewise.integrate(0., 1.);
-  double integral5 = piecewise.integrate(.5, .5);
-  double integral6 = piecewise.integrate(0., 0.);
-  double integral7 = piecewise.integrate(2., -1.);
-  double integral8 = piecewise.integrate(.5, -.5);
-  double integral9 = piecewise.integrate(1.5, -.5);
+  double integral1  = piecewise.integrate(-1., 2.);
+  double integral2  = piecewise.integrate(-.5, .5);
+  double integral3  = piecewise.integrate(-.5, 1.5);
+  double integral4  = piecewise.integrate(0., 1.);
+  double integral5  = piecewise.integrate(.5, .5);
+  double integral6  = piecewise.integrate(0., 0.);
+  double integral7  = piecewise.integrate(2., -1.);
+  double integral8  = piecewise.integrate(.5, -.5);
+  double integral9  = piecewise.integrate(1.5, -.5);
   double integral10 = piecewise.integrate(1., 0.);
 
   // Then
@@ -191,7 +188,6 @@ BOOST_FIXTURE_TEST_CASE(IntegrateInRange, Piecewise_Fixture) {
   BOOST_CHECK_CLOSE(integral8, -1.5, close_tolerance);
   BOOST_CHECK_CLOSE(integral9, -3., close_tolerance);
   BOOST_CHECK_CLOSE(integral10, -2., close_tolerance);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -201,8 +197,8 @@ BOOST_FIXTURE_TEST_CASE(IntegrateInRange, Piecewise_Fixture) {
 BOOST_FIXTURE_TEST_CASE(IntegrateOutOfRange, Piecewise_Fixture) {
 
   // Given
-  std::vector<double> knots {-1.,0.,1.,2.};
-  std::vector<std::shared_ptr<Euclid::MathUtils::Function> > functions {};
+  std::vector<double>                                       knots{-1., 0., 1., 2.};
+  std::vector<std::shared_ptr<Euclid::MathUtils::Function>> functions{};
   functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(1.)));
   functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(2.)));
   functions.push_back(std::shared_ptr<Euclid::MathUtils::Function>(new IntegrableMock(1.)));
@@ -221,9 +217,8 @@ BOOST_FIXTURE_TEST_CASE(IntegrateOutOfRange, Piecewise_Fixture) {
   BOOST_CHECK_CLOSE(integral3, 2., close_tolerance);
   BOOST_CHECK_SMALL(integral4, small_tolerance);
   BOOST_CHECK_SMALL(integral5, small_tolerance);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/MathUtils/tests/src/function/Polynomial_test.cpp
+++ b/MathUtils/tests/src/function/Polynomial_test.cpp
@@ -1,40 +1,40 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file tests/src/function/Polynomial_test.cpp
  * @date February 19, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
-#include <boost/test/floating_point_comparison.hpp>
-#include <boost/test/test_tools.hpp>
-#include <memory>
-#include <sstream>
 #include "ElementsKernel/Real.h"
 #include "MathUtils/function/Polynomial.h"
+#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/test_tools.hpp>
+#include <boost/test/unit_test.hpp>
+#include <memory>
+#include <sstream>
 
 struct Polynomial_Fixture {
-  double relative_error_tolerance {1E-10};
-  template<typename T>
+  double relative_error_tolerance{1E-10};
+  template <typename T>
   void AlmostEqualRelative(T expected, T actual) {
-    T relative_error =  (expected - actual) / actual;
+    T relative_error = (expected - actual) / actual;
     if (relative_error < 0) {
       relative_error = -relative_error;
     }
@@ -48,24 +48,23 @@ struct Polynomial_Fixture {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (Polynomial_test)
+BOOST_AUTO_TEST_SUITE(Polynomial_test)
 
 //-----------------------------------------------------------------------------
 // Test that the constructor sets the coefficients correctly
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Constructor, Polynomial_Fixture) {
-  
+
   // Given
-  std::vector<double> coef {2.5, 0.8, -1.3, 0.02};
-  Euclid::MathUtils::Polynomial polynomial {coef};
-  
+  std::vector<double>           coef{2.5, 0.8, -1.3, 0.02};
+  Euclid::MathUtils::Polynomial polynomial{coef};
+
   // When
   std::vector<double> resCoef = polynomial.getCoefficients();
-  
+
   // Then
   BOOST_CHECK_EQUAL_COLLECTIONS(resCoef.begin(), resCoef.end(), coef.begin(), coef.end());
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -73,21 +72,20 @@ BOOST_FIXTURE_TEST_CASE(Constructor, Polynomial_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Clone, Polynomial_Fixture) {
-  
+
   // Given
-  std::vector<double> coef {2.5, 0.8, -1.3, 0.02};
-  Euclid::MathUtils::Polynomial polynomial {coef};
-  
+  std::vector<double>           coef{2.5, 0.8, -1.3, 0.02};
+  Euclid::MathUtils::Polynomial polynomial{coef};
+
   // When
   auto clonePtr = polynomial.clone();
-  
+
   // Then
   BOOST_CHECK(clonePtr);
   Euclid::MathUtils::Polynomial* resPol = dynamic_cast<Euclid::MathUtils::Polynomial*>(clonePtr.get());
   BOOST_CHECK(resPol);
   std::vector<double> resCoef = resPol->getCoefficients();
   BOOST_CHECK_EQUAL_COLLECTIONS(resCoef.begin(), resCoef.end(), coef.begin(), coef.end());
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -97,19 +95,18 @@ BOOST_FIXTURE_TEST_CASE(Clone, Polynomial_Fixture) {
 BOOST_FIXTURE_TEST_CASE(FunctionOperator, Polynomial_Fixture) {
 
   // Given
-  std::vector<double> coef {2.5, 0.8, -1.3, 0.02};
-  Euclid::MathUtils::Polynomial polynomial {coef};
-  
-  for (double x=-10.; x <=10.; x+=0.1) {
-    
+  std::vector<double>           coef{2.5, 0.8, -1.3, 0.02};
+  Euclid::MathUtils::Polynomial polynomial{coef};
+
+  for (double x = -10.; x <= 10.; x += 0.1) {
+
     // When
-    double expected = 2.5 + 0.8*x -1.3*x*x + 0.02*x*x*x;
+    double expected = 2.5 + 0.8 * x - 1.3 * x * x + 0.02 * x * x * x;
     double polValue = polynomial(x);
-    
+
     // Then
     AlmostEqualRelative(expected, polValue);
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -117,15 +114,15 @@ BOOST_FIXTURE_TEST_CASE(FunctionOperator, Polynomial_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Derivative, Polynomial_Fixture) {
-  
+
   // Given
-  std::vector<double> polCoef {2.5, 0.8, -1.3, 0.02};
-  std::vector<double> expectedCoef {0.8, -2.6, 0.06};
-  Euclid::MathUtils::Polynomial polynomial {polCoef};
-  
+  std::vector<double>           polCoef{2.5, 0.8, -1.3, 0.02};
+  std::vector<double>           expectedCoef{0.8, -2.6, 0.06};
+  Euclid::MathUtils::Polynomial polynomial{polCoef};
+
   // When
   auto derivative = std::dynamic_pointer_cast<Euclid::MathUtils::Polynomial>(polynomial.derivative());
-  
+
   // Then
   BOOST_CHECK(derivative);
   std::vector<double> derCoef = derivative->getCoefficients();
@@ -137,15 +134,15 @@ BOOST_FIXTURE_TEST_CASE(Derivative, Polynomial_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(IndefiniteIntegral, Polynomial_Fixture) {
-  
+
   // Given
-  std::vector<double> polCoef {2.5, 0.8, -1.5, 0.02};
-  std::vector<double> expectedCoef {0., 2.5, 0.4, -0.5, 0.005};
-  Euclid::MathUtils::Polynomial polynomial {polCoef};
-  
+  std::vector<double>           polCoef{2.5, 0.8, -1.5, 0.02};
+  std::vector<double>           expectedCoef{0., 2.5, 0.4, -0.5, 0.005};
+  Euclid::MathUtils::Polynomial polynomial{polCoef};
+
   // When
   auto indefiniteIntegral = std::dynamic_pointer_cast<Euclid::MathUtils::Polynomial>(polynomial.indefiniteIntegral());
-  
+
   // Then
   BOOST_CHECK(indefiniteIntegral);
   std::vector<double> indefIntCoef = indefiniteIntegral->getCoefficients();
@@ -154,4 +151,4 @@ BOOST_FIXTURE_TEST_CASE(IndefiniteIntegral, Polynomial_Fixture) {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/MathUtils/tests/src/function/function_tools_test.cpp
+++ b/MathUtils/tests/src/function/function_tools_test.cpp
@@ -1,46 +1,46 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file tests/src/function/function_tools_test.cpp
  * @date February 19, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
 #include "ElementsKernel/Exception.h"
-#include "MathUtils/function/function_tools.h"
 #include "MathUtils/function/Function.h"
 #include "MathUtils/function/Integrable.h"
+#include "MathUtils/function/function_tools.h"
 #include "MathUtils/function/multiplication.h"
 #include "mocks.h"
+#include <boost/test/unit_test.hpp>
 
 class DummyMultiplyFunction : public Euclid::MathUtils::Function {
   double operator()(const double) const override {
     return 0;
   }
   std::unique_ptr<Function> clone() const override {
-    return std::unique_ptr<Function> {new DummyMultiplyFunction{}};
+    return std::unique_ptr<Function>{new DummyMultiplyFunction{}};
   }
 };
 
 std::unique_ptr<Euclid::MathUtils::Function> dummyMultiply(const Euclid::MathUtils::Function&, const Euclid::MathUtils::Function&) {
-  return std::unique_ptr<Euclid::MathUtils::Function>(new DummyMultiplyFunction {});
+  return std::unique_ptr<Euclid::MathUtils::Function>(new DummyMultiplyFunction{});
 }
 
 class FunctionType1 : public Euclid::MathUtils::Function {
@@ -48,7 +48,7 @@ class FunctionType1 : public Euclid::MathUtils::Function {
     return 0;
   }
   std::unique_ptr<Function> clone() const override {
-    return std::unique_ptr<Function> {new FunctionType1{}};
+    return std::unique_ptr<Function>{new FunctionType1{}};
   }
 };
 
@@ -57,31 +57,30 @@ class FunctionType2 : public Euclid::MathUtils::Function {
     return 0;
   }
   std::unique_ptr<Function> clone() const override {
-    return std::unique_ptr<Function> {new FunctionType2{}};
+    return std::unique_ptr<Function>{new FunctionType2{}};
   }
 };
 
 struct Function_Tools_Fixture {
-  double close_tolerance {1E-10};
-  double small_tolerance {1E-20};
+  double close_tolerance{1E-10};
+  double small_tolerance{1E-20};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (function_tools_test)
+BOOST_AUTO_TEST_SUITE(function_tools_test)
 
 //-----------------------------------------------------------------------------
 // Test that integration of a non-integrable function throws an exception
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(NonIntegrableIntegration) {
-  
+
   // Given
   FunctionMock f = FunctionMock{0.};
-  
+
   // Then
-  BOOST_CHECK_THROW(Euclid::MathUtils::integrate(f,0,1), Elements::Exception);
-  
+  BOOST_CHECK_THROW(Euclid::MathUtils::integrate(f, 0, 1), Elements::Exception);
 }
 
 //-----------------------------------------------------------------------------
@@ -89,21 +88,20 @@ BOOST_AUTO_TEST_CASE(NonIntegrableIntegration) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(IntegrableIntegration) {
-  
+
   // Given
-  double min = -1.5;
-  double max = 7.32;
-  IntegrableMock f = IntegrableMock{5.};
-  double expected = 5. * (max - min);
-  
+  double         min      = -1.5;
+  double         max      = 7.32;
+  IntegrableMock f        = IntegrableMock{5.};
+  double         expected = 5. * (max - min);
+
   // When
   double integral = Euclid::MathUtils::integrate(f, min, max);
-  
+
   // Then
   BOOST_CHECK_EQUAL(integral, expected);
   BOOST_CHECK_EQUAL(f.m_min, min);
   BOOST_CHECK_EQUAL(f.m_max, max);
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -111,17 +109,16 @@ BOOST_AUTO_TEST_CASE(IntegrableIntegration) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(NonMultipliableMultiplication, Function_Tools_Fixture) {
-  
+
   // Given
-  FunctionMock f1 {4.};
-  FunctionMock f2 {3.};
-  
+  FunctionMock f1{4.};
+  FunctionMock f2{3.};
+
   // When
   auto multiplication = Euclid::MathUtils::multiply(f1, f2);
-  
+
   // Then
   BOOST_CHECK_CLOSE((*multiplication)(15.), 12., close_tolerance);
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -129,32 +126,31 @@ BOOST_FIXTURE_TEST_CASE(NonMultipliableMultiplication, Function_Tools_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(SpecificGenericMultiplication, Function_Tools_Fixture) {
-  
+
   // Given
-  FunctionType1 f1 {};
-  FunctionType2 f2 {};
-  
+  FunctionType1 f1{};
+  FunctionType2 f2{};
+
   // When
   auto mult1 = Euclid::MathUtils::multiply(f1, f2);
   auto mult2 = Euclid::MathUtils::multiply(f2, f1);
-  
+
   // Then
   BOOST_CHECK(dynamic_cast<DummyMultiplyFunction*>(mult1.get()) == nullptr);
   BOOST_CHECK(dynamic_cast<DummyMultiplyFunction*>(mult2.get()) == nullptr);
-  
+
   // Given
   Euclid::MathUtils::multiplySpecificGenericMap[typeid(FunctionType1)] = dummyMultiply;
-  
+
   // When
   mult1 = Euclid::MathUtils::multiply(f1, f2);
   mult2 = Euclid::MathUtils::multiply(f2, f1);
-  
+
   // Then
   BOOST_CHECK(dynamic_cast<DummyMultiplyFunction*>(mult1.get()) != nullptr);
   BOOST_CHECK(dynamic_cast<DummyMultiplyFunction*>(mult2.get()) != nullptr);
-  
+
   Euclid::MathUtils::multiplySpecificGenericMap.erase(typeid(FunctionType1));
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -162,34 +158,33 @@ BOOST_FIXTURE_TEST_CASE(SpecificGenericMultiplication, Function_Tools_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(SpecificSpecificMultiplication, Function_Tools_Fixture) {
-  
+
   // Given
-  FunctionType1 f1 {};
-  FunctionType2 f2 {};
-  
+  FunctionType1 f1{};
+  FunctionType2 f2{};
+
   // When
   auto mult1 = Euclid::MathUtils::multiply(f1, f2);
   auto mult2 = Euclid::MathUtils::multiply(f2, f1);
-  
+
   // Then
   BOOST_CHECK(dynamic_cast<DummyMultiplyFunction*>(mult1.get()) == nullptr);
   BOOST_CHECK(dynamic_cast<DummyMultiplyFunction*>(mult2.get()) == nullptr);
-  
+
   // Given
-  Euclid::MathUtils::multiplySpecificSpecificMap[{typeid(FunctionType1),typeid(FunctionType2)}] = dummyMultiply;
-  
+  Euclid::MathUtils::multiplySpecificSpecificMap[{typeid(FunctionType1), typeid(FunctionType2)}] = dummyMultiply;
+
   // When
   mult1 = Euclid::MathUtils::multiply(f1, f2);
   mult2 = Euclid::MathUtils::multiply(f2, f1);
-  
+
   // Then
   BOOST_CHECK(dynamic_cast<DummyMultiplyFunction*>(mult1.get()) != nullptr);
   BOOST_CHECK(dynamic_cast<DummyMultiplyFunction*>(mult2.get()) != nullptr);
-  
-  Euclid::MathUtils::multiplySpecificSpecificMap.erase({typeid(FunctionType1),typeid(FunctionType2)});
-  
+
+  Euclid::MathUtils::multiplySpecificSpecificMap.erase({typeid(FunctionType1), typeid(FunctionType2)});
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/MathUtils/tests/src/function/function_tools_test_mock.cpp
+++ b/MathUtils/tests/src/function/function_tools_test_mock.cpp
@@ -1,88 +1,83 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file tests/src/function/function_tools_mock.cpp
  * @date Oct 29, 2015
  * @author Florian Dubath
  */
 
-#include <boost/test/unit_test.hpp>
-#include <boost/test/test_tools.hpp>
 #include "ElementsKernel/EnableGMock.h"
+#include <boost/test/test_tools.hpp>
+#include <boost/test/unit_test.hpp>
 
-#include "MathUtils/function/function_tools.h"
 #include "MathUtils/function/Function.h"
+#include "MathUtils/function/function_tools.h"
 #include "mocks.h"
 
 using namespace testing;
 
-
 struct Function_Tools_Fixture {
- class MockScheme : public Euclid::MathUtils::NumericalIntegrationScheme{
- public:
-   double operator()(const Euclid::MathUtils::Function& function, double min, double max) override{
-     return functorCall(function,min,max);
-   }
+  class MockScheme : public Euclid::MathUtils::NumericalIntegrationScheme {
+  public:
+    double operator()(const Euclid::MathUtils::Function& function, double min, double max) override {
+      return functorCall(function, min, max);
+    }
 
-   MOCK_CONST_METHOD3(functorCall, double(const Euclid::MathUtils::Function&,double,double));
- };
-
-
+    MOCK_CONST_METHOD3(functorCall, double(const Euclid::MathUtils::Function&, double, double));
+  };
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (function_tools_test_mock)
+BOOST_AUTO_TEST_SUITE(function_tools_test_mock)
 
 //-----------------------------------------------------------------------------
 // Test that integration of a non-integrable function is delegated to
 // the NumericalIntegrationScheme
 //-----------------------------------------------------------------------------
-BOOST_FIXTURE_TEST_CASE(NonIntegrableIntegration,Function_Tools_Fixture) {
+BOOST_FIXTURE_TEST_CASE(NonIntegrableIntegration, Function_Tools_Fixture) {
 
   // Given
-  FunctionMock f = FunctionMock{0.};
-  std::unique_ptr<MockScheme>  scheme(new MockScheme{});
+  FunctionMock                f = FunctionMock{0.};
+  std::unique_ptr<MockScheme> scheme(new MockScheme{});
   EXPECT_CALL(*scheme, functorCall(_, _, _)).Times(1).WillOnce(Return(3.14));
 
-
   // Then
-  double result = Euclid::MathUtils::integrate(f,0,1,std::move(scheme));
-  BOOST_CHECK_EQUAL(result,3.14);
-
+  double result = Euclid::MathUtils::integrate(f, 0, 1, std::move(scheme));
+  BOOST_CHECK_EQUAL(result, 3.14);
 }
 
 //-----------------------------------------------------------------------------
 // Test that integration of an integrable function is done without calling the
 //  NumericalIntegrationScheme
 //-----------------------------------------------------------------------------
-BOOST_FIXTURE_TEST_CASE(Integrable,Function_Tools_Fixture) {
+BOOST_FIXTURE_TEST_CASE(Integrable, Function_Tools_Fixture) {
 
   // Given
-  double min = -1.5;
-  double max = 7.32;
-  IntegrableMock f = IntegrableMock{5.};
-  double expected = 5. * (max - min);
-  std::unique_ptr<MockScheme>  scheme(new MockScheme{});
+  double                      min      = -1.5;
+  double                      max      = 7.32;
+  IntegrableMock              f        = IntegrableMock{5.};
+  double                      expected = 5. * (max - min);
+  std::unique_ptr<MockScheme> scheme(new MockScheme{});
 
   // When
-  double integral = Euclid::MathUtils::integrate(f, min, max,std::move(scheme));
+  double integral = Euclid::MathUtils::integrate(f, min, max, std::move(scheme));
 
   // Then
   BOOST_CHECK_EQUAL(integral, expected);
@@ -90,4 +85,4 @@ BOOST_FIXTURE_TEST_CASE(Integrable,Function_Tools_Fixture) {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/MathUtils/tests/src/function/mocks.h
+++ b/MathUtils/tests/src/function/mocks.h
@@ -16,48 +16,50 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/function/mocks.h
  * @date February 20, 2014
  * @author Nikolaos Apostolakos
  */
 
 #ifndef MOCKS_H
-#define	MOCKS_H
+#define MOCKS_H
 
+#include "MathUtils/function/Differentiable.h"
 #include "MathUtils/function/Function.h"
 #include "MathUtils/function/Integrable.h"
-#include "MathUtils/function/Differentiable.h"
 
 class FunctionMock : public Euclid::MathUtils::Function {
 public:
-  explicit FunctionMock(const double value) : m_value{value} { }
+  explicit FunctionMock(const double value) : m_value{value} {}
   double operator()(const double) const override {
     return m_value;
   }
   std::unique_ptr<Function> clone() const override {
-    return std::unique_ptr<Function> {new FunctionMock{m_value}};
+    return std::unique_ptr<Function>{new FunctionMock{m_value}};
   }
+
 private:
   double m_value;
 };
 
 class IntegrableMock : public Euclid::MathUtils::Integrable {
 public:
-  explicit IntegrableMock(const double value) : m_value{value} { }
+  explicit IntegrableMock(const double value) : m_value{value} {}
   double operator()(const double) const override {
     return m_value;
   }
   std::unique_ptr<Function> clone() const override {
-    return std::unique_ptr<Function> {new IntegrableMock{m_value}};
+    return std::unique_ptr<Function>{new IntegrableMock{m_value}};
   }
   double integrate(const double min, const double max) const override {
     m_min = min;
     m_max = max;
     return m_value * (max - min);
   }
-  mutable double m_min {0};
-  mutable double m_max {0};
+  mutable double m_min{0};
+  mutable double m_max{0};
+
 private:
   double m_value;
 };
@@ -72,7 +74,7 @@ public:
     }
   }
   std::unique_ptr<Function> clone() const override {
-    return std::unique_ptr<Function> {new DifferentiableMock{}};
+    return std::unique_ptr<Function>{new DifferentiableMock{}};
   }
   std::shared_ptr<Euclid::MathUtils::Function> derivative() const override {
     return nullptr;
@@ -83,10 +85,9 @@ public:
     }
     return m_func;
   }
+
 private:
-  mutable std::shared_ptr<Euclid::MathUtils::Function> m_func {};
+  mutable std::shared_ptr<Euclid::MathUtils::Function> m_func{};
 };
 
-
-#endif	/* MOCKS_H */
-
+#endif /* MOCKS_H */

--- a/MathUtils/tests/src/interpolation/Linear_test.cpp
+++ b/MathUtils/tests/src/interpolation/Linear_test.cpp
@@ -16,26 +16,26 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/interpolation/Linear_test.cpp
  * @date February 20, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
-#include <boost/test/floating_point_comparison.hpp>
-#include <memory>
 #include "MathUtils/function/Function.h"
 #include "MathUtils/interpolation/interpolation.h"
+#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/unit_test.hpp>
+#include <memory>
 
 struct Linear_Fixture {
-  double close_tolerance {1E-10};
-  double small_tolerance {1E-20};
+  double close_tolerance{1E-10};
+  double small_tolerance{1E-20};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (Linear_test)
+BOOST_AUTO_TEST_SUITE(Linear_test)
 
 //-----------------------------------------------------------------------------
 // Test the linear interpolation
@@ -44,11 +44,11 @@ BOOST_AUTO_TEST_SUITE (Linear_test)
 BOOST_FIXTURE_TEST_CASE(Linear, Linear_Fixture) {
 
   // Given
-  std::vector<double> x {-1.,0.,1.,2.,8.,10.};
-  std::vector<double> y {4.,3.,1.,2.,2.,20.};
+  std::vector<double> x{-1., 0., 1., 2., 8., 10.};
+  std::vector<double> y{4., 3., 1., 2., 2., 20.};
 
   // When
-  auto linear = Euclid::MathUtils::interpolate(x, y, Euclid::MathUtils::InterpolationType::LINEAR, false);
+  auto   linear = Euclid::MathUtils::interpolate(x, y, Euclid::MathUtils::InterpolationType::LINEAR, false);
   double value1 = (*linear)(-2.);
   double value2 = (*linear)(-1.);
   double value3 = (*linear)(-.5);
@@ -69,7 +69,6 @@ BOOST_FIXTURE_TEST_CASE(Linear, Linear_Fixture) {
   BOOST_CHECK_CLOSE(value7, 2., close_tolerance);
   BOOST_CHECK_CLOSE(value8, 11., close_tolerance);
   BOOST_CHECK_SMALL(value9, small_tolerance);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -79,11 +78,11 @@ BOOST_FIXTURE_TEST_CASE(Linear, Linear_Fixture) {
 BOOST_FIXTURE_TEST_CASE(LinearExtrapolation, Linear_Fixture) {
 
   // Given
-  std::vector<double> x {-1.,0.,1.,2.,8.,10.};
-  std::vector<double> y {4.,3.,1.,2.,2.,20.};
+  std::vector<double> x{-1., 0., 1., 2., 8., 10.};
+  std::vector<double> y{4., 3., 1., 2., 2., 20.};
 
   // When
-  auto linear = Euclid::MathUtils::interpolate(x, y, Euclid::MathUtils::InterpolationType::LINEAR, true);
+  auto   linear = Euclid::MathUtils::interpolate(x, y, Euclid::MathUtils::InterpolationType::LINEAR, true);
   double value1 = (*linear)(-2.);
   double value2 = (*linear)(-1.);
   double value3 = (*linear)(-.5);
@@ -104,7 +103,6 @@ BOOST_FIXTURE_TEST_CASE(LinearExtrapolation, Linear_Fixture) {
   BOOST_CHECK_CLOSE(value7, 2., close_tolerance);
   BOOST_CHECK_CLOSE(value8, 11., close_tolerance);
   BOOST_CHECK_CLOSE(value9, 20.9, close_tolerance);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -113,11 +111,11 @@ BOOST_FIXTURE_TEST_CASE(LinearExtrapolation, Linear_Fixture) {
 BOOST_FIXTURE_TEST_CASE(Linear1DataPoint, Linear_Fixture) {
 
   // Given
-  std::vector<double> x {2.};
-  std::vector<double> y {42.};
+  std::vector<double> x{2.};
+  std::vector<double> y{42.};
 
   // When
-  auto linear = Euclid::MathUtils::interpolate(x, y, Euclid::MathUtils::InterpolationType::LINEAR, true);
+  auto   linear = Euclid::MathUtils::interpolate(x, y, Euclid::MathUtils::InterpolationType::LINEAR, true);
   double value1 = (*linear)(-2.);
   double value2 = (*linear)(-1.);
   double value3 = (*linear)(-.5);
@@ -130,10 +128,8 @@ BOOST_FIXTURE_TEST_CASE(Linear1DataPoint, Linear_Fixture) {
   BOOST_CHECK_CLOSE(value3, 42., close_tolerance);
   BOOST_CHECK_CLOSE(value4, 42., close_tolerance);
   BOOST_CHECK_CLOSE(value5, 42., close_tolerance);
-
 }
-
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/MathUtils/tests/src/interpolation/Spline_test.cpp
+++ b/MathUtils/tests/src/interpolation/Spline_test.cpp
@@ -17,19 +17,18 @@
  */
 
 /**
-* @file tests/src/interpolation/Spline_test.cpp
-* @date February 20, 2014
-* @author Nikolaos Apostolakos
-*/
+ * @file tests/src/interpolation/Spline_test.cpp
+ * @date February 20, 2014
+ * @author Nikolaos Apostolakos
+ */
 
+#include "MathUtils/function/Piecewise.h"
+#include "MathUtils/interpolation/interpolation.h"
+#include "MathUtils/numericalDifferentiation/FiniteDifference.h"
 #include <boost/test/unit_test.hpp>
 #include <cmath>
-#include "MathUtils/interpolation/interpolation.h"
-#include "MathUtils/function/Piecewise.h"
-#include "MathUtils/numericalDifferentiation/FiniteDifference.h"
 
 using namespace Euclid::MathUtils;
-
 
 struct Spline_Fixture {
   const double eps = std::sqrt(std::numeric_limits<double>::epsilon());
@@ -48,7 +47,7 @@ struct Spline_Fixture {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (Spline_test)
+BOOST_AUTO_TEST_SUITE(Spline_test)
 
 //-----------------------------------------------------------------------------
 // The interpolated function value at x must match the same value as the original
@@ -56,7 +55,7 @@ BOOST_AUTO_TEST_SUITE (Spline_test)
 
 BOOST_FIXTURE_TEST_CASE(fx, Spline_Fixture) {
   // When
-  auto cubic = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
+  auto                cubic = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
   std::vector<double> result{};
   for (double xValue : x) {
     result.push_back((*cubic)(xValue));
@@ -67,11 +66,10 @@ BOOST_FIXTURE_TEST_CASE(fx, Spline_Fixture) {
   // Then
   for (size_t i = 0; i < y.size(); i++) {
     if (std::abs(result[i]) <= eps) {
-        BOOST_CHECK_SMALL(result[i], small_tolerance);
-        BOOST_CHECK_SMALL(y[i], small_tolerance);
-    }
-    else {
-        BOOST_CHECK_CLOSE(result[i], y[i], close_tolerance);
+      BOOST_CHECK_SMALL(result[i], small_tolerance);
+      BOOST_CHECK_SMALL(y[i], small_tolerance);
+    } else {
+      BOOST_CHECK_CLOSE(result[i], y[i], close_tolerance);
     }
   }
   BOOST_CHECK_SMALL(outside1, small_tolerance);
@@ -83,25 +81,24 @@ BOOST_FIXTURE_TEST_CASE(fx, Spline_Fixture) {
 // the splines to each side match with the original value
 //-----------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(Spline_fx, Spline_Fixture) {
-  auto cubic_f = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
-  auto cubic_pieces = dynamic_cast<Piecewise *>(cubic_f.get());
-  auto& splines = cubic_pieces->getFunctions();
+  auto  cubic_f      = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
+  auto  cubic_pieces = dynamic_cast<Piecewise*>(cubic_f.get());
+  auto& splines      = cubic_pieces->getFunctions();
 
   for (size_t i = 0; i < splines.size() - 1; ++i) {
-    auto x0 = x[i + 1];
-    auto& left = splines[i];
-    auto& right = splines[i + 1];
-    auto left_val = (*left)(x0);
-    auto right_val = (*right)(x0);
+    auto  x0        = x[i + 1];
+    auto& left      = splines[i];
+    auto& right     = splines[i + 1];
+    auto  left_val  = (*left)(x0);
+    auto  right_val = (*right)(x0);
 
     if (std::abs(left_val) <= eps || std::abs(right_val) <= eps) {
-        BOOST_CHECK_SMALL(left_val, small_tolerance);
-        BOOST_CHECK_SMALL(right_val, small_tolerance);
-        BOOST_CHECK_SMALL(y[i + 1], small_tolerance);
-    }
-    else {
-        BOOST_CHECK_CLOSE(left_val, right_val, close_tolerance);
-        BOOST_CHECK_CLOSE(left_val, y[i + 1], close_tolerance);
+      BOOST_CHECK_SMALL(left_val, small_tolerance);
+      BOOST_CHECK_SMALL(right_val, small_tolerance);
+      BOOST_CHECK_SMALL(y[i + 1], small_tolerance);
+    } else {
+      BOOST_CHECK_CLOSE(left_val, right_val, close_tolerance);
+      BOOST_CHECK_CLOSE(left_val, y[i + 1], close_tolerance);
     }
   }
 }
@@ -110,23 +107,22 @@ BOOST_FIXTURE_TEST_CASE(Spline_fx, Spline_Fixture) {
 // Similarly, the first derivative of the splines to each side must match
 //-----------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(Spline_dfx, Spline_Fixture) {
-  auto cubic_f = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
-  auto cubic_pieces = dynamic_cast<Piecewise *>(cubic_f.get());
-  auto& splines = cubic_pieces->getFunctions();
+  auto  cubic_f      = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
+  auto  cubic_pieces = dynamic_cast<Piecewise*>(cubic_f.get());
+  auto& splines      = cubic_pieces->getFunctions();
 
   for (size_t i = 0; i < splines.size() - 1; ++i) {
-    auto x0 = x[i + 1];
-    auto& left = splines[i];
+    auto  x0    = x[i + 1];
+    auto& left  = splines[i];
     auto& right = splines[i + 1];
 
-    auto left_dy = derivative(*left, x0);
+    auto left_dy  = derivative(*left, x0);
     auto right_dy = derivative(*right, x0);
 
     if (std::abs(left_dy) <= eps || std::abs(right_dy) <= eps) {
       BOOST_CHECK_SMALL(left_dy, small_tolerance);
       BOOST_CHECK_SMALL(right_dy, small_tolerance);
-    }
-    else {
+    } else {
       BOOST_CHECK_CLOSE(left_dy, right_dy, close_tolerance);
     }
   }
@@ -137,23 +133,22 @@ BOOST_FIXTURE_TEST_CASE(Spline_dfx, Spline_Fixture) {
 // also the second derivative of the splines to each side must match
 //-----------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(Spline_ddfx, Spline_Fixture) {
-  auto cubic_f = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
-  auto cubic_pieces = dynamic_cast<Piecewise *>(cubic_f.get());
-  auto& splines = cubic_pieces->getFunctions();
+  auto  cubic_f      = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
+  auto  cubic_pieces = dynamic_cast<Piecewise*>(cubic_f.get());
+  auto& splines      = cubic_pieces->getFunctions();
 
   for (size_t i = 0; i < splines.size() - 1; ++i) {
-    auto x0 = x[i + 1];
-    auto& left = splines[i];
+    auto  x0    = x[i + 1];
+    auto& left  = splines[i];
     auto& right = splines[i + 1];
 
-    auto left_ddy = derivative2nd(*left, x0);
+    auto left_ddy  = derivative2nd(*left, x0);
     auto right_ddy = derivative2nd(*right, x0);
 
     if (std::abs(left_ddy) <= eps || std::abs(right_ddy) <= eps) {
       BOOST_CHECK_SMALL(left_ddy, small_tolerance);
       BOOST_CHECK_SMALL(right_ddy, small_tolerance);
-    }
-    else {
+    } else {
       BOOST_CHECK_CLOSE(left_ddy, right_ddy, 2e-2);
     }
   }
@@ -163,14 +158,14 @@ BOOST_FIXTURE_TEST_CASE(Spline_ddfx, Spline_Fixture) {
 // Second derivative at the endpoints should be 0
 //-----------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(Spline_ddfx_endpoint, Spline_Fixture) {
-  auto cubic_f = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
-  auto cubic_pieces = dynamic_cast<Piecewise *>(cubic_f.get());
-  auto& splines = cubic_pieces->getFunctions();
+  auto  cubic_f      = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
+  auto  cubic_pieces = dynamic_cast<Piecewise*>(cubic_f.get());
+  auto& splines      = cubic_pieces->getFunctions();
 
-  auto& left = splines.front();
+  auto& left  = splines.front();
   auto& right = splines.back();
 
-  auto left_ddy = derivative2nd(*left, x.front());
+  auto left_ddy  = derivative2nd(*left, x.front());
   auto right_ddy = derivative2nd(*right, x.back());
 
   BOOST_CHECK_SMALL(left_ddy, 1e-4);
@@ -183,7 +178,7 @@ BOOST_FIXTURE_TEST_CASE(Spline_ddfx_endpoint, Spline_Fixture) {
 BOOST_FIXTURE_TEST_CASE(Spline_extrapolation, Spline_Fixture) {
   auto cubic_f = interpolate(x, y, InterpolationType::CUBIC_SPLINE, true);
 
-  auto left_ddy = derivative2nd(*cubic_f, x.front());
+  auto left_ddy  = derivative2nd(*cubic_f, x.front());
   auto right_ddy = derivative2nd(*cubic_f, x.back());
 
   BOOST_CHECK_SMALL(left_ddy, 1e-4);
@@ -196,11 +191,12 @@ BOOST_FIXTURE_TEST_CASE(Spline_extrapolation, Spline_Fixture) {
 BOOST_FIXTURE_TEST_CASE(Spline_1DataPoint, Spline_Fixture) {
 
   // Given
-  std::vector<double> x_test_value {2.};
-  std::vector<double> y_test_value {42.};
+  std::vector<double> x_test_value{2.};
+  std::vector<double> y_test_value{42.};
 
   // When
-  auto linear = Euclid::MathUtils::interpolate(x_test_value, y_test_value, Euclid::MathUtils::InterpolationType::CUBIC_SPLINE, true);
+  auto linear =
+      Euclid::MathUtils::interpolate(x_test_value, y_test_value, Euclid::MathUtils::InterpolationType::CUBIC_SPLINE, true);
   double value1 = (*linear)(-2.);
   double value2 = (*linear)(-1.);
   double value3 = (*linear)(-.5);
@@ -213,9 +209,8 @@ BOOST_FIXTURE_TEST_CASE(Spline_1DataPoint, Spline_Fixture) {
   BOOST_CHECK_CLOSE(value3, 42., close_tolerance);
   BOOST_CHECK_CLOSE(value4, 42., close_tolerance);
   BOOST_CHECK_CLOSE(value5, 42., close_tolerance);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/MathUtils/tests/src/numericalDifferentiation/FiniteDifference_test.cpp
+++ b/MathUtils/tests/src/numericalDifferentiation/FiniteDifference_test.cpp
@@ -17,22 +17,22 @@
  */
 
 /**
-* @file tests/src/numericalDifferentiation/CentralDifference_test.cpp
-* @date January 9, 2020
-* @author Alejandro Alvarez Ayllon
-*/
+ * @file tests/src/numericalDifferentiation/CentralDifference_test.cpp
+ * @date January 9, 2020
+ * @author Alejandro Alvarez Ayllon
+ */
 
-#include <boost/test/unit_test.hpp>
-#include <boost/test/floating_point_comparison.hpp>
-#include <cmath>
-#include "MathUtils/numericalDifferentiation/FiniteDifference.h"
 #include "MathUtils/function/FunctionAdapter.h"
+#include "MathUtils/numericalDifferentiation/FiniteDifference.h"
+#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/unit_test.hpp>
+#include <cmath>
 
 using namespace Euclid::MathUtils;
 
 struct FiniteDifference_Fixture {
-  double close_tolerance {1E-4};
-  double small_tolerance {1E-20};
+  double close_tolerance{1E-4};
+  double small_tolerance{1E-20};
 
   std::vector<double> xs;
 
@@ -45,19 +45,17 @@ struct FiniteDifference_Fixture {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (FiniteDifference_test)
+BOOST_AUTO_TEST_SUITE(FiniteDifference_test)
 
 //-----------------------------------------------------------------------------
 // Constant function: First and second derivatives are 0
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Constant, FiniteDifference_Fixture) {
-  auto constant_f = FunctionAdapter([](double) {
-    return 5;
-  });
+  auto constant_f = FunctionAdapter([](double) { return 5; });
 
   for (auto x : xs) {
-    auto dy = derivative(constant_f, x);
+    auto dy  = derivative(constant_f, x);
     auto ddy = derivative2nd(constant_f, x);
     BOOST_CHECK_SMALL(dy, small_tolerance);
     BOOST_CHECK_SMALL(ddy, small_tolerance);
@@ -69,13 +67,11 @@ BOOST_FIXTURE_TEST_CASE(Constant, FiniteDifference_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Linear, FiniteDifference_Fixture) {
-  const float slope = 5;
-  auto linear_f = FunctionAdapter([slope](double x) {
-    return slope * x + 4;
-  });
+  const float slope    = 5;
+  auto        linear_f = FunctionAdapter([slope](double x) { return slope * x + 4; });
 
   for (auto x : xs) {
-    auto dy = derivative(linear_f, x);
+    auto dy  = derivative(linear_f, x);
     auto ddy = derivative2nd(linear_f, x);
     BOOST_CHECK_CLOSE(dy, slope, close_tolerance);
     BOOST_CHECK_SMALL(ddy, small_tolerance);
@@ -88,13 +84,13 @@ BOOST_FIXTURE_TEST_CASE(Linear, FiniteDifference_Fixture) {
 
 BOOST_FIXTURE_TEST_CASE(Quadratic, FiniteDifference_Fixture) {
   const float a = 3, b = 5, c = 42;
-  auto quadratic_f = FunctionAdapter([a, b, c](double x) {
+  auto        quadratic_f = FunctionAdapter([a, b, c](double x) {
     double y = a * x * x + b * x + c;
     return y;
   });
 
   for (auto x : xs) {
-    auto dy = derivative(quadratic_f, x);
+    auto dy  = derivative(quadratic_f, x);
     auto ddy = derivative2nd(quadratic_f, x);
     BOOST_CHECK_CLOSE(dy, 2 * a * x + b, close_tolerance);
     BOOST_CHECK_CLOSE(ddy, 2 * a, close_tolerance);
@@ -106,10 +102,10 @@ BOOST_FIXTURE_TEST_CASE(Quadratic, FiniteDifference_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Sin, FiniteDifference_Fixture) {
-  auto sin_f = FunctionAdapter([](double x){return std::sin(x); });
+  auto sin_f = FunctionAdapter([](double x) { return std::sin(x); });
 
   for (auto x : xs) {
-    auto dy = derivative(sin_f, x);
+    auto dy  = derivative(sin_f, x);
     auto ddy = derivative2nd(sin_f, x);
     BOOST_CHECK_CLOSE(dy, cos(x), close_tolerance);
     BOOST_CHECK_CLOSE(ddy, -sin(x), close_tolerance);
@@ -121,10 +117,10 @@ BOOST_FIXTURE_TEST_CASE(Sin, FiniteDifference_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(ex, FiniteDifference_Fixture) {
-  auto ex_f = FunctionAdapter([](double x){return std::pow(M_E, x); });
+  auto ex_f = FunctionAdapter([](double x) { return std::pow(M_E, x); });
 
   for (auto x : xs) {
-    auto dy = derivative(ex_f, x);
+    auto dy  = derivative(ex_f, x);
     auto ddy = derivative2nd(ex_f, x);
     BOOST_CHECK_CLOSE(dy, ex_f(x), close_tolerance);
     BOOST_CHECK_CLOSE(ddy, ex_f(x), close_tolerance);
@@ -133,4 +129,4 @@ BOOST_FIXTURE_TEST_CASE(ex, FiniteDifference_Fixture) {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/MathUtils/tests/src/numericalIntegration/AdaptativeIntegration_test.cpp
+++ b/MathUtils/tests/src/numericalIntegration/AdaptativeIntegration_test.cpp
@@ -16,114 +16,106 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/numericalIntegration/AdaptativeIntegration_test.cpp
  * @date 29 oct 2015
  * @author Florian Dubath
  */
-#include <vector>
-#include <boost/test/unit_test.hpp>
-#include <boost/test/test_tools.hpp>
 #include "ElementsKernel/EnableGMock.h"
+#include <boost/test/test_tools.hpp>
+#include <boost/test/unit_test.hpp>
+#include <vector>
 
-#include "MathUtils/function/Function.h"
-#include "MathUtils/numericalIntegration/AdaptativeIntegration.h"
 #include "ElementsKernel/Exception.h"
 #include "ElementsKernel/Real.h"
+#include "MathUtils/function/Function.h"
+#include "MathUtils/numericalIntegration/AdaptativeIntegration.h"
 
 using namespace testing;
 
 struct AdaptativeIntegration_Fixture {
-  class QuadratureMock1{
+  class QuadratureMock1 {
   public:
-    QuadratureMock1(){
-      EXPECT_CALL(*this, functorCall(_, _, _,_)).Times(1).WillOnce(Return(1.0));
-      EXPECT_CALL(*this, functorCallPrev(_, _, _,1.0,_)).Times(1).WillOnce(Return(1.0));
+    QuadratureMock1() {
+      EXPECT_CALL(*this, functorCall(_, _, _, _)).Times(1).WillOnce(Return(1.0));
+      EXPECT_CALL(*this, functorCallPrev(_, _, _, 1.0, _)).Times(1).WillOnce(Return(1.0));
     }
 
-    double operator()(const Euclid::MathUtils::Function& function,double min, double max, int order){
-      return functorCall(function,min,max,order);
+    double operator()(const Euclid::MathUtils::Function& function, double min, double max, int order) {
+      return functorCall(function, min, max, order);
     }
 
-    double operator()(const Euclid::MathUtils::Function& function,double min, double max, double previous_value, int order){
-      return functorCallPrev(function,min,max,previous_value,order);
+    double operator()(const Euclid::MathUtils::Function& function, double min, double max, double previous_value, int order) {
+      return functorCallPrev(function, min, max, previous_value, order);
     }
 
-    MOCK_CONST_METHOD4(functorCall, double(const Euclid::MathUtils::Function&,double,double,int));
-    MOCK_CONST_METHOD5(functorCallPrev, double(const Euclid::MathUtils::Function&,double,double,double,int));
-
+    MOCK_CONST_METHOD4(functorCall, double(const Euclid::MathUtils::Function&, double, double, int));
+    MOCK_CONST_METHOD5(functorCallPrev, double(const Euclid::MathUtils::Function&, double, double, double, int));
   };
-  class QuadratureMock2{
+  class QuadratureMock2 {
   public:
-  QuadratureMock2(){
-        EXPECT_CALL(*this, functorCall(_, _, _,_)).Times(1).WillOnce(Return(1.0));
-        EXPECT_CALL(*this, functorCallPrev(_, _, _,1.0,4)).Times(1).WillOnce(Return(1.1));
-        EXPECT_CALL(*this, functorCallPrev(_, _, _,1.1,5)).Times(1).WillOnce(Return(1.1111));
-        EXPECT_CALL(*this, functorCallPrev(_, _, _,1.1111,6)).Times(1).WillOnce(Return(1.1122111));
-        EXPECT_CALL(*this, functorCallPrev(_, _, _,1.1122111,7)).Times(1).WillOnce(Return(1.1123223));
-      }
+    QuadratureMock2() {
+      EXPECT_CALL(*this, functorCall(_, _, _, _)).Times(1).WillOnce(Return(1.0));
+      EXPECT_CALL(*this, functorCallPrev(_, _, _, 1.0, 4)).Times(1).WillOnce(Return(1.1));
+      EXPECT_CALL(*this, functorCallPrev(_, _, _, 1.1, 5)).Times(1).WillOnce(Return(1.1111));
+      EXPECT_CALL(*this, functorCallPrev(_, _, _, 1.1111, 6)).Times(1).WillOnce(Return(1.1122111));
+      EXPECT_CALL(*this, functorCallPrev(_, _, _, 1.1122111, 7)).Times(1).WillOnce(Return(1.1123223));
+    }
 
-      double operator()(const Euclid::MathUtils::Function& function,double min, double max, int order){
-        return functorCall(function,min,max,order);
-      }
+    double operator()(const Euclid::MathUtils::Function& function, double min, double max, int order) {
+      return functorCall(function, min, max, order);
+    }
 
-      double operator()(const Euclid::MathUtils::Function& function,double min, double max, double previous_value, int order){
-        return functorCallPrev(function,min,max,previous_value,order);
-      }
+    double operator()(const Euclid::MathUtils::Function& function, double min, double max, double previous_value, int order) {
+      return functorCallPrev(function, min, max, previous_value, order);
+    }
 
-      MOCK_CONST_METHOD4(functorCall, double(const Euclid::MathUtils::Function&,double,double,int));
-      MOCK_CONST_METHOD5(functorCallPrev, double(const Euclid::MathUtils::Function&,double,double,double,int));
-
+    MOCK_CONST_METHOD4(functorCall, double(const Euclid::MathUtils::Function&, double, double, int));
+    MOCK_CONST_METHOD5(functorCallPrev, double(const Euclid::MathUtils::Function&, double, double, double, int));
   };
 
   /**
    * function f(x)->a
    */
-  class ConstFunction: public Euclid::MathUtils::Function {
+  class ConstFunction : public Euclid::MathUtils::Function {
   public:
-    explicit ConstFunction(double a) : m_a { a } {};
+    explicit ConstFunction(double a) : m_a{a} {};
 
     double operator()(const double) const override {
       return m_a;
     }
 
     std::unique_ptr<Function> clone() const override {
-      return std::unique_ptr<Function> { new ConstFunction(m_a) };
+      return std::unique_ptr<Function>{new ConstFunction(m_a)};
     }
+
   private:
     double m_a;
   };
-
-
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (AdaptativeIntegration_test)
+BOOST_AUTO_TEST_SUITE(AdaptativeIntegration_test)
 
 BOOST_FIXTURE_TEST_CASE(anchor_test, AdaptativeIntegration_Fixture) {
 
-  ConstFunction const_function{2.0};
-  Euclid::MathUtils::AdaptativeIntegration<QuadratureMock1> integrator{0.1,3};
+  ConstFunction                                             const_function{2.0};
+  Euclid::MathUtils::AdaptativeIntegration<QuadratureMock1> integrator{0.1, 3};
 
-  double result=integrator(const_function,0.5,1.33);
-  BOOST_CHECK_EQUAL(result,1.0);
-
-
+  double result = integrator(const_function, 0.5, 1.33);
+  BOOST_CHECK_EQUAL(result, 1.0);
 }
 
 BOOST_FIXTURE_TEST_CASE(recursion_test, AdaptativeIntegration_Fixture) {
 
-  ConstFunction const_function{2.0};
-  Euclid::MathUtils::AdaptativeIntegration<QuadratureMock2> integrator{0.0002,3};
+  ConstFunction                                             const_function{2.0};
+  Euclid::MathUtils::AdaptativeIntegration<QuadratureMock2> integrator{0.0002, 3};
 
-  double result=integrator(const_function,0.5,1.33);
-  BOOST_CHECK_EQUAL(result,1.1123223);
-
-
+  double result = integrator(const_function, 0.5, 1.33);
+  BOOST_CHECK_EQUAL(result, 1.1123223);
 }
-
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/MathUtils/tests/src/numericalIntegration/SimpsonsRule_test.cpp
+++ b/MathUtils/tests/src/numericalIntegration/SimpsonsRule_test.cpp
@@ -16,38 +16,36 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/numericalIntegration/SimpsonRule_test.cpp
  * @date 29 oct. 2015
  * @author Florian Dubath
  */
-#include <set>
-#include <boost/test/unit_test.hpp>
 #include "ElementsKernel/Exception.h"
 #include "ElementsKernel/Real.h"
 #include "MathUtils/function/Function.h"
 #include "MathUtils/numericalIntegration/SimpsonsRule.h"
+#include <boost/test/unit_test.hpp>
+#include <set>
 
 struct simpsonsRule_Fixture {
-  Euclid::MathUtils::SimpsonsRule quadrature { };
+  Euclid::MathUtils::SimpsonsRule quadrature{};
 
   /**
    * function f(x)->a
    */
-  class ConstFunction: public Euclid::MathUtils::Function {
+  class ConstFunction : public Euclid::MathUtils::Function {
   public:
-    explicit ConstFunction(double a) :
-        m_a { a } {
-    }
-    ;
+    explicit ConstFunction(double a) : m_a{a} {};
 
     double operator()(const double) const override {
       return m_a;
     }
 
     std::unique_ptr<Function> clone() const override {
-      return std::unique_ptr<Function> { new ConstFunction(m_a) };
+      return std::unique_ptr<Function>{new ConstFunction(m_a)};
     }
+
   private:
     double m_a;
   };
@@ -55,20 +53,18 @@ struct simpsonsRule_Fixture {
   /**
    * function f(x)->ax+b
    */
-  class AffineFunction: public Euclid::MathUtils::Function {
+  class AffineFunction : public Euclid::MathUtils::Function {
   public:
-    AffineFunction(double a, double b) :
-        m_a { a }, m_b { b } {
-    }
-    ;
+    AffineFunction(double a, double b) : m_a{a}, m_b{b} {};
 
     double operator()(const double x) const override {
       return m_a * x + m_b;
     }
 
     std::unique_ptr<Function> clone() const override {
-      return std::unique_ptr<Function> { new AffineFunction(m_a, m_b) };
+      return std::unique_ptr<Function>{new AffineFunction(m_a, m_b)};
     }
+
   private:
     double m_a;
     double m_b;
@@ -77,20 +73,18 @@ struct simpsonsRule_Fixture {
   /**
    * function f(x)->ax^2+bx+c
    */
-  class QuadraticFunction: public Euclid::MathUtils::Function {
+  class QuadraticFunction : public Euclid::MathUtils::Function {
   public:
-    QuadraticFunction(double a, double b, double c) :
-        m_a { a }, m_b { b }, m_c { c } {
-    }
-    ;
+    QuadraticFunction(double a, double b, double c) : m_a{a}, m_b{b}, m_c{c} {};
 
     double operator()(const double x) const override {
       return m_a * x * x + m_b * x + m_c;
     }
 
     std::unique_ptr<Function> clone() const override {
-      return std::unique_ptr<Function> { new QuadraticFunction(m_a, m_b, m_c) };
+      return std::unique_ptr<Function>{new QuadraticFunction(m_a, m_b, m_c)};
     }
+
   private:
     double m_a;
     double m_b;
@@ -100,20 +94,18 @@ struct simpsonsRule_Fixture {
   /**
    * function f(x)->ax^3+bx^2+cx+d
    */
-  class CubicFunction: public Euclid::MathUtils::Function {
+  class CubicFunction : public Euclid::MathUtils::Function {
   public:
-    CubicFunction(double a, double b, double c, double d) :
-        m_a { a }, m_b { b }, m_c { c }, m_d { d } {
-    }
-    ;
+    CubicFunction(double a, double b, double c, double d) : m_a{a}, m_b{b}, m_c{c}, m_d{d} {};
 
     double operator()(const double x) const override {
       return m_a * x * x * x + m_b * x * x + m_c * x + m_d;
     }
 
     std::unique_ptr<Function> clone() const override {
-      return std::unique_ptr<Function> { new CubicFunction(m_a, m_b, m_c, m_d) };
+      return std::unique_ptr<Function>{new CubicFunction(m_a, m_b, m_c, m_d)};
     }
+
   private:
     double m_a;
     double m_b;
@@ -124,20 +116,18 @@ struct simpsonsRule_Fixture {
   /**
    * function f(x)->a exp(bx)
    */
-  class ExpFunction: public Euclid::MathUtils::Function {
+  class ExpFunction : public Euclid::MathUtils::Function {
   public:
-    ExpFunction(double a, double b) :
-        m_a { a }, m_b { b } {
-    }
-    ;
+    ExpFunction(double a, double b) : m_a{a}, m_b{b} {};
 
     double operator()(const double x) const override {
       return m_a * std::exp(x * m_b);
     }
 
     std::unique_ptr<Function> clone() const override {
-      return std::unique_ptr<Function> { new ExpFunction(m_a, m_b) };
+      return std::unique_ptr<Function>{new ExpFunction(m_a, m_b)};
     }
+
   private:
     double m_a;
     double m_b;
@@ -146,21 +136,19 @@ struct simpsonsRule_Fixture {
   /**
    * function f(x)->1/ sqrt(x*x*x)
    */
-  class TestFunction: public Euclid::MathUtils::Function {
+  class TestFunction : public Euclid::MathUtils::Function {
   public:
-
     double operator()(const double x) const override {
       return 1. / std::sqrt(x * x * x);
     }
 
     std::unique_ptr<Function> clone() const override {
-      return std::unique_ptr<Function> { new TestFunction() };
+      return std::unique_ptr<Function>{new TestFunction()};
     }
   };
 
-  class MockFunction: public Euclid::MathUtils::Function {
+  class MockFunction : public Euclid::MathUtils::Function {
   public:
-
     double operator()(const double x) const override {
       int value = std::floor(x + 0.0001);
       m_called.insert(value);
@@ -169,46 +157,40 @@ struct simpsonsRule_Fixture {
     }
 
     std::unique_ptr<Function> clone() const override {
-      return std::unique_ptr<Function> { new MockFunction() };
+      return std::unique_ptr<Function>{new MockFunction()};
     }
 
-    mutable std::set<int> m_called { };
-    mutable size_t m_called_number = 0;
+    mutable std::set<int> m_called{};
+    mutable size_t        m_called_number = 0;
 
-    std::vector<double> m_result { };
+    std::vector<double> m_result{};
   };
-
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (simpsonsRule_test)
+BOOST_AUTO_TEST_SUITE(simpsonsRule_test)
 
 // check that when called with order bellow the minimal order an exception is thrown.
 BOOST_FIXTURE_TEST_CASE(error_test, simpsonsRule_Fixture) {
-  ConstFunction constant_function { 1.0 };
+  ConstFunction constant_function{1.0};
 
-  BOOST_CHECK_THROW(quadrature(constant_function, 0., 1., 0),
-      Elements::Exception);
-  BOOST_CHECK_THROW(quadrature(constant_function, 0., 1., 1),
-      Elements::Exception);
-  BOOST_CHECK_THROW(quadrature(constant_function, 0., 1., 2),
-      Elements::Exception);
+  BOOST_CHECK_THROW(quadrature(constant_function, 0., 1., 0), Elements::Exception);
+  BOOST_CHECK_THROW(quadrature(constant_function, 0., 1., 1), Elements::Exception);
+  BOOST_CHECK_THROW(quadrature(constant_function, 0., 1., 2), Elements::Exception);
   BOOST_CHECK_NO_THROW(quadrature(constant_function, 0., 1., 3));
   BOOST_CHECK_NO_THROW(quadrature(constant_function, 0., 1., 4));
 
-  BOOST_CHECK_THROW(quadrature(constant_function, 0., 1., 1., 2),
-      Elements::Exception);
-  BOOST_CHECK_THROW(quadrature(constant_function, 0., 1., 1., 3),
-      Elements::Exception);
+  BOOST_CHECK_THROW(quadrature(constant_function, 0., 1., 1., 2), Elements::Exception);
+  BOOST_CHECK_THROW(quadrature(constant_function, 0., 1., 1., 3), Elements::Exception);
   BOOST_CHECK_NO_THROW(quadrature(constant_function, 0., 1., 1., 4));
   BOOST_CHECK_NO_THROW(quadrature(constant_function, 0., 1., 1., 5));
 }
 
 BOOST_FIXTURE_TEST_CASE(Linear, simpsonsRule_Fixture) {
-  ConstFunction constant_function { 1.0 };
-  AffineFunction affine_function { 1.0, 0.0 };
-  double result = quadrature(constant_function, 0., 1., 3);
+  ConstFunction  constant_function{1.0};
+  AffineFunction affine_function{1.0, 0.0};
+  double         result = quadrature(constant_function, 0., 1., 3);
   BOOST_CHECK(Elements::isEqual(result, 1.));
 
   result = quadrature(affine_function, 0., 1., 3);
@@ -219,38 +201,42 @@ BOOST_FIXTURE_TEST_CASE(Linear, simpsonsRule_Fixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(quadratic, simpsonsRule_Fixture) {
-  QuadraticFunction quadratic_func_test { 1.0, 0., 0, };
+  QuadraticFunction quadratic_func_test{
+      1.0,
+      0.,
+      0,
+  };
   double result = quadrature(quadratic_func_test, 0., 1., 3);
   BOOST_CHECK(Elements::isEqual(result, 1. / 3.));
 }
 
 BOOST_FIXTURE_TEST_CASE(cubic, simpsonsRule_Fixture) {
-  CubicFunction cubic_func_test { 1., 0., 0., 0. };
-  double result = quadrature(cubic_func_test, 0., 1., 3);
+  CubicFunction cubic_func_test{1., 0., 0., 0.};
+  double        result = quadrature(cubic_func_test, 0., 1., 3);
   BOOST_CHECK(Elements::isEqual(result, 1. / 4.));
 }
 
 BOOST_FIXTURE_TEST_CASE(recursion, simpsonsRule_Fixture) {
-  CubicFunction cubic { 1., 0., 0., 0. };
+  CubicFunction cubic{1., 0., 0., 0.};
   for (int order = 3; order < 10; order++) {
-    double result_o = quadrature(cubic, 0., 1., order);
-    double result_o1 = quadrature(cubic, 0., 1., order + 1);
+    double result_o   = quadrature(cubic, 0., 1., order);
+    double result_o1  = quadrature(cubic, 0., 1., order + 1);
     double result_rec = quadrature(cubic, 0., 1., result_o, order + 1);
     BOOST_CHECK(Elements::isEqual(result_rec, result_o1));
   }
 
-  TestFunction test_function { };
+  TestFunction test_function{};
   for (int order = 3; order < 10; order++) {
-    double result_o = quadrature(test_function, 0., 1., order);
-    double result_o1 = quadrature(test_function, 0., 1., order + 1);
+    double result_o   = quadrature(test_function, 0., 1., order);
+    double result_o1  = quadrature(test_function, 0., 1., order + 1);
     double result_rec = quadrature(test_function, 0., 1., result_o, order + 1);
     BOOST_CHECK(Elements::isEqual(result_rec, result_o1));
   }
 }
 
 BOOST_FIXTURE_TEST_CASE(exp_decr, simpsonsRule_Fixture) {
-  ExpFunction exp_function { 1.0, -1.0 };
-  double result = quadrature(exp_function, 0., 1., 3);
+  ExpFunction exp_function{1.0, -1.0};
+  double      result = quadrature(exp_function, 0., 1., 3);
 
   double expected = (1. - exp(-1.));
   BOOST_CHECK((result - expected) / expected < 0.00001);
@@ -258,23 +244,22 @@ BOOST_FIXTURE_TEST_CASE(exp_decr, simpsonsRule_Fixture) {
   result = quadrature(exp_function, 0., 1., 4);
   BOOST_CHECK((result - expected) / expected < 0.000001);
 
-  TestFunction test_function { };
+  TestFunction test_function{};
   expected = 2. * (1. - 1. / std::sqrt(2.));
-  std::vector<double> precisions { 0.0001, 0.00001, 0.000001, 0.0000001 };
-  std::vector<int> orders { 3, 4, 5, 6 };
+  std::vector<double> precisions{0.0001, 0.00001, 0.000001, 0.0000001};
+  std::vector<int>    orders{3, 4, 5, 6};
   for (size_t step = 0; step < orders.size(); step++) {
     result = quadrature(test_function, 1., 2., orders[step]);
     BOOST_CHECK_MESSAGE((result - expected) / expected < precisions[step],
-        "Expected:" + std::to_string(expected) + " Actual :"
-            + std::to_string(result) + " Diff:"
-            + std::to_string(100. * (result - expected) / expected) + "%");
+                        "Expected:" + std::to_string(expected) + " Actual :" + std::to_string(result) +
+                            " Diff:" + std::to_string(100. * (result - expected) / expected) + "%");
   }
 }
 
 BOOST_FIXTURE_TEST_CASE(implementation_test, simpsonsRule_Fixture) {
-  MockFunction mock_function { };
-  mock_function.m_result= {1,1,1,1,1,1,1,1,1};
-  double result = quadrature(mock_function, 0, 8, 3);
+  MockFunction mock_function{};
+  mock_function.m_result = {1, 1, 1, 1, 1, 1, 1, 1, 1};
+  double result          = quadrature(mock_function, 0, 8, 3);
 
   // expected 3/8f(0)+7/6f(1)+23/24f(2)+f(3)+f(4)+f(5) +23/24f(6)+7/6f(7)+3/8f(8)
   double expected = 8.;
@@ -290,21 +275,20 @@ BOOST_FIXTURE_TEST_CASE(implementation_test, simpsonsRule_Fixture) {
     ++value;
   }
 
-  mock_function.m_called= {};
-  mock_function.m_result= {100,33,0.1,1000,2,10000,0.001,333,1};
-  result = quadrature(mock_function, 0, 8, 3);
+  mock_function.m_called = {};
+  mock_function.m_result = {100, 33, 0.1, 1000, 2, 10000, 0.001, 333, 1};
+  result                 = quadrature(mock_function, 0, 8, 3);
 
   // expected 3/8f(0)+7/6f(1)+23/24f(2)+f(3)+f(4)+f(5) +23/24f(6)+7/6f(7)+3/8f(8)
   expected = 11466.97179166666666666666666666666666666666666666666666666666;
 
   BOOST_CHECK_EQUAL(result, expected);
-
 }
 
 BOOST_FIXTURE_TEST_CASE(implementation_next_step_test, simpsonsRule_Fixture) {
-  MockFunction mock_function { };
-  mock_function.m_result= {1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1};
-  double result = quadrature(mock_function, 0, 16, 16., 4);
+  MockFunction mock_function{};
+  mock_function.m_result = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  double result          = quadrature(mock_function, 0, 16, 16., 4);
 
   double expected = 16.;
 
@@ -313,7 +297,7 @@ BOOST_FIXTURE_TEST_CASE(implementation_next_step_test, simpsonsRule_Fixture) {
   // one expect the new points to be called (8) + the second and third on both
   // ends to correct the factor (+2 +2)
 
-  std::vector<int> values = { 1, 2, 3, 4, 5, 7, 9, 11, 12, 13, 14, 15 };
+  std::vector<int> values = {1, 2, 3, 4, 5, 7, 9, 11, 12, 13, 14, 15};
   BOOST_CHECK_EQUAL(mock_function.m_called.size(), values.size());
   BOOST_CHECK_EQUAL(mock_function.m_called_number, values.size());
   int id = 0;
@@ -321,9 +305,8 @@ BOOST_FIXTURE_TEST_CASE(implementation_next_step_test, simpsonsRule_Fixture) {
     BOOST_CHECK_EQUAL(values[id], called);
     ++id;
   }
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/NdArray/NdArray/NdArray.h
+++ b/NdArray/NdArray/NdArray.h
@@ -17,20 +17,20 @@
  */
 
 /**
-* @file NdArray/NdArray.h
-* @date November 21, 2018
-* @author Alejandro Alvarez Ayllon
-*/
+ * @file NdArray/NdArray.h
+ * @date November 21, 2018
+ * @author Alejandro Alvarez Ayllon
+ */
 
 #ifndef ALEXANDRIA_NDARRAY_H
 #define ALEXANDRIA_NDARRAY_H
 
+#include "AlexandriaKernel/memory_tools.h"
+#include <cassert>
 #include <iostream>
 #include <numeric>
 #include <stdexcept>
 #include <vector>
-#include <cassert>
-#include "AlexandriaKernel/memory_tools.h"
 
 namespace Euclid {
 namespace NdArray {
@@ -42,12 +42,12 @@ namespace NdArray {
  * @tparam Container
  *  Which container to use, by default std::vector
  */
-template<typename T>
+template <typename T>
 class NdArray {
 private:
   struct ContainerInterface;
 
-  template<template<class...> class Container = std::vector>
+  template <template <class...> class Container = std::vector>
   struct ContainerWrapper;
 
 public:
@@ -58,14 +58,13 @@ public:
    * @tparam Const
    *    If true, this defines a const iterator
    */
-  template<bool Const>
-  class Iterator
-    : public std::iterator<std::random_access_iterator_tag, typename std::conditional<Const, const T, T>::type> {
+  template <bool Const>
+  class Iterator : public std::iterator<std::random_access_iterator_tag, typename std::conditional<Const, const T, T>::type> {
   private:
-    ContainerInterface *m_container_ptr;
-    size_t m_offset;
+    ContainerInterface* m_container_ptr;
+    size_t              m_offset;
 
-    Iterator(ContainerInterface *container_ptr, size_t offset);
+    Iterator(ContainerInterface* container_ptr, size_t offset);
 
     friend class NdArray;
 
@@ -171,7 +170,7 @@ public:
     bool operator>(const Iterator& other);
   };
 
-  typedef Iterator<true> const_iterator;
+  typedef Iterator<true>  const_iterator;
   typedef Iterator<false> iterator;
 
   /**
@@ -197,7 +196,7 @@ public:
    * @throws std::invalid_argument
    *    If the data size does not corresponds to the matrix size.
    */
-  template<template<class...> class Container = std::vector>
+  template <template <class...> class Container = std::vector>
   NdArray(const std::vector<size_t>& shape, const Container<T>& data);
 
   /**
@@ -214,7 +213,7 @@ public:
    * @throws std::invalid_argument
    *    If the data size does not corresponds to the matrix size.
    */
-  template<template<class...> class Container = std::vector>
+  template <template <class...> class Container = std::vector>
   NdArray(const std::vector<size_t>& shape, Container<T>&& data);
 
   /**
@@ -229,7 +228,7 @@ public:
    * @throws std::invalid_argument
    *    If the data size does not corresponds to the matrix size.
    */
-  template<typename Iterator>
+  template <typename Iterator>
   NdArray(const std::vector<size_t>& shape, Iterator begin, Iterator end);
 
   /**
@@ -242,8 +241,8 @@ public:
    *    Unlike numpy, attr_names is treated strictly as an alias, so
    *    NdArray<float>({20}, {"X", "Y"}) has a shape of (20, 2)
    */
-  template<typename ...Args>
-  NdArray(const std::vector<size_t>& shape, const std::vector<std::string>& attr_names, Args&& ... args);
+  template <typename... Args>
+  NdArray(const std::vector<size_t>& shape, const std::vector<std::string>& attr_names, Args&&... args);
 
   /**
    * Constructs a default-initialized matrix with the given shape (as an initializer list).
@@ -312,7 +311,7 @@ public:
    * @return
    *    *this
    */
-  template<typename ...D>
+  template <typename... D>
   self_type& reshape(size_t i, D... rest);
 
   /**
@@ -365,7 +364,7 @@ public:
    *    This is a convenience function that allows access without requiring a vector when the
    *    number of dimensions is known in advance (i.e. `at(x, y, z)` instead of `at(std::vector<size_t>{x, y, z})`).
    */
-  template<typename ...D>
+  template <typename... D>
   T& at(size_t i, D... rest);
 
   /**
@@ -378,7 +377,7 @@ public:
    *    This is a convenience function that allows access without requiring a vector when the
    *    number of dimensions is known in advance (i.e. `at(x, y, z)` instead of `at(std::vector<size_t>{x, y, z})`).
    */
-  template<typename ...D>
+  template <typename... D>
   const T& at(size_t i, D... rest) const;
 
   /**
@@ -424,7 +423,7 @@ public:
    * Concatenate to this array another one *along the first axis*
    * @return *this
    */
-  self_type& concatenate(const self_type &other);
+  self_type& concatenate(const self_type& other);
 
   /**
    * @return
@@ -433,9 +432,9 @@ public:
   const std::vector<std::string>& attributes() const;
 
 private:
-  std::vector<size_t> m_shape, m_stride_size;
+  std::vector<size_t>      m_shape, m_stride_size;
   std::vector<std::string> m_attr_names;
-  size_t m_size;
+  size_t                   m_size;
 
   struct ContainerInterface {
     /// Owned by the specific implementation ContainerWrapper,
@@ -464,7 +463,7 @@ private:
     virtual std::unique_ptr<ContainerInterface> copy() const = 0;
   };
 
-  template<template<class...> class Container>
+  template <template <class...> class Container>
   struct ContainerWrapper : public ContainerInterface {
     using ContainerInterface::m_data_ptr;
     Container<T> m_container;
@@ -475,8 +474,8 @@ private:
 
     ContainerWrapper(ContainerWrapper&&) = default;
 
-    template<typename ...Args>
-    ContainerWrapper(Args&& ... args) : m_container(std::forward<Args>(args)...) {
+    template <typename... Args>
+    ContainerWrapper(Args&&... args) : m_container(std::forward<Args>(args)...) {
       m_data_ptr = m_container.data();
     }
 
@@ -484,15 +483,14 @@ private:
       return m_container.size();
     }
 
-    template<typename T2>
+    template <typename T2>
     auto resizeImpl(const std::vector<size_t>& shape)
-    -> decltype((void) std::declval<Container<T2>>().resize(std::vector<size_t>{}), void()) {
+        -> decltype((void)std::declval<Container<T2>>().resize(std::vector<size_t>{}), void()) {
       m_container.resize(shape);
     }
 
-    template<typename T2>
-    auto resizeImpl(const std::vector<size_t>& shape)
-    -> decltype((void) std::declval<Container<T2>>().resize(size_t{}), void()) {
+    template <typename T2>
+    auto resizeImpl(const std::vector<size_t>& shape) -> decltype((void)std::declval<Container<T2>>().resize(size_t{}), void()) {
       auto new_size = std::accumulate(shape.begin(), shape.end(), 1u, std::multiplies<size_t>());
       m_container.resize(new_size);
     }
@@ -543,7 +541,7 @@ private:
   /**
    * Helper to expand at with a variable number of arguments
    */
-  template<typename ...D>
+  template <typename... D>
   T& at_helper(std::vector<size_t>& acc, size_t i, D... rest);
 
   /**
@@ -559,7 +557,7 @@ private:
   /**
    * Helper to expand constant at with a variable number of arguments
    */
-  template<typename ...D>
+  template <typename... D>
   const T& at_helper(std::vector<size_t>& acc, size_t i, D... rest) const;
 
   /**
@@ -567,7 +565,7 @@ private:
    */
   const T& at_helper(std::vector<size_t>& acc) const;
 
-  template<typename ...D>
+  template <typename... D>
   self_type& reshape_helper(std::vector<size_t>& acc, size_t i, D... rest);
 
   self_type& reshape_helper(std::vector<size_t>& acc);
@@ -576,14 +574,14 @@ private:
 /**
  * Serialize a NdArray
  */
-template<typename T>
+template <typename T>
 std::ostream& operator<<(std::ostream& out, const NdArray<T>& ndarray);
 
-} // end NdArray
-} // end Euclid
+}  // namespace NdArray
+}  // namespace Euclid
 
 #define NDARRAY_IMPL
 #include "NdArray/_impl/NdArray.icpp"
 #undef NDARRAY_IMPL
 
-#endif // ALEXANDRIA_NDARRAY_H
+#endif  // ALEXANDRIA_NDARRAY_H

--- a/NdArray/NdArray/_impl/NdArray.icpp
+++ b/NdArray/NdArray/_impl/NdArray.icpp
@@ -23,157 +23,158 @@
 namespace Euclid {
 namespace NdArray {
 
-template<typename T>
-template<bool Const>
-NdArray<T>::Iterator<Const>::Iterator(ContainerInterface *container_ptr, size_t offset)
-  : m_container_ptr{container_ptr}, m_offset{offset} {}
+template <typename T>
+template <bool Const>
+NdArray<T>::Iterator<Const>::Iterator(ContainerInterface* container_ptr, size_t offset)
+    : m_container_ptr{container_ptr}, m_offset{offset} {}
 
-
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 NdArray<T>::Iterator<Const>::Iterator(const Iterator<false>& other)
-  : m_container_ptr{other.m_container_ptr},
-    m_offset{other.m_offset} {
-}
+    : m_container_ptr{other.m_container_ptr}, m_offset{other.m_offset} {}
 
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 auto NdArray<T>::Iterator<Const>::operator++() -> Iterator& {
   ++m_offset;
   return *this;
 }
 
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 auto NdArray<T>::Iterator<Const>::operator++(int) -> Iterator {
   return Iterator{m_container_ptr, m_offset + 1};
 }
 
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 bool NdArray<T>::Iterator<Const>::operator==(const Iterator& other) const {
   return m_container_ptr == other.m_container_ptr && m_offset == other.m_offset;
 }
 
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 bool NdArray<T>::Iterator<Const>::operator!=(const Iterator& other) const {
   return m_container_ptr != other.m_container_ptr || m_offset != other.m_offset;
 }
 
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 auto NdArray<T>::Iterator<Const>::operator*() -> value_t& {
   return m_container_ptr->at(m_offset);
 }
 
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 auto NdArray<T>::Iterator<Const>::operator*() const -> value_t {
   return m_container_ptr->at(m_offset);
 }
 
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 auto NdArray<T>::Iterator<Const>::operator+=(size_t n) -> Iterator& {
   m_offset += n;
   return *this;
 }
 
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 auto NdArray<T>::Iterator<Const>::operator+(size_t n) -> Iterator {
   return Iterator{m_container_ptr, m_offset + n};
 }
 
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 auto NdArray<T>::Iterator<Const>::operator-=(size_t n) -> Iterator& {
-  assert (n <= m_offset);
+  assert(n <= m_offset);
   m_offset -= n;
   return *this;
 }
 
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 auto NdArray<T>::Iterator<Const>::operator-(size_t n) -> Iterator {
-  assert (n <= m_offset);
+  assert(n <= m_offset);
   return Iterator{m_container_ptr, m_offset - n};
 }
 
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 auto NdArray<T>::Iterator<Const>::operator-(const Iterator& other) -> difference_type {
   assert(m_container_ptr == other.m_container_ptr);
   return m_offset - other.m_offset;
 }
 
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 auto NdArray<T>::Iterator<Const>::operator[](size_t i) -> value_t& {
   return m_container_ptr->at(m_offset + i);
 }
 
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 bool NdArray<T>::Iterator<Const>::operator<(const Iterator& other) {
   assert(m_container_ptr == other.m_container_ptr);
   return m_offset < other.m_offset;
 }
 
-template<typename T>
-template<bool Const>
+template <typename T>
+template <bool Const>
 bool NdArray<T>::Iterator<Const>::operator>(const Iterator& other) {
   assert(m_container_ptr == other.m_container_ptr);
   return m_offset > other.m_offset;
 }
 
-template<typename T>
+template <typename T>
 NdArray<T>::NdArray(const std::vector<size_t>& shape)
-  : m_shape{shape}, m_size{std::accumulate(m_shape.begin(), m_shape.end(), 1u, std::multiplies<size_t>())},
-    m_container(new ContainerWrapper<std::vector>(m_size)) {
+    : m_shape{shape}
+    , m_size{std::accumulate(m_shape.begin(), m_shape.end(), 1u, std::multiplies<size_t>())}
+    , m_container(new ContainerWrapper<std::vector>(m_size)) {
   update_strides();
 }
 
-template<typename T>
-template<template<class...> class Container>
+template <typename T>
+template <template <class...> class Container>
 NdArray<T>::NdArray(const std::vector<size_t>& shape, const Container<T>& data)
-  : m_shape{shape}, m_size{std::accumulate(m_shape.begin(), m_shape.end(), 1u, std::multiplies<size_t>())},
-    m_container{new ContainerWrapper<Container>(data)} {
+    : m_shape{shape}
+    , m_size{std::accumulate(m_shape.begin(), m_shape.end(), 1u, std::multiplies<size_t>())}
+    , m_container{new ContainerWrapper<Container>(data)} {
   if (m_size != m_container->size()) {
     throw std::invalid_argument("Data size does not match the shape");
   }
   update_strides();
 }
 
-template<typename T>
-template<template<class...> class Container>
+template <typename T>
+template <template <class...> class Container>
 NdArray<T>::NdArray(const std::vector<size_t>& shape, Container<T>&& data)
-  : m_shape{shape}, m_size{std::accumulate(m_shape.begin(), m_shape.end(), 1u, std::multiplies<size_t>())},
-    m_container{new ContainerWrapper<Container>(std::move(data))} {
+    : m_shape{shape}
+    , m_size{std::accumulate(m_shape.begin(), m_shape.end(), 1u, std::multiplies<size_t>())}
+    , m_container{new ContainerWrapper<Container>(std::move(data))} {
   if (m_size != m_container->size()) {
     throw std::invalid_argument("Data size does not match the shape");
   }
   update_strides();
 }
 
-template<typename T>
-template<typename II>
+template <typename T>
+template <typename II>
 NdArray<T>::NdArray(const std::vector<size_t>& shape, II begin, II end)
-  : m_shape{shape},
-    m_size{std::accumulate(m_shape.begin(), m_shape.end(), 1u, std::multiplies<size_t>())},
-    m_container{new ContainerWrapper<std::vector>(begin, end)} {
+    : m_shape{shape}
+    , m_size{std::accumulate(m_shape.begin(), m_shape.end(), 1u, std::multiplies<size_t>())}
+    , m_container{new ContainerWrapper<std::vector>(begin, end)} {
   if (m_size != m_container->size()) {
     throw std::invalid_argument("Data size does not match the shape");
   }
   update_strides();
 }
 
-template<typename T>
+template <typename T>
 NdArray<T>::NdArray(const self_type* other)
-  : m_shape{other->m_shape}, m_attr_names{other->m_attr_names},
-    m_size{std::accumulate(m_shape.begin(), m_shape.end(), 1u, std::multiplies<size_t>())},
-    m_container{other->m_container->copy()} {
+    : m_shape{other->m_shape}
+    , m_attr_names{other->m_attr_names}
+    , m_size{std::accumulate(m_shape.begin(), m_shape.end(), 1u, std::multiplies<size_t>())}
+    , m_container{other->m_container->copy()} {
   update_strides();
 }
 
@@ -183,14 +184,14 @@ inline std::vector<size_t> appendAttrShape(std::vector<size_t> shape, size_t app
   return shape;
 }
 
-template<typename T>
-template<typename ...Args>
-NdArray<T>::NdArray(const std::vector<size_t>& shape, const std::vector<std::string>& attr_names, Args&& ... args)
-  : NdArray{appendAttrShape(shape, attr_names.size()), std::forward<Args>(args)...} {
+template <typename T>
+template <typename... Args>
+NdArray<T>::NdArray(const std::vector<size_t>& shape, const std::vector<std::string>& attr_names, Args&&... args)
+    : NdArray{appendAttrShape(shape, attr_names.size()), std::forward<Args>(args)...} {
   m_attr_names = attr_names;
 }
 
-template<typename T>
+template <typename T>
 auto NdArray<T>::reshape(const std::vector<size_t> new_shape) -> self_type& {
   if (!m_attr_names.empty())
     throw std::invalid_argument("Can not reshape arrays with attribute names");
@@ -204,77 +205,77 @@ auto NdArray<T>::reshape(const std::vector<size_t> new_shape) -> self_type& {
   return *this;
 }
 
-template<typename T>
-template<typename ...D>
+template <typename T>
+template <typename... D>
 auto NdArray<T>::reshape(size_t i, D... rest) -> self_type& {
   std::vector<size_t> acc{i};
   return reshape_helper(acc, rest...);
 }
 
-template<typename T>
+template <typename T>
 T& NdArray<T>::at(const std::vector<size_t>& coords) {
   auto offset = get_offset(coords);
   return m_container->at(offset);
 }
 
-template<typename T>
+template <typename T>
 const T& NdArray<T>::at(const std::vector<size_t>& coords) const {
   auto offset = get_offset(coords);
   return m_container->at(offset);
 }
 
-template<typename T>
+template <typename T>
 T& NdArray<T>::at(const std::vector<size_t>& coords, const std::string& attr) {
   auto offset = get_offset(coords, attr);
   return m_container->at(offset);
 }
 
-template<typename T>
+template <typename T>
 const T& NdArray<T>::at(const std::vector<size_t>& coords, const std::string& attr) const {
   auto offset = get_offset(coords, attr);
   return m_container->at(offset);
 }
 
-template<typename T>
-template<typename ...D>
+template <typename T>
+template <typename... D>
 T& NdArray<T>::at(size_t i, D... rest) {
   std::vector<size_t> acc{i};
   return at_helper(acc, rest...);
 }
 
-template<typename T>
-template<typename ...D>
+template <typename T>
+template <typename... D>
 const T& NdArray<T>::at(size_t i, D... rest) const {
   std::vector<size_t> acc{i};
   return at_helper(acc, rest...);
 }
 
-template<typename T>
+template <typename T>
 auto NdArray<T>::begin() -> iterator {
   return iterator{m_container.get(), 0};
 }
 
-template<typename T>
+template <typename T>
 auto NdArray<T>::end() -> iterator {
   return iterator{m_container.get(), m_size};
 }
 
-template<typename T>
+template <typename T>
 auto NdArray<T>::begin() const -> const_iterator {
   return const_iterator{m_container.get(), 0};
 }
 
-template<typename T>
+template <typename T>
 auto NdArray<T>::end() const -> const_iterator {
   return const_iterator{m_container.get(), m_size};
 }
 
-template<typename T>
+template <typename T>
 size_t NdArray<T>::size() const {
   return m_size;
 }
 
-template<typename T>
+template <typename T>
 bool NdArray<T>::operator==(const self_type& b) const {
   if (shape() != b.shape())
     return false;
@@ -285,17 +286,17 @@ bool NdArray<T>::operator==(const self_type& b) const {
   return true;
 }
 
-template<typename T>
+template <typename T>
 bool NdArray<T>::operator!=(const self_type& b) const {
   return !(*this == b);
 }
 
-template<typename T>
+template <typename T>
 const std::vector<std::string>& NdArray<T>::attributes() const {
   return m_attr_names;
 }
 
-template<typename T>
+template <typename T>
 auto NdArray<T>::concatenate(const self_type& other) -> self_type& {
   // Verify dimensionality
   if (m_shape.size() != other.m_shape.size()) {
@@ -308,7 +309,7 @@ auto NdArray<T>::concatenate(const self_type& other) -> self_type& {
 
   // New shape
   auto old_size = m_container->size();
-  auto shape = m_shape;
+  auto shape    = m_shape;
   shape[0] += other.m_shape[0];
 
   // Resize container
@@ -321,21 +322,17 @@ auto NdArray<T>::concatenate(const self_type& other) -> self_type& {
   return *this;
 }
 
-template<typename T>
+template <typename T>
 size_t NdArray<T>::get_offset(const std::vector<size_t>& coords) const {
   if (coords.size() != m_shape.size()) {
-    throw std::out_of_range(
-      "Invalid number of coordinates, got " + std::to_string(coords.size())
-      + ", expected " + std::to_string(m_shape.size())
-    );
+    throw std::out_of_range("Invalid number of coordinates, got " + std::to_string(coords.size()) + ", expected " +
+                            std::to_string(m_shape.size()));
   }
 
   size_t offset = 0;
   for (size_t i = 0; i < coords.size(); ++i) {
     if (coords[i] >= m_shape[i]) {
-      throw std::out_of_range(
-        std::to_string(coords[i]) + " >= " + std::to_string(m_shape[i]) + " for axis " + std::to_string(i)
-      );
+      throw std::out_of_range(std::to_string(coords[i]) + " >= " + std::to_string(m_shape[i]) + " for axis " + std::to_string(i));
     }
     offset += coords[i] * m_stride_size[i];
   }
@@ -344,7 +341,7 @@ size_t NdArray<T>::get_offset(const std::vector<size_t>& coords) const {
   return offset;
 }
 
-template<typename T>
+template <typename T>
 size_t NdArray<T>::get_offset(std::vector<size_t> coords, const std::string& attr) const {
   auto i = std::find(m_attr_names.begin(), m_attr_names.end(), attr);
   if (i == m_attr_names.end())
@@ -354,7 +351,7 @@ size_t NdArray<T>::get_offset(std::vector<size_t> coords, const std::string& att
   return get_offset(coords);
 }
 
-template<typename T>
+template <typename T>
 void NdArray<T>::update_strides() {
   m_stride_size.resize(m_shape.size());
 
@@ -368,49 +365,49 @@ void NdArray<T>::update_strides() {
 /**
  * Helper to expand at with a variable number of arguments
  */
-template<typename T>
-template<typename ...D>
+template <typename T>
+template <typename... D>
 T& NdArray<T>::at_helper(std::vector<size_t>& acc, size_t i, D... rest) {
   acc.push_back(i);
   return at_helper(acc, rest...);
 }
 
-template<typename T>
+template <typename T>
 T& NdArray<T>::at_helper(std::vector<size_t>& acc) {
   return at(acc);
 }
 
-template<typename T>
+template <typename T>
 T& NdArray<T>::at_helper(std::vector<size_t>& acc, const std::string& attr) {
   return at(acc, attr);
 }
 
-template<typename T>
-template<typename ...D>
+template <typename T>
+template <typename... D>
 const T& NdArray<T>::at_helper(std::vector<size_t>& acc, size_t i, D... rest) const {
   acc.push_back(i);
   return at_helper(acc, rest...);
 }
 
-template<typename T>
+template <typename T>
 const T& NdArray<T>::at_helper(std::vector<size_t>& acc) const {
   return at(acc);
 }
 
-template<typename T>
-template<typename ...D>
+template <typename T>
+template <typename... D>
 auto NdArray<T>::reshape_helper(std::vector<size_t>& acc, size_t i, D... rest) -> self_type& {
   acc.push_back(i);
   return reshape_helper(acc, rest...);
 }
 
-template<typename T>
+template <typename T>
 auto NdArray<T>::reshape_helper(std::vector<size_t>& acc) -> self_type& {
   return reshape(acc);
 }
 
-template<typename T>
-std::ostream& operator<<(std::ostream& out, const NdArray <T>& ndarray) {
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const NdArray<T>& ndarray) {
   auto shape = ndarray.shape();
 
   if (ndarray.size()) {
@@ -430,7 +427,7 @@ std::ostream& operator<<(std::ostream& out, const NdArray <T>& ndarray) {
   return out;
 }
 
-} // end of namespace NdArray
-} // end of namespace Euclid
+}  // end of namespace NdArray
+}  // end of namespace Euclid
 
-#endif // NDARRAY_IMPL
+#endif  // NDARRAY_IMPL

--- a/NdArray/NdArray/io/Npy.h
+++ b/NdArray/NdArray/io/Npy.h
@@ -38,7 +38,7 @@ namespace NdArray {
  * @param array
  *  NdArray to write
  */
-template<typename T>
+template <typename T>
 void writeNpy(std::ostream& out, const NdArray<T>& array);
 
 /**
@@ -54,9 +54,8 @@ void writeNpy(std::ostream& out, const NdArray<T>& array);
  * @note
  *  The underlying numpy format is expected to match the template type T
  */
-template<typename T>
+template <typename T>
 NdArray<T> readNpy(std::istream& input);
-
 
 /**
  * @see
@@ -70,7 +69,7 @@ NdArray<T> readNpy(std::istream& input);
  * @param array
  *  NdArray to write
  */
-template<typename T>
+template <typename T>
 void writeNpy(const boost::filesystem::path& path, const NdArray<T>& array) {
   std::ofstream output(path.native(), std::ios_base::out | std::ios_base::binary);
   writeNpy(output, array);
@@ -89,19 +88,18 @@ void writeNpy(const boost::filesystem::path& path, const NdArray<T>& array) {
  * @note
  *  The underlying numpy format is expected to match the template type T
  */
-template<typename T>
+template <typename T>
 NdArray<T> readNpy(const boost::filesystem::path& path) {
   std::ifstream input(path.native(), std::ios_base::in | std::ios_base::binary);
   return readNpy<T>(input);
 }
 
-
-} // end of namespace NdArray
-} // end of namespace Euclid
+}  // end of namespace NdArray
+}  // end of namespace Euclid
 
 #define NPY_IMPL
-#include "NdArray/io/_impl/NpyWriter.icpp"
 #include "NdArray/io/_impl/NpyReader.icpp"
+#include "NdArray/io/_impl/NpyWriter.icpp"
 #undef NPY_IMPL
 
-#endif // ALEXANDRIA_NDARRAY_NPY_H
+#endif  // ALEXANDRIA_NDARRAY_NPY_H

--- a/NdArray/NdArray/io/NpyMmap.h
+++ b/NdArray/NdArray/io/NpyMmap.h
@@ -19,9 +19,9 @@
 #ifndef ALEXANDRIA_NDARRAY_IO_NPYMMAP_H
 #define ALEXANDRIA_NDARRAY_IO_NPYMMAP_H
 
+#include "NdArray/NdArray.h"
 #include <boost/filesystem/path.hpp>
 #include <boost/iostreams/device/mapped_file.hpp>
-#include "NdArray/NdArray.h"
 
 namespace Euclid {
 namespace NdArray {
@@ -45,10 +45,10 @@ namespace NdArray {
  * @note
  *  If you open in read-only mode, assign to a const NdArray to avoid accidental writes
  */
-template<typename T>
-NdArray<T> mmapNpy(const boost::filesystem::path& path,
-                   boost::iostreams::mapped_file_base::mapmode mode = boost::iostreams::mapped_file_base::readwrite,
-                   size_t max_size = 0);
+template <typename T>
+NdArray<T> mmapNpy(const boost::filesystem::path&              path,
+                   boost::iostreams::mapped_file_base::mapmode mode     = boost::iostreams::mapped_file_base::readwrite,
+                   size_t                                      max_size = 0);
 
 /**
  * Create using mmap an NdArray backed by a numpy file
@@ -65,7 +65,7 @@ NdArray<T> mmapNpy(const boost::filesystem::path& path,
  * @return
  *  A new NdArray
  */
-template<typename T>
+template <typename T>
 NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<size_t>& shape,
                          const std::vector<std::string>& attr_names, size_t max_size = 0);
 
@@ -82,17 +82,16 @@ NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<
  * @return
  *  A new NdArray
  */
-template<typename T>
-NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<size_t>& shape,
-                         size_t max_size = 0) {
+template <typename T>
+NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<size_t>& shape, size_t max_size = 0) {
   return createMmapNpy<T>(path, shape, {}, max_size);
 }
 
-} // end of namespace NdArray
-} // end of namespace Euclid
+}  // end of namespace NdArray
+}  // end of namespace Euclid
 
 #define NPYMMAP_IMPL
 #include "NdArray/io/_impl/NpyMmap.icpp"
 #undef NPYMMAP_IMPL
 
-#endif // ALEXANDRIA_NDARRAY_IO_NPYMMAP_H
+#endif  // ALEXANDRIA_NDARRAY_IO_NPYMMAP_H

--- a/NdArray/NdArray/io/_impl/NpyMmap.icpp
+++ b/NdArray/NdArray/io/_impl/NpyMmap.icpp
@@ -19,8 +19,8 @@
 #ifdef NPYMMAP_IMPL
 
 #include "NpyCommon.h"
-#include <boost/iostreams/stream.hpp>
 #include <boost/filesystem/path.hpp>
+#include <boost/iostreams/stream.hpp>
 #include <numeric>
 
 namespace Euclid {
@@ -28,16 +28,15 @@ namespace NdArray {
 
 typedef boost::iostreams::stream<boost::iostreams::mapped_file> MappedStream;
 
-template<typename T>
-NdArray <T> mmapNpy(const boost::filesystem::path& path, boost::iostreams::mapped_file_base::mapmode mode,
-                    size_t max_size) {
-  std::string dtype;
-  size_t n_elements = 0;
-  std::vector<size_t> shape;
+template <typename T>
+NdArray<T> mmapNpy(const boost::filesystem::path& path, boost::iostreams::mapped_file_base::mapmode mode, size_t max_size) {
+  std::string              dtype;
+  size_t                   n_elements = 0;
+  std::vector<size_t>      shape;
   std::vector<std::string> attrs;
 
   boost::iostreams::mapped_file_params map_params;
-  map_params.path = path.native();
+  map_params.path  = path.native();
   map_params.flags = mode;
   if (max_size)
     map_params.length = max_size;
@@ -45,7 +44,7 @@ NdArray <T> mmapNpy(const boost::filesystem::path& path, boost::iostreams::mappe
     max_size = boost::filesystem::file_size(path);
 
   boost::iostreams::mapped_file input(map_params);
-  MappedStream stream(input);
+  MappedStream                  stream(input);
   stream.set_auto_close(false);
   readNpyHeader(stream, dtype, shape, attrs, n_elements);
 
@@ -59,25 +58,25 @@ NdArray <T> mmapNpy(const boost::filesystem::path& path, boost::iostreams::mappe
   return {shape, attrs, std::move(MappedContainer<T>(path, stream.tellg(), n_elements, attrs, std::move(input), max_size))};
 }
 
-template<typename T>
-NdArray <T> createMmapNpy(const boost::filesystem::path& path, const std::vector<size_t>& shape,
-                          const std::vector<std::string>& attrs, size_t max_size) {
+template <typename T>
+NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<size_t>& shape,
+                         const std::vector<std::string>& attrs, size_t max_size) {
   // Pre-generate header
   std::stringstream header;
   writeNpyHeader<T>(header, appendAttrShape(shape, attrs.size()), attrs);
-  auto header_str = header.str();
+  auto header_str  = header.str();
   auto header_size = header_str.size();
 
   // Compute file expected size
   size_t n_elements = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<size_t>());
   if (!attrs.empty())
     n_elements *= attrs.size();
-  size_t data_size = n_elements * sizeof(T);
+  size_t data_size  = n_elements * sizeof(T);
   size_t total_size = header_size + data_size;
 
   boost::iostreams::mapped_file_params map_params;
-  map_params.path = path.native();
-  map_params.flags = boost::iostreams::mapped_file_base::readwrite;
+  map_params.path          = path.native();
+  map_params.flags         = boost::iostreams::mapped_file_base::readwrite;
   map_params.new_file_size = total_size;
   if (max_size >= total_size)
     map_params.length = max_size;
@@ -89,7 +88,7 @@ NdArray <T> createMmapNpy(const boost::filesystem::path& path, const std::vector
   return {shape, attrs, std::move(MappedContainer<T>(path, header_size, n_elements, attrs, std::move(output), max_size))};
 }
 
-} // end of namespace NdArray
-} // end of namespace Euclid
+}  // end of namespace NdArray
+}  // end of namespace Euclid
 
-#endif // NPYMMAP_IMPL
+#endif  // NPYMMAP_IMPL

--- a/NdArray/NdArray/io/_impl/NpyReader.icpp
+++ b/NdArray/NdArray/io/_impl/NpyReader.icpp
@@ -18,11 +18,11 @@
 
 #ifdef NPY_IMPL
 
-#include <cstring>
-#include <istream>
-#include <ElementsKernel/Exception.h>
 #include "NdArray/NdArray.h"
 #include "NpyCommon.h"
+#include <ElementsKernel/Exception.h>
+#include <cstring>
+#include <istream>
 
 namespace Euclid {
 namespace NdArray {
@@ -30,11 +30,11 @@ namespace NdArray {
 using boost::endian::little_uint16_t;
 using boost::endian::little_uint32_t;
 
-template<typename T>
-NdArray <T> readNpy(std::istream& input) {
-  std::string dtype;
-  size_t n_elements;
-  std::vector<size_t> shape;
+template <typename T>
+NdArray<T> readNpy(std::istream& input) {
+  std::string              dtype;
+  size_t                   n_elements;
+  std::vector<size_t>      shape;
   std::vector<std::string> attr_names;
 
   readNpyHeader(input, dtype, shape, attr_names, n_elements);
@@ -46,11 +46,11 @@ NdArray <T> readNpy(std::istream& input) {
   }
 
   std::vector<T> data(n_elements);
-  input.read(reinterpret_cast<char *>(&data[0]), sizeof(T) * data.size());
+  input.read(reinterpret_cast<char*>(&data[0]), sizeof(T) * data.size());
   return {shape, attr_names, std::move(data)};
 }
 
-} // end of namespace NdArray
-} // end of namespace Euclid
+}  // end of namespace NdArray
+}  // end of namespace Euclid
 
-#endif // NPY_IMPL
+#endif  // NPY_IMPL

--- a/NdArray/NdArray/io/_impl/NpyWriter.icpp
+++ b/NdArray/NdArray/io/_impl/NpyWriter.icpp
@@ -23,11 +23,11 @@
 #else
 #include <endian.h>
 #endif
-#include <sstream>
-#include <boost/endian/arithmetic.hpp>
-#include <ElementsKernel/Exception.h>
 #include "NdArray/NdArray.h"
 #include "NpyCommon.h"
+#include <ElementsKernel/Exception.h>
+#include <boost/endian/arithmetic.hpp>
+#include <sstream>
 
 namespace Euclid {
 namespace NdArray {
@@ -35,16 +35,16 @@ namespace NdArray {
 /*
  * Implementation of writeNpy
  */
-template<typename T>
+template <typename T>
 void writeNpy(std::ostream& out, const NdArray<T>& array) {
   writeNpyHeader<T>(out, array.shape(), array.attributes());
   // The header already has the endian type, so just dump the content of the array
   for (auto v : array) {
-    out.write(reinterpret_cast<const char *>(&v), sizeof(v));
+    out.write(reinterpret_cast<const char*>(&v), sizeof(v));
   }
 }
 
-} // end of namespace NdArray
-} // end of namespace Euclid
+}  // end of namespace NdArray
+}  // end of namespace Euclid
 
-#endif // NPY_IMPL
+#endif  // NPY_IMPL

--- a/NdArray/tests/src/NdArray_test.cpp
+++ b/NdArray/tests/src/NdArray_test.cpp
@@ -17,13 +17,13 @@
  */
 
 /**
-* @file tests/src/Matrix_test.cpp
-* @date November 21, 2018
-* @author Alejandro Alvarez Ayllon
-*/
+ * @file tests/src/Matrix_test.cpp
+ * @date November 21, 2018
+ * @author Alejandro Alvarez Ayllon
+ */
 
-#include <boost/test/unit_test.hpp>
 #include "NdArray/NdArray.h"
+#include <boost/test/unit_test.hpp>
 
 using namespace Euclid::NdArray;
 
@@ -52,13 +52,10 @@ BOOST_AUTO_TEST_CASE(TwoDimension_test) {
   BOOST_CHECK_EQUAL((m.at(std::vector<size_t>{0, 0})), 10);
   BOOST_CHECK_EQUAL((m.at(1, 1)), 20);
 
-  const NdArray<int> &cm = m;
+  const NdArray<int>& cm = m;
   BOOST_CHECK_EQUAL((cm.at(1, 1)), 20);
 
-  std::vector<int> expected{
-    10, 50, 0,
-    15, 20, 0
-  };
+  std::vector<int> expected{10, 50, 0, 15, 20, 0};
   BOOST_CHECK_EQUAL_COLLECTIONS(cm.begin(), cm.end(), expected.begin(), expected.end());
 }
 
@@ -75,8 +72,7 @@ BOOST_AUTO_TEST_CASE(BadInitFromVector_test) {
   try {
     NdArray<int> m{std::vector<size_t>{2, 3}, {10, 50, 0, 15}};
     BOOST_ERROR("The construction should have failed");
-  }
-  catch (...) {
+  } catch (...) {
   }
 }
 
@@ -100,7 +96,7 @@ BOOST_AUTO_TEST_CASE(Fill_test) {
 BOOST_AUTO_TEST_CASE(VectorCopy_test) {
   std::vector<int> original{1, 1, 2, 3, 5, 8};
   std::vector<int> expected(original.begin(), original.end());
-  NdArray<int> m(std::vector<size_t>{2, 3}, original);
+  NdArray<int>     m(std::vector<size_t>{2, 3}, original);
 
   BOOST_CHECK_EQUAL(original.size(), 6);
   BOOST_CHECK_EQUAL_COLLECTIONS(m.begin(), m.end(), expected.begin(), expected.end());
@@ -109,7 +105,7 @@ BOOST_AUTO_TEST_CASE(VectorCopy_test) {
 BOOST_AUTO_TEST_CASE(VectorMove_test) {
   std::vector<int> original{1, 1, 2, 3, 5, 8};
   std::vector<int> expected(original.begin(), original.end());
-  NdArray<int> m(std::vector<size_t>{2, 3}, std::move(original));
+  NdArray<int>     m(std::vector<size_t>{2, 3}, std::move(original));
 
   BOOST_CHECK_EQUAL(original.size(), 0);
   BOOST_CHECK_EQUAL_COLLECTIONS(m.begin(), m.end(), expected.begin(), expected.end());
@@ -117,7 +113,7 @@ BOOST_AUTO_TEST_CASE(VectorMove_test) {
 
 BOOST_AUTO_TEST_CASE(Ostream_test) {
   std::vector<int> original{1, 1, 2, 3, 5, 8};
-  NdArray<int> m(std::vector<size_t>{2, 3}, std::move(original));
+  NdArray<int>     m(std::vector<size_t>{2, 3}, std::move(original));
 
   std::stringstream stream;
   stream << m;
@@ -127,14 +123,14 @@ BOOST_AUTO_TEST_CASE(Ostream_test) {
 
 BOOST_AUTO_TEST_CASE(FromIterator_test) {
   std::list<int> original{1, 7, 6, 9, 5, 3};
-  NdArray<int> m(std::vector<size_t>{2, 3}, std::begin(original), std::end(original));
+  NdArray<int>   m(std::vector<size_t>{2, 3}, std::begin(original), std::end(original));
   BOOST_CHECK_EQUAL(original.size(), 6);
   BOOST_CHECK_EQUAL_COLLECTIONS(m.begin(), m.end(), original.begin(), original.end());
 }
 
 BOOST_AUTO_TEST_CASE(Reshape_test) {
   std::vector<int> values{10, 50, 0, 15, 20, 0};
-  NdArray<int> m{std::vector<size_t>{2, 3}, values};
+  NdArray<int>     m{std::vector<size_t>{2, 3}, values};
 
   m.reshape(6);
 
@@ -149,7 +145,7 @@ BOOST_AUTO_TEST_CASE(Reshape_test) {
 
 BOOST_AUTO_TEST_CASE(BadReshape_test) {
   std::vector<int> values{10, 50, 0, 15, 20, 0};
-  NdArray<int> m{std::vector<size_t>{2, 3}, values};
+  NdArray<int>     m{std::vector<size_t>{2, 3}, values};
 
   BOOST_CHECK_THROW(m.reshape(3), std::range_error);
   BOOST_CHECK_THROW(m.reshape(10), std::range_error);
@@ -157,7 +153,7 @@ BOOST_AUTO_TEST_CASE(BadReshape_test) {
 
 BOOST_AUTO_TEST_CASE(Copy_test) {
   std::vector<int> values{10, 50, 0, 15, 20, 0};
-  NdArray<int> m{std::vector<size_t>{2, 3}, values};
+  NdArray<int>     m{std::vector<size_t>{2, 3}, values};
 
   auto copy = m.copy();
   BOOST_CHECK_EQUAL_COLLECTIONS(values.begin(), values.end(), copy.begin(), copy.end());
@@ -173,8 +169,8 @@ BOOST_AUTO_TEST_CASE(Copy_test) {
 BOOST_AUTO_TEST_CASE(Concatenate_test) {
   std::vector<int> values1{1, 2, 3, 4, 5, 6};
   std::vector<int> values2{50, 60, 70, 80, 90, 100};
-  NdArray<int> m{std::vector<size_t>{2, 3}, values1};
-  NdArray<int> add{std::vector<size_t>{2, 3}, values2};
+  NdArray<int>     m{std::vector<size_t>{2, 3}, values1};
+  NdArray<int>     add{std::vector<size_t>{2, 3}, values2};
 
   m.concatenate(add);
 
@@ -198,7 +194,7 @@ BOOST_AUTO_TEST_CASE(BadConcatenate_test) {
 
 BOOST_AUTO_TEST_CASE(AttrNames_test) {
   const std::vector<std::string> attr_names{"ID", "SED", "PDZ"};
-  NdArray<int> named{{20}, attr_names};
+  NdArray<int>                   named{{20}, attr_names};
 
   BOOST_CHECK_EQUAL(named.shape().size(), 2);
   BOOST_CHECK_EQUAL(named.shape()[0], 20);
@@ -206,7 +202,7 @@ BOOST_AUTO_TEST_CASE(AttrNames_test) {
   BOOST_CHECK_EQUAL(named.size(), 60);
 
   for (size_t i = 0; i < named.shape()[0]; ++i) {
-    named.at(i, "ID") = i;
+    named.at(i, "ID")  = i;
     named.at(i, "SED") = i * 2;
     named.at(i, "PDZ") = i * 10 + 5;
   }

--- a/NdArray/tests/src/NpyMmap_test.cpp
+++ b/NdArray/tests/src/NpyMmap_test.cpp
@@ -16,11 +16,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <boost/test/unit_test.hpp>
-#include <ElementsKernel/Temporary.h>
 #include "NdArray/io/Npy.h"
 #include "NdArray/io/NpyMmap.h"
 #include "TestHelper.h"
+#include <ElementsKernel/Temporary.h>
+#include <boost/test/unit_test.hpp>
 
 using namespace Euclid::NdArray;
 
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(MmapOpen_test) {
     BOOST_CHECK_EQUAL_COLLECTIONS(ndarray.begin(), ndarray.end(), mmapped.begin(), mmapped.end());
     // Modify a couple of elements
     // Note we start at 1024 so there is no chance they have been generated randomly
-    mmapped.at(0, 1, 2) = 1024 + 42;
+    mmapped.at(0, 1, 2)   = 1024 + 42;
     mmapped.at(42, 5, 33) = 1024 + 108;
   }
 
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(MmapOpenPrivate_test) {
     BOOST_CHECK_EQUAL_COLLECTIONS(ndarray.begin(), ndarray.end(), mmapped.begin(), mmapped.end());
     // Modify a couple of elements
     // Note we start at 1024 so there is no chance they have been generated randomly
-    mmapped.at(0, 1, 2) = 1024 + 42;
+    mmapped.at(0, 1, 2)   = 1024 + 42;
     mmapped.at(42, 5, 33) = 1024 + 108;
 
     BOOST_CHECK_EQUAL(mmapped.at(0, 1, 2), 1024 + 42);
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(MmapAppend_NotEnough_test) {
 }
 
 BOOST_AUTO_TEST_CASE(MmapNamed_test) {
-  Elements::TempFile file("npy_named_mmap_%%.npy");
+  Elements::TempFile             file("npy_named_mmap_%%.npy");
   const std::vector<std::string> attr_names{"ID", "SED", "PDZ"};
 
   // Create mmap
@@ -164,13 +164,13 @@ BOOST_AUTO_TEST_CASE(MmapNamed_test) {
 
   // Fill
   for (size_t i = 0; i < ndarray.shape()[0]; ++i) {
-    ndarray.at(i, "ID") = i;
+    ndarray.at(i, "ID")  = i;
     ndarray.at(i, "SED") = i * 2;
     ndarray.at(i, "PDZ") = i * 10 + 5;
   }
 
   // Read from Python
-  constexpr const char *PYCODE = R"EDOCYP(
+  constexpr const char* PYCODE = R"EDOCYP(
 import sys
 import numpy as np
 a = np.load(sys.argv[1])
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(ReadAttrNames_test) {
   std::vector<std::string> expected_attrs{"a", "b"};
 
   // Write from Python
-  constexpr const char *PYCODE = R"EDOCYP(
+  constexpr const char* PYCODE = R"EDOCYP(
 import sys
 import numpy as np
 
@@ -224,7 +224,7 @@ np.save(sys.argv[1], a)
   array.at(3, "a") = 78;
 
   // The changes must be visible to another process
-  constexpr const char *PYCODE2 = R"EDOCYP(
+  constexpr const char* PYCODE2 = R"EDOCYP(
 import sys
 import numpy as np
 
@@ -239,7 +239,7 @@ assert np.array_equal(expected, a), a
 }
 
 BOOST_AUTO_TEST_CASE(NamedAppend_test) {
-  Elements::TempFile file("npy_named_resize_mmap_%%.npy");
+  Elements::TempFile             file("npy_named_resize_mmap_%%.npy");
   const std::vector<std::string> attr_names{"X", "Y"};
 
   auto ndarray = createMmapNpy<double>(file.path(), {100}, attr_names, 10240);

--- a/NdArray/tests/src/Npy_test.cpp
+++ b/NdArray/tests/src/Npy_test.cpp
@@ -16,18 +16,17 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
-#include <ElementsKernel/Temporary.h>
 #include "NdArray/io/Npy.h"
 #include "TestHelper.h"
+#include <ElementsKernel/Temporary.h>
+#include <boost/mpl/list.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace Euclid::NdArray;
 
 BOOST_AUTO_TEST_SUITE(Npy_test)
 
 typedef boost::mpl::list<int32_t, int64_t, float, double> array_type;
-
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Npy1d_readwrite_test, T, array_type) {
   std::stringstream stream;
@@ -79,14 +78,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Npy1d_python_test, T, array_type) {
   writeNpy(file.path(), ndarray);
 
   // Read NPY
-  constexpr const char *PYCODE = R"EDOCYP(
+  constexpr const char* PYCODE = R"EDOCYP(
 import sys
 import numpy as np
 a = np.load(sys.argv[1])
 assert a.shape == (100,)
 print(a.sum())
 )EDOCYP";
-  auto output = runPython(PYCODE, file.path());
+  auto                  output = runPython(PYCODE, file.path());
 
   T sum;
   output >> sum;
@@ -104,14 +103,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Npy2d_python_test, T, array_type) {
   writeNpy(file.path(), ndarray);
 
   // Read NPY
-  constexpr const char *PYCODE = R"EDOCYP(
+  constexpr const char* PYCODE = R"EDOCYP(
 import sys
 import numpy as np
 a = np.load(sys.argv[1])
 assert a.shape == (50, 2)
 print((a[:,0] * a[:,1]).sum())
 )EDOCYP";
-  auto output = runPython(PYCODE, file.path());
+  auto                  output = runPython(PYCODE, file.path());
 
   // Must match
   T expected = 0;
@@ -128,7 +127,7 @@ BOOST_AUTO_TEST_CASE(Npy2d_frompython_test) {
   Elements::TempFile file("npy_test_frompython_%%.npy");
 
   // Write NPY from Python
-  constexpr const char *PYCODE = R"EDOCYP(
+  constexpr const char* PYCODE = R"EDOCYP(
 import sys
 import numpy as np
 a = np.save(sys.argv[1], np.arange(0, 100, dtype='=u4').reshape(2, 5, 10))
@@ -161,7 +160,7 @@ BOOST_AUTO_TEST_CASE(Npy_badtype_test) {
 BOOST_AUTO_TEST_CASE(Npy_badendian_test) {
   Elements::TempFile file(std::string("npy_testpy_endian_%%.npy"));
 
-  constexpr const char *PYCODE = R"EDOCYP(
+  constexpr const char* PYCODE = R"EDOCYP(
 import sys
 import numpy as np
 np.save(sys.argv[1], np.arange(100, 400, dtype='>i8'))
@@ -177,10 +176,10 @@ BOOST_AUTO_TEST_CASE(AttrNames_test) {
 
   // Construct NdArray
   const std::vector<std::string> attr_names{"ID", "SED", "PDZ"};
-  NdArray<int> named{{20}, attr_names};
+  NdArray<int>                   named{{20}, attr_names};
 
   for (size_t i = 0; i < named.shape()[0]; ++i) {
-    named.at(i, "ID") = i;
+    named.at(i, "ID")  = i;
     named.at(i, "SED") = i * 2;
     named.at(i, "PDZ") = i * 10 + 5;
   }
@@ -189,7 +188,7 @@ BOOST_AUTO_TEST_CASE(AttrNames_test) {
   writeNpy(file.path(), named);
 
   // Read from Python
-  constexpr const char *PYCODE = R"EDOCYP(
+  constexpr const char* PYCODE = R"EDOCYP(
 import sys
 import numpy as np
 a = np.load(sys.argv[1])
@@ -212,7 +211,7 @@ BOOST_AUTO_TEST_CASE(ReadAttrNames_test) {
   std::vector<std::string> expected_attrs{"a", "b"};
 
   // Write from Python
-  constexpr const char *PYCODE = R"EDOCYP(
+  constexpr const char* PYCODE = R"EDOCYP(
 import sys
 import numpy as np
 
@@ -242,7 +241,7 @@ BOOST_AUTO_TEST_CASE(AttrNames_mixed_test) {
   Elements::TempFile file(std::string("npy_testpy_read_attrs_%%.npy"));
 
   // Write from Python
-  constexpr const char *PYCODE = R"EDOCYP(
+  constexpr const char* PYCODE = R"EDOCYP(
 import sys
 import numpy as np
 

--- a/NdArray/tests/src/TestHelper.h
+++ b/NdArray/tests/src/TestHelper.h
@@ -19,17 +19,19 @@
 #ifndef NDARRAY_TEST_H
 #define NDARRAY_TEST_H
 
-#include <sstream>
+#include "ElementsKernel/Temporary.h"
 #include <boost/filesystem/path.hpp>
 #include <boost/process.hpp>
+#include <boost/test/unit_test.hpp>
+#include <sstream>
 
 /**
  * Run embedded Python code
  */
-static std::stringstream runPython(const char *code, const boost::filesystem::path& npy) {
+static std::stringstream runPython(const char* code, const boost::filesystem::path& npy) {
   namespace bp = boost::process;
   Elements::TempFile code_file("npy_%%%%.py");
-  std::ofstream out(code_file.path().native());
+  std::ofstream      out(code_file.path().native());
   out << code;
   out.close();
 
@@ -39,7 +41,7 @@ static std::stringstream runPython(const char *code, const boost::filesystem::pa
   BOOST_CHECK(!python_exec.empty());
 
   bp::ipstream py_output;
-  int r = bp::system(python_exec, code_file.path().native(), npy.native(), bp::std_out > py_output);
+  int          r = bp::system(python_exec, code_file.path().native(), npy.native(), bp::std_out > py_output);
   BOOST_CHECK_EQUAL(r, 0);
 
   std::stringstream stream;
@@ -47,4 +49,4 @@ static std::stringstream runPython(const char *code, const boost::filesystem::pa
   return stream;
 }
 
-#endif // NDARRAY_TEST_H
+#endif  // NDARRAY_TEST_H

--- a/PhysicsUtils/PhysicsUtils/CosmologicalDistances.h
+++ b/PhysicsUtils/PhysicsUtils/CosmologicalDistances.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file PhysicsUtils/CosmologicalDistances.h
  * @date November 29, 2015
  * @author Florian Dubath
@@ -24,7 +24,6 @@
 
 #ifndef PHYSICSUTILS_PHYSICSUTILS_COSMOLOGICALDISTANCES_H_
 #define PHYSICSUTILS_PHYSICSUTILS_COSMOLOGICALDISTANCES_H_
-
 
 #include "PhysicsUtils/CosmologicalParameters.h"
 
@@ -36,7 +35,7 @@ namespace PhysicsUtils {
  *
  * @brief Compute the distances according to it. See http://xxx.lanl.gov/abs/astro-ph/9905116
  */
-class CosmologicalDistances{
+class CosmologicalDistances {
 public:
   virtual ~CosmologicalDistances() = default;
 
@@ -70,11 +69,9 @@ public:
    * @param relative_precision The requested precision.
    *
    */
-  double comovingDistance(double z,
-                          const CosmologicalParameters& parameters,
-                          double relative_precision = 0.0000001) const;
+  double comovingDistance(double z, const CosmologicalParameters& parameters, double relative_precision = 0.0000001) const;
 
- /**
+  /**
    * @brief return the transverse comoving distance in [pc]
    *
    * @param z The redshift for which the distance has to be computed.
@@ -83,7 +80,7 @@ public:
    */
   double transverseComovingDistance(double z, const CosmologicalParameters& parameters) const;
 
- /**
+  /**
    * @brief return the luminous distance in [pc]. For z=0 the returned value is 10pc.
    *
    * @param z The redshift for which the distance has to be computed.
@@ -103,16 +100,15 @@ public:
   double distanceModulus(double z, const CosmologicalParameters& parameters) const;
 
   /**
-    * @brief return the dimensionless comoving volume element.
-    *
-    * @param z The redshift for which the volume element has to be computed.
-    *
-    * @param parameters The cosmological parameters the distance has to be computed for.
-    */
+   * @brief return the dimensionless comoving volume element.
+   *
+   * @param z The redshift for which the volume element has to be computed.
+   *
+   * @param parameters The cosmological parameters the distance has to be computed for.
+   */
   double dimensionlessComovingVolumeElement(double z, const CosmologicalParameters& parameters) const;
-
 };
 
-}
-}
+}  // namespace PhysicsUtils
+}  // namespace Euclid
 #endif /* PHYSICSUTILS_PHYSICSUTILS_COSMOLOGICALDISTANCES_H_ */

--- a/PhysicsUtils/PhysicsUtils/CosmologicalParameters.h
+++ b/PhysicsUtils/PhysicsUtils/CosmologicalParameters.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file PhysicsUtils/CosmologicalParameters.h
  * @date November 29, 2015
  * @author Florian Dubath
@@ -49,8 +49,7 @@ public:
    * @param hubble_constant
    * H_0 in (km/s)/Mpc
    */
-  CosmologicalParameters(double omega_m = 0.3089, double omega_lambda = 0.6911,
-      double hubble_constant = 67.74);
+  CosmologicalParameters(double omega_m = 0.3089, double omega_lambda = 0.6911, double hubble_constant = 67.74);
 
   virtual ~CosmologicalParameters() = default;
 
@@ -81,6 +80,6 @@ private:
   double m_H_0;
 };
 
-}
-}
+}  // namespace PhysicsUtils
+}  // namespace Euclid
 #endif /* PHYSICSUTILS_PHYSICSUTILS_COSMOLOGICALPARAMETERS_H_ */

--- a/PhysicsUtils/src/lib/CosmologicalDistances.cpp
+++ b/PhysicsUtils/src/lib/CosmologicalDistances.cpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file src/lib/CosmologicalDistances.h
  * @date November 29, 2015
  * @author Florian Dubath
@@ -26,8 +26,8 @@
 #include "ElementsKernel/PhysConstants.h"
 #include "ElementsKernel/Real.h"
 
-#include "MathUtils/function/function_tools.h"
 #include "MathUtils/function/FunctionAdapter.h"
+#include "MathUtils/function/function_tools.h"
 #include "MathUtils/numericalIntegration/AdaptativeIntegration.h"
 #include "MathUtils/numericalIntegration/SimpsonsRule.h"
 
@@ -37,45 +37,36 @@ namespace Euclid {
 namespace PhysicsUtils {
 
 double CosmologicalDistances::hubbleDistance(const CosmologicalParameters& parameters) const {
-  return Elements::Units::c_light * 1.0E3 / parameters.getHubbleConstant(); // in [pc]
+  return Elements::Units::c_light * 1.0E3 / parameters.getHubbleConstant();  // in [pc]
 }
 
-double CosmologicalDistances::hubbleParameter(double z,
-    const CosmologicalParameters& parameters) const {
+double CosmologicalDistances::hubbleParameter(double z, const CosmologicalParameters& parameters) const {
   double square = (1. + z) * (1. + z);
-  double cube = square * (1. + z);
-  return std::sqrt(
-      parameters.getOmegaM() * cube + parameters.getOmegaK() * square
-          + parameters.getOmegaLambda());
+  double cube   = square * (1. + z);
+  return std::sqrt(parameters.getOmegaM() * cube + parameters.getOmegaK() * square + parameters.getOmegaLambda());
 }
 
-double CosmologicalDistances::comovingDistance(double z,
-    const CosmologicalParameters& parameters, double relative_precision) const {
+double CosmologicalDistances::comovingDistance(double z, const CosmologicalParameters& parameters,
+                                               double relative_precision) const {
   if (Elements::isEqual(0., z)) {
     return 0.;
   }
 
-  std::unique_ptr<MathUtils::NumericalIntegrationScheme> integrationScheme {
-      new MathUtils::AdaptativeIntegration<MathUtils::SimpsonsRule>(
-          relative_precision, MathUtils::SimpsonsRule::minimal_order) };
+  std::unique_ptr<MathUtils::NumericalIntegrationScheme> integrationScheme{
+      new MathUtils::AdaptativeIntegration<MathUtils::SimpsonsRule>(relative_precision, MathUtils::SimpsonsRule::minimal_order)};
 
-  MathUtils::FunctionAdapter adpater(
-      [&parameters,this](double x) {return 1./hubbleParameter(x,parameters);});
+  MathUtils::FunctionAdapter adpater([&parameters, this](double x) { return 1. / hubbleParameter(x, parameters); });
 
-  return hubbleDistance(parameters)
-      * integrate(adpater, 0., z, std::move(integrationScheme));
-
+  return hubbleDistance(parameters) * integrate(adpater, 0., z, std::move(integrationScheme));
 }
 
-double CosmologicalDistances::transverseComovingDistance(double z,
-    const CosmologicalParameters& parameters) const {
+double CosmologicalDistances::transverseComovingDistance(double z, const CosmologicalParameters& parameters) const {
   double comoving = comovingDistance(z, parameters);
   if (Elements::isEqual(0., parameters.getOmegaK())) {
     return comoving;
   }
 
-  double dHOverSqrtOmegaK = hubbleDistance(parameters)
-      / std::sqrt(std::abs(parameters.getOmegaK()));
+  double dHOverSqrtOmegaK = hubbleDistance(parameters) / std::sqrt(std::abs(parameters.getOmegaK()));
 
   if (parameters.getOmegaK() > 0) {
     return dHOverSqrtOmegaK * std::sinh(comoving / dHOverSqrtOmegaK);
@@ -84,8 +75,7 @@ double CosmologicalDistances::transverseComovingDistance(double z,
   }
 }
 
-double CosmologicalDistances::luminousDistance(double z,
-    const CosmologicalParameters& parameters) const {
+double CosmologicalDistances::luminousDistance(double z, const CosmologicalParameters& parameters) const {
   if (Elements::isEqual(0., z)) {
     return 10.;
   } else {
@@ -93,19 +83,16 @@ double CosmologicalDistances::luminousDistance(double z,
   }
 }
 
-double CosmologicalDistances::distanceModulus(double z,
-    const CosmologicalParameters& parameters) const {
+double CosmologicalDistances::distanceModulus(double z, const CosmologicalParameters& parameters) const {
   return 5. * std::log10(luminousDistance(z, parameters) / 10.);
 }
 
-
-double CosmologicalDistances::dimensionlessComovingVolumeElement(double z,
-    const CosmologicalParameters& parameters) const{
+double CosmologicalDistances::dimensionlessComovingVolumeElement(double z, const CosmologicalParameters& parameters) const {
   double D_H = hubbleDistance(parameters);
-  double E = hubbleParameter(z,parameters);
-  double D_M = transverseComovingDistance(z,parameters);
-  return D_M*D_M/(E*D_H*D_H);
+  double E   = hubbleParameter(z, parameters);
+  double D_M = transverseComovingDistance(z, parameters);
+  return D_M * D_M / (E * D_H * D_H);
 }
 
-}
-}
+}  // namespace PhysicsUtils
+}  // namespace Euclid

--- a/PhysicsUtils/src/lib/CosmologicalParameters.cpp
+++ b/PhysicsUtils/src/lib/CosmologicalParameters.cpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file src/lib/CosmologicalParameters.h
  * @date November 29, 2015
  * @author Florian Dubath
@@ -27,30 +27,24 @@
 namespace Euclid {
 namespace PhysicsUtils {
 
-CosmologicalParameters::CosmologicalParameters(double omega_m,
-                     double omega_lambda,
-                     double hubble_constant) : m_omega_m{omega_m},
-                                               m_omega_lambda{omega_lambda},
-                                               m_omega_k{1.0-omega_m-omega_lambda},
-                                               m_H_0{hubble_constant}{
-}
+CosmologicalParameters::CosmologicalParameters(double omega_m, double omega_lambda, double hubble_constant)
+    : m_omega_m{omega_m}, m_omega_lambda{omega_lambda}, m_omega_k{1.0 - omega_m - omega_lambda}, m_H_0{hubble_constant} {}
 
-double CosmologicalParameters::getOmegaM() const{
+double CosmologicalParameters::getOmegaM() const {
   return m_omega_m;
 }
 
-double CosmologicalParameters::getOmegaLambda() const{
+double CosmologicalParameters::getOmegaLambda() const {
   return m_omega_lambda;
 }
 
-double CosmologicalParameters::getOmegaK() const{
+double CosmologicalParameters::getOmegaK() const {
   return m_omega_k;
 }
 
-double CosmologicalParameters::getHubbleConstant() const{
+double CosmologicalParameters::getHubbleConstant() const {
   return m_H_0;
 }
 
-
-}
-}
+}  // namespace PhysicsUtils
+}  // namespace Euclid

--- a/PhysicsUtils/tests/src/CosmologicalDistances_test.cpp
+++ b/PhysicsUtils/tests/src/CosmologicalDistances_test.cpp
@@ -1,177 +1,183 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file tests/src/lib/CosmologicalDistances_test.h
  * @date November 29, 2015
  * @author Florian Dubath
  */
-#include <cmath>
-#include <boost/test/unit_test.hpp>
 #include "ElementsKernel/Real.h"
 #include "PhysicsUtils/CosmologicalDistances.h"
+#include <boost/test/unit_test.hpp>
+#include <cmath>
 
 using namespace Euclid;
 using namespace PhysicsUtils;
 
 struct CosmologicalDistances_Fixture {
-  double omega_m = 0.2;
+  double omega_m      = 0.2;
   double omega_lambda = 0.7;
   // so we expect omega_k to be 0.1 !=0
   double H_0 = 77.0;
 
-  std::vector<double> zs { 0, 0.001, 0.01, 0.1, 0.5, 1., 1.5, 2., 4., 6. };
-  std::vector<double> hubble_parameters { 1., 1.0004002699919667,
-      1.0040269916690487, 1.042688831818966, 1.2649110640673518,
-      1.6431676725154984, 2.1095023109728985, 2.6457513110645907,
-      5.3103672189407014, 8.6139421869432127 };
-  std::vector<double> comoving { 0., 3892629.7211428746, 38856076.082309492,
-      381426775.30670536, 1743252275.3547294, 3097511958.8287911,
-      4144034048.8586593, 4968125488.521699, 7037575806.8509665,
-      8185617947.9015932 };
-  std::vector<double> luminous { 10., 4429033.2516768286, 44595140.97263521,
-      475341190.49684501, 2918477377.0888844, 6792421919.9330025,
-      11199033877.97576, 15937134721.927008, 36706225562.921059,
-      59064863879.408623 };
+  std::vector<double> zs{0, 0.001, 0.01, 0.1, 0.5, 1., 1.5, 2., 4., 6.};
+  std::vector<double> hubble_parameters{1.,
+                                        1.0004002699919667,
+                                        1.0040269916690487,
+                                        1.042688831818966,
+                                        1.2649110640673518,
+                                        1.6431676725154984,
+                                        2.1095023109728985,
+                                        2.6457513110645907,
+                                        5.3103672189407014,
+                                        8.6139421869432127};
+  std::vector<double> comoving{0.,
+                               3892629.7211428746,
+                               38856076.082309492,
+                               381426775.30670536,
+                               1743252275.3547294,
+                               3097511958.8287911,
+                               4144034048.8586593,
+                               4968125488.521699,
+                               7037575806.8509665,
+                               8185617947.9015932};
+  std::vector<double> luminous{10.,
+                               4429033.2516768286,
+                               44595140.97263521,
+                               475341190.49684501,
+                               2918477377.0888844,
+                               6792421919.9330025,
+                               11199033877.97576,
+                               15937134721.927008,
+                               36706225562.921059,
+                               59064863879.408623};
 
-  std::vector<double> volumeElement {0.0, 9.990733333168602e-07,
-    9.907367503391648e-05, 0.009081033159604667,
-    0.14679118615652445, 0.33115915506673393, 0.4361667073426341,
-    0.47945673110160303, 0.43890675385247246, 0.35200068850695454};
+  std::vector<double> volumeElement{0.0,
+                                    9.990733333168602e-07,
+                                    9.907367503391648e-05,
+                                    0.009081033159604667,
+                                    0.14679118615652445,
+                                    0.33115915506673393,
+                                    0.4361667073426341,
+                                    0.47945673110160303,
+                                    0.43890675385247246,
+                                    0.35200068850695454};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (CosmologicalDistances_test)
+BOOST_AUTO_TEST_SUITE(CosmologicalDistances_test)
 
 BOOST_FIXTURE_TEST_CASE(hubble_distance, CosmologicalDistances_Fixture) {
 
-  CosmologicalDistances distances { };
+  CosmologicalDistances distances{};
 
   for (double h_0 = 65.; h_0 < 100.; h_0 += 2.1) {
-    CosmologicalParameters parameters { omega_m, omega_lambda, h_0 };
-    double expected = 2.99792458e+11 / h_0; // in [pc]
-    BOOST_CHECK(
-        Elements::isEqual(expected, distances.hubbleDistance(parameters)));
+    CosmologicalParameters parameters{omega_m, omega_lambda, h_0};
+    double                 expected = 2.99792458e+11 / h_0;  // in [pc]
+    BOOST_CHECK(Elements::isEqual(expected, distances.hubbleDistance(parameters)));
   }
 }
 
 BOOST_FIXTURE_TEST_CASE(hubble_parameter, CosmologicalDistances_Fixture) {
-  std::vector<double> result_1 { 1., 1.0015003749375231, 1.0150374377332099,
-      1.1536897329871669, 1.8371173070873836, 2.8284271247461903,
-      3.9528470752104741, 5.196152422706632, 11.180339887498949,
-      18.520259177452136 };
-  CosmologicalDistances distances { };
+  std::vector<double>   result_1{1.,
+                               1.0015003749375231,
+                               1.0150374377332099,
+                               1.1536897329871669,
+                               1.8371173070873836,
+                               2.8284271247461903,
+                               3.9528470752104741,
+                               5.196152422706632,
+                               11.180339887498949,
+                               18.520259177452136};
+  CosmologicalDistances distances{};
 
   // check the limit cases
-  CosmologicalParameters parameters_1 { 1., 0., H_0 };
+  CosmologicalParameters parameters_1{1., 0., H_0};
 
   for (size_t i = 0; i < zs.size(); ++i) {
-    BOOST_CHECK(
-        Elements::isEqual(result_1[i],
-            distances.hubbleParameter(zs[i], parameters_1)));
+    BOOST_CHECK(Elements::isEqual(result_1[i], distances.hubbleParameter(zs[i], parameters_1)));
   }
 
-  CosmologicalParameters parameters_2 { 0., 0., H_0 };
+  CosmologicalParameters parameters_2{0., 0., H_0};
   for (size_t i = 0; i < zs.size(); ++i) {
-    BOOST_CHECK(
-        Elements::isEqual(1. + zs[i],
-            distances.hubbleParameter(zs[i], parameters_2)));
+    BOOST_CHECK(Elements::isEqual(1. + zs[i], distances.hubbleParameter(zs[i], parameters_2)));
   }
 
-  CosmologicalParameters parameters_3 { 0., 1., H_0 };
+  CosmologicalParameters parameters_3{0., 1., H_0};
   for (size_t i = 0; i < zs.size(); ++i) {
-    BOOST_CHECK(
-        Elements::isEqual(1., distances.hubbleParameter(zs[i], parameters_3)));
+    BOOST_CHECK(Elements::isEqual(1., distances.hubbleParameter(zs[i], parameters_3)));
   }
 
-  CosmologicalParameters parameters_4 { omega_m, omega_lambda, H_0 };
+  CosmologicalParameters parameters_4{omega_m, omega_lambda, H_0};
   for (size_t i = 0; i < zs.size(); ++i) {
-    BOOST_CHECK(
-        Elements::isEqual(hubble_parameters[i],
-            distances.hubbleParameter(zs[i], parameters_4)));
+    BOOST_CHECK(Elements::isEqual(hubble_parameters[i], distances.hubbleParameter(zs[i], parameters_4)));
   }
 }
 
 BOOST_FIXTURE_TEST_CASE(comoving_distance, CosmologicalDistances_Fixture) {
-  CosmologicalDistances distances { };
-  CosmologicalParameters parameters { omega_m, omega_lambda, H_0 };
+  CosmologicalDistances  distances{};
+  CosmologicalParameters parameters{omega_m, omega_lambda, H_0};
   for (size_t i = 0; i < zs.size(); ++i) {
-    BOOST_CHECK(
-        Elements::isEqual(comoving[i],
-            distances.comovingDistance(zs[i], parameters)));
-
+    BOOST_CHECK(Elements::isEqual(comoving[i], distances.comovingDistance(zs[i], parameters)));
   }
 }
 
 BOOST_FIXTURE_TEST_CASE(transverse_comoving_distance, CosmologicalDistances_Fixture) {
-  CosmologicalDistances distances { };
+  CosmologicalDistances distances{};
 
   // case with negative omega_k
-  CosmologicalParameters parameters_1 { omega_m, 1.1 - omega_m, H_0 };
-  BOOST_CHECK(
-      Elements::isEqual(4423595310.7368011,
-          distances.transverseComovingDistance(1.5, parameters_1)));
+  CosmologicalParameters parameters_1{omega_m, 1.1 - omega_m, H_0};
+  BOOST_CHECK(Elements::isEqual(4423595310.7368011, distances.transverseComovingDistance(1.5, parameters_1)));
 
   // case with 0 omega_k
-  CosmologicalParameters parameters_2 { omega_m, 1.0 - omega_m, H_0 };
-  BOOST_CHECK(
-      Elements::isEqual(4319113837.9162245,
-          distances.transverseComovingDistance(1.5, parameters_2)));
+  CosmologicalParameters parameters_2{omega_m, 1.0 - omega_m, H_0};
+  BOOST_CHECK(Elements::isEqual(4319113837.9162245, distances.transverseComovingDistance(1.5, parameters_2)));
 
   // case with positive omega_k
-  CosmologicalParameters parameters_3 { omega_m, 0.9 - omega_m, H_0 };
-  BOOST_CHECK(
-      Elements::isEqual(4222723848.5923686,
-          distances.transverseComovingDistance(1.5, parameters_3)));
+  CosmologicalParameters parameters_3{omega_m, 0.9 - omega_m, H_0};
+  BOOST_CHECK(Elements::isEqual(4222723848.5923686, distances.transverseComovingDistance(1.5, parameters_3)));
 }
 
 BOOST_FIXTURE_TEST_CASE(luminous_distance, CosmologicalDistances_Fixture) {
-  CosmologicalDistances distances { };
-  CosmologicalParameters parameters { };
+  CosmologicalDistances  distances{};
+  CosmologicalParameters parameters{};
   for (size_t i = 0; i < zs.size(); ++i) {
-    BOOST_CHECK(
-        Elements::isEqual(luminous[i],
-            distances.luminousDistance(zs[i], parameters)));
+    BOOST_CHECK(Elements::isEqual(luminous[i], distances.luminousDistance(zs[i], parameters)));
   }
 }
 
 BOOST_FIXTURE_TEST_CASE(DM_test, CosmologicalDistances_Fixture) {
-  CosmologicalDistances distances { };
-  CosmologicalParameters parameters { };
-  BOOST_CHECK(
-      Elements::isEqual(44.415392424409184,
-          distances.distanceModulus(1.1, parameters)));
+  CosmologicalDistances  distances{};
+  CosmologicalParameters parameters{};
+  BOOST_CHECK(Elements::isEqual(44.415392424409184, distances.distanceModulus(1.1, parameters)));
   BOOST_CHECK_EQUAL(0., distances.distanceModulus(0., parameters));
 }
 
 BOOST_FIXTURE_TEST_CASE(VE_test, CosmologicalDistances_Fixture) {
-  CosmologicalDistances distances { };
-  CosmologicalParameters parameters { };
+  CosmologicalDistances  distances{};
+  CosmologicalParameters parameters{};
   for (size_t i = 0; i < zs.size(); ++i) {
-     BOOST_CHECK_CLOSE(
-         volumeElement[i],
-         distances.dimensionlessComovingVolumeElement(zs[i], parameters),
-         0.00001);
-   }
+    BOOST_CHECK_CLOSE(volumeElement[i], distances.dimensionlessComovingVolumeElement(zs[i], parameters), 0.00001);
+  }
 }
 
-//BOOST_FIXTURE_TEST_CASE(export_data, CosmologicalDistances_Fixture) {
+// BOOST_FIXTURE_TEST_CASE(export_data, CosmologicalDistances_Fixture) {
 //  CosmologicalDistances distances{};
 //  CosmologicalParameters parameters{0.25,0.75,70.};
 //
@@ -190,5 +196,4 @@ BOOST_FIXTURE_TEST_CASE(VE_test, CosmologicalDistances_Fixture) {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/PhysicsUtils/tests/src/CosmologicalParameters_test.cpp
+++ b/PhysicsUtils/tests/src/CosmologicalParameters_test.cpp
@@ -1,72 +1,60 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file tests/src/lib/CosmologicalParameters_test.h
  * @date November 29, 2015
  * @author Florian Dubath
  */
-#include <cmath>
-#include <boost/test/unit_test.hpp>
 #include "ElementsKernel/Real.h"
 #include "PhysicsUtils/CosmologicalParameters.h"
+#include <boost/test/unit_test.hpp>
+#include <cmath>
 
 using namespace Euclid;
 using namespace PhysicsUtils;
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (CosmologicalParameters_test)
+BOOST_AUTO_TEST_SUITE(CosmologicalParameters_test)
 
 BOOST_AUTO_TEST_CASE(Constructor) {
 
   double H_0 = 70;
   for (int i = 0; i < 11; i++) {
     for (int j = 0; j < 11; j++) {
-      double omega_m = i * 0.1;
+      double omega_m      = i * 0.1;
       double omega_lambda = j * 0.1;
 
-      auto cosmologicalParameters = CosmologicalParameters { omega_m,
-          omega_lambda, H_0 };
+      auto cosmologicalParameters = CosmologicalParameters{omega_m, omega_lambda, H_0};
       // check H_0
-      BOOST_CHECK(
-          Elements::isEqual(H_0, cosmologicalParameters.getHubbleConstant()));
+      BOOST_CHECK(Elements::isEqual(H_0, cosmologicalParameters.getHubbleConstant()));
 
       // Check the Omega parameters
-      BOOST_CHECK(
-          Elements::isEqual(omega_m, cosmologicalParameters.getOmegaM()));
-      BOOST_CHECK(
-          Elements::isEqual(omega_lambda,
-              cosmologicalParameters.getOmegaLambda()));
-      BOOST_CHECK(
-          Elements::isEqual(1 - omega_m - omega_lambda,
-              cosmologicalParameters.getOmegaK()));
+      BOOST_CHECK(Elements::isEqual(omega_m, cosmologicalParameters.getOmegaM()));
+      BOOST_CHECK(Elements::isEqual(omega_lambda, cosmologicalParameters.getOmegaLambda()));
+      BOOST_CHECK(Elements::isEqual(1 - omega_m - omega_lambda, cosmologicalParameters.getOmegaK()));
 
       // check again the sum
-      BOOST_CHECK(
-          Elements::isEqual(1.0,
-              cosmologicalParameters.getOmegaM()
-                  + cosmologicalParameters.getOmegaLambda()
-                  + cosmologicalParameters.getOmegaK()));
+      BOOST_CHECK(Elements::isEqual(1.0, cosmologicalParameters.getOmegaM() + cosmologicalParameters.getOmegaLambda() +
+                                             cosmologicalParameters.getOmegaK()));
     }
   }
-
 }
 
-BOOST_AUTO_TEST_SUITE_END ()
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/SOM/SOM/Distance.h
+++ b/SOM/SOM/Distance.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
  * @file Distance.h
  * @author nikoapos
  */
@@ -24,8 +24,8 @@
 #ifndef SOM_DISTANCE_H
 #define SOM_DISTANCE_H
 
-#include <array>
 #include "ElementsKernel/Exception.h"
+#include <array>
 
 namespace Euclid {
 namespace SOM {
@@ -33,30 +33,24 @@ namespace Distance {
 
 template <typename std::size_t ND>
 class Interface {
-  
+
 public:
-  
   virtual ~Interface() = default;
-  
-  virtual double distance(const std::array<double, ND>& left,
-                          const std::array<double, ND>& right) const = 0;
-  
-  virtual double distance(const std::array<double, ND>&,
-                                         const std::array<double, ND>&,
-                                         const std::array<double, ND>&) const {
+
+  virtual double distance(const std::array<double, ND>& left, const std::array<double, ND>& right) const = 0;
+
+  virtual double distance(const std::array<double, ND>&, const std::array<double, ND>&, const std::array<double, ND>&) const {
     throw Elements::Exception() << "Distance with uncertainties is not supported "
-            << "for this type of distance";
+                                << "for this type of distance";
   }
-  
 };
 
 template <typename std::size_t ND>
 class L2 : public Interface<ND> {
-  
+
 public:
-  
   virtual ~L2() = default;
-  
+
   double distance(const std::array<double, ND>& left, const std::array<double, ND>& right) const override {
     double result = 0;
     for (std::size_t i = 0; i < ND; ++i) {
@@ -64,24 +58,21 @@ public:
     }
     return std::sqrt(result);
   }
-  
-  double distance(const std::array<double, ND>& left,
-                                 const std::array<double, ND>& right,
-                                 const std::array<double, ND>& uncertainties) const override {
+
+  double distance(const std::array<double, ND>& left, const std::array<double, ND>& right,
+                  const std::array<double, ND>& uncertainties) const override {
     double result = 0;
     for (std::size_t i = 0; i < ND; ++i) {
-      double up = (left[i] - right[i]) * (left[i] - right[i]);
+      double up   = (left[i] - right[i]) * (left[i] - right[i]);
       double down = uncertainties[i] * uncertainties[i];
       result += up / down;
     }
     return std::sqrt(result);
   }
-
 };
 
-}
-}
-}
+}  // namespace Distance
+}  // namespace SOM
+}  // namespace Euclid
 
 #endif /* SOM_DISTANCE_H */
-

--- a/SOM/SOM/ImplTools.h
+++ b/SOM/SOM/ImplTools.h
@@ -1,29 +1,28 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
  * @file ImplTools.h
  * @author nikoapos
  */
 
 #ifndef SOM_IMPLTOOLS_H
 #define SOM_IMPLTOOLS_H
-
 
 #include "GridContainer/GridAxis.h"
 
@@ -34,8 +33,7 @@ namespace ImplTools {
 GridContainer::GridAxis<std::size_t> indexAxis(const std::string& name, std::size_t size);
 
 }
-}
-}
+}  // namespace SOM
+}  // namespace Euclid
 
 #endif /* SOM_IMPLTOOLS_H */
-

--- a/SOM/SOM/InitFunc.h
+++ b/SOM/SOM/InitFunc.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
  * @file InitFunc.h
  * @author nikoapos
  */
@@ -24,42 +24,35 @@
 #ifndef SOM_INITFUNC_H
 #define SOM_INITFUNC_H
 
-#include <vector>
 #include <functional>
 #include <random>
+#include <vector>
 
 namespace Euclid {
 namespace SOM {
 
 namespace InitFunc {
-  
+
 using Signature = std::function<double()>;
 
-Signature zero = [](){
-  return 0;
-};
+Signature zero = []() { return 0; };
 
 Signature normalDistribution(double sigma, double mu) {
-  std::random_device rd;
-  std::mt19937 gen(rd());
-  std::normal_distribution<> d(mu,sigma);
-  return [gen, d]() mutable {
-    return d(gen);
-  };
+  std::random_device         rd;
+  std::mt19937               gen(rd());
+  std::normal_distribution<> d(mu, sigma);
+  return [gen, d]() mutable { return d(gen); };
 }
 
 Signature uniformRandom(double min, double max) {
   std::uniform_real_distribution<double> unif(min, max);
-  std::default_random_engine re;
-  return [unif, re]() mutable {
-    return unif(re);
-  };
+  std::default_random_engine             re;
+  return [unif, re]() mutable { return unif(re); };
 }
 
-}
+}  // namespace InitFunc
 
-}
-}
+}  // namespace SOM
+}  // namespace Euclid
 
 #endif /* SOM_INITFUNC_H */
-

--- a/SOM/SOM/LearningRestraintFunc.h
+++ b/SOM/SOM/LearningRestraintFunc.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
  * @file LearningRestraintFunc.h
  * @author nikoapos
  */
@@ -45,9 +45,8 @@ Signature exponentialDecay(double initial_rate) {
   };
 }
 
-}
-}
-}
+}  // namespace LearningRestraintFunc
+}  // namespace SOM
+}  // namespace Euclid
 
 #endif /* SOM_LEARNINGRESTRAINTFUNC_H */
-

--- a/SOM/SOM/NeighborhoodFunc.h
+++ b/SOM/SOM/NeighborhoodFunc.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
  * @file NeighborhoodFunc.h
  * @author nikoapos
  */
@@ -24,26 +24,24 @@
 #ifndef SOM_NEIGHBORHOODFUNC_H
 #define SOM_NEIGHBORHOODFUNC_H
 
-#include <functional>
 #include <cmath>
+#include <functional>
 
 namespace Euclid {
 namespace SOM {
 namespace NeighborhoodFunc {
 
-using Signature = std::function<double(std::pair<std::size_t, std::size_t> bmu,
-                                       std::pair<std::size_t, std::size_t> cell,
+using Signature = std::function<double(std::pair<std::size_t, std::size_t> bmu, std::pair<std::size_t, std::size_t> cell,
                                        std::size_t iteration, std::size_t total_iterations)>;
 
 Signature linearUnitDisk(double initial_radius) {
   double r_square = initial_radius * initial_radius;
-  return [r_square](std::pair<std::size_t, std::size_t> bmu,
-                    std::pair<std::size_t, std::size_t> cell,
-                    std::size_t iteration, std::size_t total_iterations) -> double {
+  return [r_square](std::pair<std::size_t, std::size_t> bmu, std::pair<std::size_t, std::size_t> cell, std::size_t iteration,
+                    std::size_t total_iterations) -> double {
     double iter_factor = 1.0 * (total_iterations - iteration) / total_iterations;
-    iter_factor = iter_factor * iter_factor; // We compare the squared distances
-    double x = bmu.first - cell.first;
-    double y = bmu.second - cell.second;
+    iter_factor        = iter_factor * iter_factor;  // We compare the squared distances
+    double x           = bmu.first - cell.first;
+    double y           = bmu.second - cell.second;
     double dist_square = x * x + y * y;
     if (dist_square < r_square * iter_factor) {
       return 1.;
@@ -53,29 +51,27 @@ Signature linearUnitDisk(double initial_radius) {
   };
 }
 
-Signature kohonen(std::size_t x_size, std::size_t y_size, double sigma_cutoff_mult=1.) {
-  
-  double init_sigma = std::max(x_size, y_size) / 2.;
-  std::tuple<std::size_t, std::size_t, double> sigma_buffer {0, 0, 0.};
-  double cutoff_mult_square = sigma_cutoff_mult * sigma_cutoff_mult;
-  
-  return [init_sigma, sigma_buffer, cutoff_mult_square](
-                  std::pair<std::size_t, std::size_t> bmu,
-                  std::pair<std::size_t, std::size_t> cell,
-                  std::size_t iteration, std::size_t total_iterations) mutable -> double {
-    
+Signature kohonen(std::size_t x_size, std::size_t y_size, double sigma_cutoff_mult = 1.) {
+
+  double                                       init_sigma = std::max(x_size, y_size) / 2.;
+  std::tuple<std::size_t, std::size_t, double> sigma_buffer{0, 0, 0.};
+  double                                       cutoff_mult_square = sigma_cutoff_mult * sigma_cutoff_mult;
+
+  return [init_sigma, sigma_buffer, cutoff_mult_square](std::pair<std::size_t, std::size_t> bmu,
+                                                        std::pair<std::size_t, std::size_t> cell, std::size_t iteration,
+                                                        std::size_t total_iterations) mutable -> double {
     // If we have new iteration we recompute the sigma, otherwise we use the already
     // calculated one
     if (std::get<0>(sigma_buffer) != iteration || std::get<1>(sigma_buffer) != total_iterations) {
       std::get<0>(sigma_buffer) = iteration;
       std::get<1>(sigma_buffer) = total_iterations;
-      double time_constant = total_iterations / std::log(init_sigma);
+      double time_constant      = total_iterations / std::log(init_sigma);
       std::get<2>(sigma_buffer) = init_sigma * std::exp(-1. * iteration / time_constant);
     }
     double sigma_square = std::get<2>(sigma_buffer) * std::get<2>(sigma_buffer);
 
-    double x = static_cast<double>(bmu.first) - cell.first;
-    double y = static_cast<double>(bmu.second) - cell.second;
+    double x           = static_cast<double>(bmu.first) - cell.first;
+    double y           = static_cast<double>(bmu.second) - cell.second;
     double dist_square = x * x + y * y;
 
     if (dist_square < cutoff_mult_square * sigma_square) {
@@ -83,14 +79,11 @@ Signature kohonen(std::size_t x_size, std::size_t y_size, double sigma_cutoff_mu
     } else {
       return 0.;
     }
-
-
   };
 }
 
-}
-}
-}
+}  // namespace NeighborhoodFunc
+}  // namespace SOM
+}  // namespace Euclid
 
 #endif /* SOM_NEIGHBORHOODFUNC_H */
-

--- a/SOM/SOM/SOM.h
+++ b/SOM/SOM/SOM.h
@@ -25,14 +25,14 @@
 #ifndef _SOM_SOM_H
 #define _SOM_SOM_H
 
-#include <vector>
+#include "GridContainer/GridContainer.h"
+#include "SOM/Distance.h"
+#include "SOM/InitFunc.h"
 #include <array>
 #include <limits>
-#include <type_traits>
 #include <tuple>
-#include "GridContainer/GridContainer.h"
-#include "SOM/InitFunc.h"
-#include "SOM/Distance.h"
+#include <type_traits>
+#include <vector>
 
 namespace Euclid {
 namespace SOM {
@@ -42,20 +42,19 @@ namespace SOM {
  * @brief
  *
  */
-template <std::size_t ND, typename DistFunc=Distance::L2<ND>>
+template <std::size_t ND, typename DistFunc = Distance::L2<ND>>
 class SOM {
-  
+
   static_assert(std::is_base_of<Distance::Interface<ND>, DistFunc>::value,
-          "DistFunc must be a subclass of the Distance::Interface<ND>");
+                "DistFunc must be a subclass of the Distance::Interface<ND>");
 
 public:
-  
-  using CellGridType = GridContainer::GridContainer<std::vector<std::array<double, ND>>, std::size_t, std::size_t>;
-  using iterator = typename CellGridType::iterator;
+  using CellGridType   = GridContainer::GridContainer<std::vector<std::array<double, ND>>, std::size_t, std::size_t>;
+  using iterator       = typename CellGridType::iterator;
   using const_iterator = typename CellGridType::const_iterator;
-  
-  SOM(std::size_t x, std::size_t y, InitFunc::Signature init_func=InitFunc::zero);
-  
+
+  SOM(std::size_t x, std::size_t y, InitFunc::Signature init_func = InitFunc::zero);
+
   SOM(SOM<ND, DistFunc>&&) = default;
   SOM& operator=(SOM<ND, DistFunc>&&) = default;
 
@@ -63,42 +62,39 @@ public:
    * @brief Destructor
    */
   virtual ~SOM() = default;
-  
+
   std::array<double, ND>& operator()(std::size_t x, std::size_t y);
-  
+
   const std::array<double, ND>& operator()(std::size_t x, std::size_t y) const;
-  
+
   const std::pair<std::size_t, std::size_t>& getSize() const;
-  
+
   iterator begin();
-  
+
   iterator end();
-  
+
   const_iterator begin() const;
-  
+
   const_iterator end() const;
-  
+
   const_iterator cbegin();
-  
+
   const_iterator cend();
-  
+
   std::tuple<std::size_t, std::size_t, double> findBMU(const std::array<double, ND>& input) const;
-  
+
   std::tuple<std::size_t, std::size_t, double> findBMU(const std::array<double, ND>& input,
-                                              const std::array<double, ND>& uncertainties) const;
-  
+                                                       const std::array<double, ND>& uncertainties) const;
+
   template <typename InputType, typename WeightFunc>
-  std::tuple<std::size_t, std::size_t, double> findBMU(const InputType& input,
-                                              WeightFunc weight_func) const;
-  
+  std::tuple<std::size_t, std::size_t, double> findBMU(const InputType& input, WeightFunc weight_func) const;
+
   template <typename InputType, typename WeightFunc, typename UncertaintyFunc>
-  std::tuple<std::size_t, std::size_t, double> findBMU(const InputType& input,
-                                              WeightFunc weight_func,
-                                              UncertaintyFunc uncertainty_func) const;
+  std::tuple<std::size_t, std::size_t, double> findBMU(const InputType& input, WeightFunc weight_func,
+                                                       UncertaintyFunc uncertainty_func) const;
 
 private:
-  
-  CellGridType m_cells;
+  CellGridType                        m_cells;
   std::pair<std::size_t, std::size_t> m_size;
 
 }; /* End of SOM class */

--- a/SOM/SOM/SOMProjector.h
+++ b/SOM/SOM/SOMProjector.h
@@ -24,36 +24,32 @@
 #ifndef SOM_SOMPROJECTOR_H
 #define SOM_SOMPROJECTOR_H
 
-#include <functional>
-#include <iterator>
 #include "GridContainer/GridContainer.h"
 #include "SOM/SOM.h"
+#include <functional>
+#include <iterator>
 
 namespace Euclid {
 namespace SOM {
 class SOMProjector {
 
 public:
-
   template <typename T>
   using ProjectGrid = GridContainer::GridContainer<std::vector<T>, std::size_t, std::size_t>;
 
-  template<typename T, std::size_t ND, typename DistFunc, typename InputIter, typename WeightFunc, typename AdderFunc>
+  template <typename T, std::size_t ND, typename DistFunc, typename InputIter, typename WeightFunc, typename AdderFunc>
   static ProjectGrid<T> project(const SOM<ND, DistFunc>& som, InputIter begin, InputIter end, WeightFunc weight_func,
                                 AdderFunc adder_func, const T& init_cell = T{});
 
-  template<typename T, std::size_t ND, typename DistFunc, typename InputIter, typename WeightFunc,
-    typename UncertaintyFunc, typename AdderFunc>
+  template <typename T, std::size_t ND, typename DistFunc, typename InputIter, typename WeightFunc, typename UncertaintyFunc,
+            typename AdderFunc>
   static ProjectGrid<T> project(const SOM<ND, DistFunc>& som, InputIter begin, InputIter end, WeightFunc weight_func,
-                                UncertaintyFunc uncertainty_func,
-                                AdderFunc adder_func, const T& init_cell = T{});
-
+                                UncertaintyFunc uncertainty_func, AdderFunc adder_func, const T& init_cell = T{});
 };
 
-}
-}
+}  // namespace SOM
+}  // namespace Euclid
 
 #include "SOM/_impl/SOMProjector.icpp"
 
 #endif /* SOM_SOMPROJECTOR_H */
-

--- a/SOM/SOM/SOMTrainer.h
+++ b/SOM/SOM/SOMTrainer.h
@@ -24,9 +24,9 @@
 #ifndef SOM_SOMTRAINER_H
 #define SOM_SOMTRAINER_H
 
-#include "SOM/SOM.h"
-#include "SOM/NeighborhoodFunc.h"
 #include "SOM/LearningRestraintFunc.h"
+#include "SOM/NeighborhoodFunc.h"
+#include "SOM/SOM.h"
 #include "SOM/SamplingPolicy.h"
 
 namespace Euclid {
@@ -35,19 +35,15 @@ namespace SOM {
 class SOMTrainer {
 
 public:
-
-  SOMTrainer(NeighborhoodFunc::Signature neighborhood_func,
-             LearningRestraintFunc::Signature learning_restraint_func)
-          : m_neighborhood_func(neighborhood_func),
-            m_learning_restraint_func(learning_restraint_func) {
-  }
+  SOMTrainer(NeighborhoodFunc::Signature neighborhood_func, LearningRestraintFunc::Signature learning_restraint_func)
+      : m_neighborhood_func(neighborhood_func), m_learning_restraint_func(learning_restraint_func) {}
 
   template <std::size_t ND, typename DistFunc, typename InputIter, typename InputToWeightFunc>
   void train(SOM<ND, DistFunc>& som, std::size_t iter_no, InputIter begin, InputIter end, InputToWeightFunc weight_func,
-             const SamplingPolicy::Interface<InputIter>& sampling_policy=SamplingPolicy::FullSet<InputIter>{}) {
+             const SamplingPolicy::Interface<InputIter>& sampling_policy = SamplingPolicy::FullSet<InputIter>{}) {
 
     // We repeat the training for iter_no iterations
-    for (std::size_t i = 0; i < iter_no; ++ i) {
+    for (std::size_t i = 0; i < iter_no; ++i) {
 
       // Compute the factor of the current iteration
       auto learn_factor = m_learning_restraint_func(i, iter_no);
@@ -64,40 +60,35 @@ public:
         // Find the coordinates of the BMU for the input
         std::size_t bmu_x;
         std::size_t bmu_y;
-        double nd_distance;
+        double      nd_distance;
         std::tie(bmu_x, bmu_y, nd_distance) = som.findBMU(*it, weight_func);
 
         // Now go through all the cells and update their values according their coordinates
-        for (auto cell_it = som.begin(); cell_it != som.end(); ++ cell_it) {
+        for (auto cell_it = som.begin(); cell_it != som.end(); ++cell_it) {
 
           // Compute the factor based on the distance of the BMU and the cell
-          auto cell_x = cell_it.template axisValue<0>();
-          auto cell_y = cell_it.template axisValue<1>();
+          auto cell_x              = cell_it.template axisValue<0>();
+          auto cell_y              = cell_it.template axisValue<1>();
           auto neighborhood_factor = m_neighborhood_func({bmu_x, bmu_y}, {cell_x, cell_y}, i, iter_no);
 
           // Get the weights of the cell and update them
           if (neighborhood_factor != 0) {
             auto& cell_weights = *cell_it;
             for (std::size_t wi = 0; wi < ND; ++wi) {
-              cell_weights[wi] =
-                cell_weights[wi] + neighborhood_factor * learn_factor * (input_weights[wi] - cell_weights[wi]);
+              cell_weights[wi] = cell_weights[wi] + neighborhood_factor * learn_factor * (input_weights[wi] - cell_weights[wi]);
             }
           }
-
         }
       }
     }
   }
 
 private:
-
-  NeighborhoodFunc::Signature m_neighborhood_func;
+  NeighborhoodFunc::Signature      m_neighborhood_func;
   LearningRestraintFunc::Signature m_learning_restraint_func;
-
 };
 
-}
-}
+}  // namespace SOM
+}  // namespace Euclid
 
 #endif /* SOM_SOMTRAINER_H */
-

--- a/SOM/SOM/SamplingPolicy.h
+++ b/SOM/SOM/SamplingPolicy.h
@@ -24,10 +24,10 @@
 #ifndef SOM_SAMPLINGPOLICY_H
 #define SOM_SAMPLINGPOLICY_H
 
-#include <list>
-#include <utility>
-#include <random>
 #include <iterator>
+#include <list>
+#include <random>
+#include <utility>
 
 namespace Euclid {
 namespace SOM {
@@ -37,18 +37,15 @@ template <typename IterType>
 class Interface {
 
 public:
-
   virtual IterType start(IterType begin, IterType end) const = 0;
 
   virtual IterType next(IterType iter) const = 0;
-
 };
 
 template <typename IterType>
 class FullSet : public Interface<IterType> {
 
 public:
-
   IterType start(IterType begin, IterType) const override {
     return begin;
   }
@@ -56,22 +53,20 @@ public:
   IterType next(IterType iter) const override {
     return ++iter;
   }
-
 };
 
 template <typename IterType>
 class Bootstrap : public Interface<IterType> {
 
-  public:
-
+public:
   IterType start(IterType begin, IterType end) const override {
 
     m_end = end;
 
-    std::random_device rd;
-    std::mt19937 gen(rd());
+    std::random_device              rd;
+    std::mt19937                    gen(rd());
     std::uniform_int_distribution<> dis(0, std::distance(begin, end) - 1);
-    auto random_index = dis(gen);
+    auto                            random_index = dis(gen);
 
     auto result = begin;
     std::advance(result, random_index);
@@ -84,9 +79,7 @@ class Bootstrap : public Interface<IterType> {
   }
 
 private:
-
   mutable IterType m_end;
-
 };
 
 template <typename IterType>
@@ -95,10 +88,9 @@ Bootstrap<IterType> bootstrapFactory(IterType) {
 }
 
 template <typename IterType>
-class Jackknife :public Interface<IterType> {
+class Jackknife : public Interface<IterType> {
 
 public:
-
   explicit Jackknife(std::size_t sample_size) : m_sample_size(sample_size), m_current(sample_size) {
     m_iter_list.reserve(sample_size);
   }
@@ -112,27 +104,27 @@ public:
     m_iter_list.reserve(m_sample_size);
 
     // Put all the possible iterators in a temporary linked list
-    std::list<IterType> all_iter_list {};
+    std::list<IterType> all_iter_list{};
     for (auto it = begin; it != end; ++it) {
       all_iter_list.push_back(it);
     }
 
     // Create the random device to use
     std::random_device rd;
-    std::mt19937 gen(rd());
+    std::mt19937       gen(rd());
 
     // Pick up m_sample_size random iterators from the temporary list
     int all_max_index = all_iter_list.size() - 1;
     for (std::size_t i = 0; i < m_sample_size && all_max_index >= 0; ++i, --all_max_index) {
       std::uniform_int_distribution<> dis(0, all_max_index);
-      auto it = all_iter_list.begin();
+      auto                            it = all_iter_list.begin();
       std::advance(it, dis(gen));
       m_iter_list.push_back(*it);
       all_iter_list.erase(it);
     }
 
     // Set the current iterator at the beginning of the vector and return it
-    m_current = 0;
+    m_current        = 0;
     m_iter_list_size = m_iter_list.size();
     return m_iter_list[m_current];
   }
@@ -146,13 +138,11 @@ public:
   }
 
 private:
-
-  std::size_t m_sample_size;
+  std::size_t                   m_sample_size;
   mutable std::vector<IterType> m_iter_list;
-  mutable std::size_t m_iter_list_size;
-  mutable IterType m_end;
-  mutable std::size_t m_current;
-
+  mutable std::size_t           m_iter_list_size;
+  mutable IterType              m_end;
+  mutable std::size_t           m_current;
 };
 
 template <typename IterType>
@@ -160,9 +150,8 @@ Jackknife<IterType> jackknifeFactory(IterType, std::size_t sample_size) {
   return Jackknife<IterType>{sample_size};
 }
 
-}
-}
-}
+}  // namespace SamplingPolicy
+}  // namespace SOM
+}  // namespace Euclid
 
 #endif /* SOM_SAMPLINGPOLICY_H */
-

--- a/SOM/SOM/UMatrix.h
+++ b/SOM/SOM/UMatrix.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
  * @file UMatrix.h
  * @author nikoapos
  */
@@ -32,17 +32,14 @@ namespace SOM {
 
 using UMatrix = GridContainer::GridContainer<std::vector<double>, std::size_t, std::size_t>;
 
-enum class UMatrixType {
-  MIN, MAX, MEAN
-};
+enum class UMatrixType { MIN, MAX, MEAN };
 
-template <std::size_t ND, typename DistFunc=Distance::L2<ND>>
-UMatrix computeUMatrix(const SOM<ND, DistFunc>& som, UMatrixType type=UMatrixType::MEAN);
+template <std::size_t ND, typename DistFunc = Distance::L2<ND>>
+UMatrix computeUMatrix(const SOM<ND, DistFunc>& som, UMatrixType type = UMatrixType::MEAN);
 
-}
-}
+}  // namespace SOM
+}  // namespace Euclid
 
 #include "SOM/_impl/UMatrix.icpp"
 
 #endif /* SOM_UMATRIX_H */
-

--- a/SOM/SOM/_impl/SOM.icpp
+++ b/SOM/SOM/_impl/SOM.icpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
  * @file SOM.icpp
  * @author nikoapos
  */
@@ -28,7 +28,7 @@ namespace SOM {
 
 template <std::size_t ND, typename DistFunc>
 SOM<ND, DistFunc>::SOM(std::size_t x, std::size_t y, InitFunc::Signature init_func)
-        : m_cells(ImplTools::indexAxis("X", x), ImplTools::indexAxis("Y", y)), m_size(x, y) {
+    : m_cells(ImplTools::indexAxis("X", x), ImplTools::indexAxis("Y", y)), m_size(x, y) {
 
   // Initialize all the grid cells using the given function
   for (auto& array : m_cells) {
@@ -37,7 +37,7 @@ SOM<ND, DistFunc>::SOM(std::size_t x, std::size_t y, InitFunc::Signature init_fu
     }
   }
 
-} // end of namespace SOM_impl
+}  // end of namespace SOM_impl
 
 template <std::size_t ND, typename DistFunc>
 const std::pair<std::size_t, std::size_t>& SOM<ND, DistFunc>::getSize() const {
@@ -87,64 +87,61 @@ typename SOM<ND, DistFunc>::const_iterator SOM<ND, DistFunc>::cend() {
 namespace SOM_impl {
 
 template <std::size_t ND, typename DistFunc>
-std::tuple<std::size_t, std::size_t, double> findBMU_impl(const SOM<ND, DistFunc>& som,
-        std::function<double(const std::array<double, ND>&)> dist_func) {
-  auto result_iter = som.begin();
+std::tuple<std::size_t, std::size_t, double> findBMU_impl(const SOM<ND, DistFunc>&                             som,
+                                                          std::function<double(const std::array<double, ND>&)> dist_func) {
+  auto   result_iter      = som.begin();
   double closest_distance = std::numeric_limits<double>::max();
   for (auto iter = som.begin(); iter != som.end(); ++iter) {
     double dist = dist_func(*iter);
     if (dist < closest_distance) {
-      result_iter = iter;
+      result_iter      = iter;
       closest_distance = dist;
     }
   }
   return std::make_tuple(result_iter.template axisValue<0>(), result_iter.template axisValue<1>(), closest_distance);
 }
 
-} // end of namespace SOM_impl
+}  // end of namespace SOM_impl
 
 template <std::size_t ND, typename DistFunc>
 std::tuple<std::size_t, std::size_t, double> SOM<ND, DistFunc>::findBMU(const std::array<double, ND>& input) const {
-  DistFunc dist_func {};
-  return SOM_impl::findBMU_impl<ND, DistFunc>(*this, [&dist_func, &input](const std::array<double, ND>& cell) -> double {
-    return dist_func.distance(cell, input);
-  });
+  DistFunc dist_func{};
+  return SOM_impl::findBMU_impl<ND, DistFunc>(
+      *this, [&dist_func, &input](const std::array<double, ND>& cell) -> double { return dist_func.distance(cell, input); });
 }
 
 template <std::size_t ND, typename DistFunc>
 std::tuple<std::size_t, std::size_t, double> SOM<ND, DistFunc>::findBMU(const std::array<double, ND>& input,
-                                                               const std::array<double, ND>& uncertainties) const {
-  DistFunc dist_func {};
-  return SOM_impl::findBMU_impl<ND, DistFunc>(*this, [&dist_func, &input, &uncertainties](const std::array<double, ND>& cell) -> double {
-    return dist_func.distance(cell, input, uncertainties);
-  });
+                                                                        const std::array<double, ND>& uncertainties) const {
+  DistFunc dist_func{};
+  return SOM_impl::findBMU_impl<ND, DistFunc>(*this,
+                                              [&dist_func, &input, &uncertainties](const std::array<double, ND>& cell) -> double {
+                                                return dist_func.distance(cell, input, uncertainties);
+                                              });
 }
 
 template <std::size_t ND, typename DistFunc>
 template <typename InputType, typename WeightFunc>
-std::tuple<std::size_t, std::size_t, double> SOM<ND, DistFunc>::findBMU(const InputType& input,
-                                                               WeightFunc weight_func) const {
-  
+std::tuple<std::size_t, std::size_t, double> SOM<ND, DistFunc>::findBMU(const InputType& input, WeightFunc weight_func) const {
+
   static_assert(std::is_same<decltype(std::declval<WeightFunc>()(input)), std::array<double, ND>>::value,
-          "WeightFunc must be callable with input as parameter, returning an std::array<double, ND>");
-  
+                "WeightFunc must be callable with input as parameter, returning an std::array<double, ND>");
+
   return findBMU(weight_func(input));
 }
 
 template <std::size_t ND, typename DistFunc>
 template <typename InputType, typename WeightFunc, typename UncertaintyFunc>
-std::tuple<std::size_t, std::size_t, double> SOM<ND, DistFunc>::findBMU(const InputType& input,
-                                                               WeightFunc weight_func,
-                                                               UncertaintyFunc uncertainty_func) const {
-  
+std::tuple<std::size_t, std::size_t, double> SOM<ND, DistFunc>::findBMU(const InputType& input, WeightFunc weight_func,
+                                                                        UncertaintyFunc uncertainty_func) const {
+
   static_assert(std::is_same<decltype(std::declval<WeightFunc>()(input)), std::array<double, ND>>::value,
-          "WeightFunc must be callable with input as parameter, returning an std::array<double, ND>");
+                "WeightFunc must be callable with input as parameter, returning an std::array<double, ND>");
   static_assert(std::is_same<decltype(std::declval<UncertaintyFunc>()(input)), std::array<double, ND>>::value,
-          "UncertaintyFunc must be callable with input as parameter, returning an std::array<double, ND>");
-  
+                "UncertaintyFunc must be callable with input as parameter, returning an std::array<double, ND>");
+
   return findBMU(weight_func(input), uncertainty_func(input));
 }
 
-}
-}
-
+}  // namespace SOM
+}  // namespace Euclid

--- a/SOM/SOM/_impl/SOMProjector.icpp
+++ b/SOM/SOM/_impl/SOMProjector.icpp
@@ -1,28 +1,28 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
  * @file SOMProjector.icpp
  * @author nikoapos
  */
 
-#include <tuple>
 #include "SOM/ImplTools.h"
+#include <tuple>
 
 namespace Euclid {
 namespace SOM {
@@ -30,59 +30,60 @@ namespace SOM {
 namespace SOMProjector_impl {
 
 template <typename T, std::size_t ND, typename DistFunc, typename InputIter, typename AdderFunc, typename BmuFunc>
-SOMProjector::ProjectGrid<T> project_impl(const SOM<ND, DistFunc>& som, InputIter begin, InputIter end,
-                                          AdderFunc adder_func, BmuFunc bmu_func, const T& init_cell) {
-  
+SOMProjector::ProjectGrid<T> project_impl(const SOM<ND, DistFunc>& som, InputIter begin, InputIter end, AdderFunc adder_func,
+                                          BmuFunc bmu_func, const T& init_cell) {
+
   // Create the grid to return
-  auto size = som.getSize();
-  SOMProjector::ProjectGrid<T> result {ImplTools::indexAxis("X", size.first), ImplTools::indexAxis("Y", size.second)};
-  
+  auto                         size = som.getSize();
+  SOMProjector::ProjectGrid<T> result{ImplTools::indexAxis("X", size.first), ImplTools::indexAxis("Y", size.second)};
+
   // Set all the cells to the default value
   for (auto& cell : result) {
     cell = init_cell;
   }
-  
+
   // Iterate through all the inputs and project them to the result
   for (auto it = begin; it != end; ++it) {
     auto& input = *it;
-    
+
     // Get the BMU coordinates
     std::size_t x;
     std::size_t y;
-    double dist;
+    double      dist;
     std::tie(x, y, dist) = bmu_func(input);
-    
+
     // Project the input to the result cell
     adder_func(result(x, y), input);
   }
-  
+
   return result;
 }
 
-}
+}  // namespace SOMProjector_impl
 
 template <typename T, std::size_t ND, typename DistFunc, typename InputIter, typename WeightFunc, typename AdderFunc>
-SOMProjector::ProjectGrid<T> SOMProjector::project(const SOM<ND, DistFunc>& som, InputIter begin, InputIter end, WeightFunc weight_func,
-                                                   AdderFunc adder_func, const T& init_cell) {
-  
-  auto bmu_func = [&som, &weight_func](const typename std::iterator_traits<InputIter>::value_type & input) {
+SOMProjector::ProjectGrid<T> SOMProjector::project(const SOM<ND, DistFunc>& som, InputIter begin, InputIter end,
+                                                   WeightFunc weight_func, AdderFunc adder_func, const T& init_cell) {
+
+  auto bmu_func = [&som, &weight_func](const typename std::iterator_traits<InputIter>::value_type& input) {
     return som.findBMU(input, weight_func);
   };
-  
+
   return SOMProjector_impl::project_impl(som, begin, end, adder_func, bmu_func, init_cell);
 }
 
-template <typename T, std::size_t ND, typename DistFunc, typename InputIter, typename WeightFunc, typename UncertaintyFunc, typename AdderFunc>
-SOMProjector::ProjectGrid<T> SOMProjector::project(const SOM<ND, DistFunc>& som, InputIter begin, InputIter end, WeightFunc weight_func,
-                                                   UncertaintyFunc uncertainty_func, AdderFunc adder_func, const T& init_cell) {
-  
-  auto bmu_func = [&som, &weight_func, &uncertainty_func](const typename std::iterator_traits<InputIter>::value_type & input) {
+template <typename T, std::size_t ND, typename DistFunc, typename InputIter, typename WeightFunc, typename UncertaintyFunc,
+          typename AdderFunc>
+SOMProjector::ProjectGrid<T> SOMProjector::project(const SOM<ND, DistFunc>& som, InputIter begin, InputIter end,
+                                                   WeightFunc weight_func, UncertaintyFunc uncertainty_func, AdderFunc adder_func,
+                                                   const T& init_cell) {
+
+  auto bmu_func = [&som, &weight_func, &uncertainty_func](const typename std::iterator_traits<InputIter>::value_type& input) {
     return som.findBMU(input, weight_func, uncertainty_func);
   };
-  
+
   return SOMProjector_impl::project_impl(som, begin, end, adder_func, bmu_func, init_cell);
 }
 
-}
-}
-
+}  // namespace SOM
+}  // namespace Euclid

--- a/SOM/SOM/_impl/UMatrix.icpp
+++ b/SOM/SOM/_impl/UMatrix.icpp
@@ -1,76 +1,65 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
  * @file UMatrix.icpp
  * @author nikoapos
  */
 
-#include <numeric>
+#include "SOM/ImplTools.h"
 #include <algorithm>
 #include <map>
-#include "SOM/ImplTools.h"
+#include <numeric>
 
 namespace Euclid {
 namespace SOM {
 
 namespace UMatrix_impl {
 
-std::map<UMatrixType, std::function<double(const std::vector<double>&)>> type_func_map {
-  {UMatrixType::MIN,
-          [](const std::vector<double>& dist_list) {
-            return *std::min_element(dist_list.begin(), dist_list.end());
-          }
-  },
-  {UMatrixType::MAX,
-          [](const std::vector<double>& dist_list) {
-            return *std::max_element(dist_list.begin(), dist_list.end());
-          }
-  },
-  {UMatrixType::MEAN,
-          [](const std::vector<double>& dist_list) {
-            return std::accumulate(dist_list.begin(), dist_list.end(), 0.) / dist_list.size();
-          }
-  }
-};
+std::map<UMatrixType, std::function<double(const std::vector<double>&)>> type_func_map{
+    {UMatrixType::MIN, [](const std::vector<double>& dist_list) { return *std::min_element(dist_list.begin(), dist_list.end()); }},
+    {UMatrixType::MAX, [](const std::vector<double>& dist_list) { return *std::max_element(dist_list.begin(), dist_list.end()); }},
+    {UMatrixType::MEAN, [](const std::vector<double>& dist_list) {
+       return std::accumulate(dist_list.begin(), dist_list.end(), 0.) / dist_list.size();
+     }}};
 
 }
 
 template <std::size_t ND, typename DistFunc>
 UMatrix computeUMatrix(const SOM<ND, DistFunc>& som, UMatrixType type) {
-  
-  DistFunc dist_func {};
-  
-  auto size = som.getSize();
+
+  DistFunc dist_func{};
+
+  auto    size   = som.getSize();
   UMatrix result = UMatrix(ImplTools::indexAxis("X", size.first), ImplTools::indexAxis("Y", size.second));
-  
+
   // Chose the method used for computing the u-matrix values
   auto type_func = UMatrix_impl::type_func_map.at(type);
-  
+
   // Go through the SOM cells and compute the u-matrix cells
   for (std::size_t x = 0; x < size.first; ++x) {
     for (std::size_t y = 0; y < size.second; ++y) {
-      
+
       // Go through the neighbor cells and create the vector with the distances
-      std::vector<double> dist_list {};
+      std::vector<double> dist_list{};
       for (int i = int(x) - 1; i <= (int)x + 1; ++i) {
-        for (int j = int(y) - 1; j <= (int)y + 1; ++ j) {
-          
+        for (int j = int(y) - 1; j <= (int)y + 1; ++j) {
+
           // Check that we are not at the cell itself
           if (i == (int)x && j == (int)y) {
             continue;
@@ -79,19 +68,18 @@ UMatrix computeUMatrix(const SOM<ND, DistFunc>& som, UMatrixType type) {
           if (i < 0 || i == (int)size.first || j < 0 || j == (int)size.second) {
             continue;
           }
-          
+
           dist_list.push_back(dist_func.distance(som(x, y), som(i, j)));
         }
       }
-      
+
       // Populate the u-matrix cell
       result(x, y) = type_func(dist_list);
     }
   }
-  
+
   return result;
 }
 
-}
-}
-
+}  // namespace SOM
+}  // namespace Euclid

--- a/SOM/SOM/serialization/SOM.h
+++ b/SOM/SOM/serialization/SOM.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
  * @file SOM.h
  * @author nikoapos
  */
@@ -24,12 +24,12 @@
 #ifndef SOM_SERIALIZATION_SOM_H
 #define SOM_SERIALIZATION_SOM_H
 
-#include <typeinfo>
-#include <boost/serialization/string.hpp>
-#include <boost/serialization/split_free.hpp>
-#include "ElementsKernel/Exception.h"
 #include "AlexandriaKernel/serialization/array.h"
+#include "ElementsKernel/Exception.h"
 #include "SOM/SOM.h"
+#include <boost/serialization/split_free.hpp>
+#include <boost/serialization/string.hpp>
+#include <typeinfo>
 
 namespace boost {
 namespace serialization {
@@ -67,18 +67,17 @@ void load_construct_data(Archive& ar, Euclid::SOM::SOM<ND, DistFunc>* t, const u
   std::string dist_func_type;
   ar >> dist_func_type;
   if (dist_func_type != typeid(DistFunc).name()) {
-    throw Elements::Exception() << "Incompatible DistFunc parameter. File contains SOM with "
-            << dist_func_type << " and is read as " << typeid(DistFunc).name();
+    throw Elements::Exception() << "Incompatible DistFunc parameter. File contains SOM with " << dist_func_type
+                                << " and is read as " << typeid(DistFunc).name();
   }
   std::size_t x;
   ar >> x;
   std::size_t y;
   ar >> y;
-  ::new(t) Euclid::SOM::SOM<ND, DistFunc>(x,  y);
+  ::new (t) Euclid::SOM::SOM<ND, DistFunc>(x, y);
 }
 
-}
-}
+}  // namespace serialization
+}  // namespace boost
 
 #endif /* SOM_SERIALIZATION_SOM_H */
-

--- a/SOM/SOM/serialize.h
+++ b/SOM/SOM/serialize.h
@@ -24,22 +24,22 @@
 #ifndef SOM_SERIALIZE_H
 #define SOM_SERIALIZE_H
 
-#include <iostream>
-#include <boost/archive/binary_iarchive.hpp>
-#include <boost/archive/binary_oarchive.hpp>
-#include <CCfits/CCfits>
 #include "ElementsKernel/Exception.h"
 #include "SOM/Distance.h"
 #include "SOM/serialization/SOM.h"
+#include <CCfits/CCfits>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <iostream>
 
 namespace Euclid {
 namespace SOM {
 
-template<typename OArchive, std::size_t ND, typename DistFunc>
-void somExport(std::ostream& out, const SOM <ND, DistFunc>& som) {
+template <typename OArchive, std::size_t ND, typename DistFunc>
+void somExport(std::ostream& out, const SOM<ND, DistFunc>& som) {
   // Do NOT delete this pointer!!! It  points to the actual som
-  const SOM<ND, DistFunc> *ptr = &som;
-  OArchive boa{out};
+  const SOM<ND, DistFunc>* ptr = &som;
+  OArchive                 boa{out};
   boa << ptr;
 }
 
@@ -48,19 +48,19 @@ void somBinaryExport(std::ostream& out, const SOM<ND, DistFunc>& som) {
   somExport<boost::archive::binary_oarchive>(out, som);
 }
 
-template <typename IArchive, std::size_t ND, typename DistFunc=Distance::L2<ND>>
+template <typename IArchive, std::size_t ND, typename DistFunc = Distance::L2<ND>>
 SOM<ND, DistFunc> somImport(std::istream& in) {
-  IArchive bia {in};
+  IArchive bia{in};
   // Do NOT delete manually this pointer. It is wrapped with a unique_ptr later.
   SOM<ND, DistFunc>* ptr;
   bia >> ptr;
-  std::unique_ptr<SOM<ND, DistFunc>> smart_ptr {ptr};
+  std::unique_ptr<SOM<ND, DistFunc>> smart_ptr{ptr};
   // We move out to the result the som pointed by the pointer. The unique_ptr
   // will delete the (now empty) pointed object
   return std::move(*smart_ptr);
 }
 
-template <std::size_t ND, typename DistFunc=Distance::L2<ND>>
+template <std::size_t ND, typename DistFunc = Distance::L2<ND>>
 SOM<ND, DistFunc> somBinaryImport(std::istream& in) {
   return somImport<boost::archive::binary_iarchive, ND, DistFunc>(in);
 }
@@ -69,20 +69,20 @@ template <std::size_t ND, typename DistFunc>
 void somFitsExport(const std::string& filename, const SOM<ND, DistFunc>& som) {
 
   // Create the output file and the array HDU
-  int n_axes = 3;
+  int         n_axes = 3;
   std::size_t x;
   std::size_t y;
-  std::tie(x, y) = som.getSize();
-  long ax_sizes[3] = {(long)x, (long)y, (long)ND};
-  CCfits::FITS fits (filename, DOUBLE_IMG, n_axes, ax_sizes);
+  std::tie(x, y)           = som.getSize();
+  long         ax_sizes[3] = {(long)x, (long)y, (long)ND};
+  CCfits::FITS fits(filename, DOUBLE_IMG, n_axes, ax_sizes);
 
   // Write in the header the DistFunc type
   fits.pHDU().addKey("DISTFUNC", typeid(DistFunc).name(), "");
 
   // Create a valarray with the SOM data
-  std::size_t total_size = x * y * ND;
-  std::valarray<double> data (total_size);
-  int i = 0;
+  std::size_t           total_size = x * y * ND;
+  std::valarray<double> data(total_size);
+  int                   i = 0;
   for (std::size_t w_i = 0; w_i < ND; ++w_i) {
     for (auto& w_arr : som) {
       data[i] = w_arr[w_i];
@@ -90,20 +90,19 @@ void somFitsExport(const std::string& filename, const SOM<ND, DistFunc>& som) {
     }
   }
   fits.pHDU().write(1, total_size, data);
-
 }
 
-template <std::size_t ND, typename DistFunc=Distance::L2<ND>>
+template <std::size_t ND, typename DistFunc = Distance::L2<ND>>
 SOM<ND, DistFunc> somFitsImport(const std::string& filename) {
 
-  CCfits::FITS fits (filename, CCfits::Read);
+  CCfits::FITS fits(filename, CCfits::Read);
 
   // Check that the type of the DistFunc is correct
   std::string dist_func_type;
   fits.pHDU().readKey("DISTFUNC", dist_func_type);
   if (dist_func_type != typeid(DistFunc).name()) {
-    throw Elements::Exception() << "Incompatible DistFunc parameter. File contains SOM with "
-            << dist_func_type << " and is read as " << typeid(DistFunc).name();
+    throw Elements::Exception() << "Incompatible DistFunc parameter. File contains SOM with " << dist_func_type
+                                << " and is read as " << typeid(DistFunc).name();
   }
 
   // Get the dimensions of the data in the file
@@ -111,8 +110,8 @@ SOM<ND, DistFunc> somFitsImport(const std::string& filename) {
     throw Elements::Exception() << "Data array in file " << filename << " does not have 3 dimensions";
   }
   if (fits.pHDU().axis(2) != ND) {
-    throw Elements::Exception() << "Weights dimension of array in file " << filename <<
-            " should have size " << ND << " but was " << fits.pHDU().axis(2);
+    throw Elements::Exception() << "Weights dimension of array in file " << filename << " should have size " << ND << " but was "
+                                << fits.pHDU().axis(2);
   }
   std::size_t x = fits.pHDU().axis(0);
   std::size_t y = fits.pHDU().axis(1);
@@ -122,8 +121,8 @@ SOM<ND, DistFunc> somFitsImport(const std::string& filename) {
   fits.pHDU().read(data);
 
   // Copy the data in a SOM object
-  SOM<ND, DistFunc> result {x, y};
-  int i = 0;
+  SOM<ND, DistFunc> result{x, y};
+  int               i = 0;
   for (std::size_t w_i = 0; w_i < ND; ++w_i) {
     for (auto& w_arr : result) {
       w_arr[w_i] = data[i];
@@ -134,8 +133,7 @@ SOM<ND, DistFunc> somFitsImport(const std::string& filename) {
   return std::move(result);
 }
 
-}
-}
+}  // namespace SOM
+}  // namespace Euclid
 
 #endif /* SOM_SERIALIZE_H */
-

--- a/SOM/src/lib/ImplTools.cpp
+++ b/SOM/src/lib/ImplTools.cpp
@@ -21,7 +21,6 @@
  * @author nikoapos
  */
 
-
 #include "SOM/ImplTools.h"
 #include "GridContainer/GridAxis.h"
 
@@ -37,7 +36,6 @@ GridContainer::GridAxis<std::size_t> indexAxis(const std::string& name, std::siz
   return GridContainer::GridAxis<std::size_t>{name, std::move(indices)};
 }
 
-}
-}
-}
-
+}  // namespace ImplTools
+}  // namespace SOM
+}  // namespace Euclid

--- a/SOM/tests/src/SOM_serialization_test.cpp
+++ b/SOM/tests/src/SOM_serialization_test.cpp
@@ -22,17 +22,17 @@
  * @author Alejandro Alvarez Ayllon
  */
 
-#include <sstream>
-#include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
+#include <boost/mpl/list.hpp>
+#include <boost/test/unit_test.hpp>
+#include <sstream>
 
+#include "SOM/InitFunc.h"
 #include "SOM/SOM.h"
 #include "SOM/SOMTrainer.h"
-#include "SOM/InitFunc.h"
 #include "SOM/serialize.h"
 
 using namespace Euclid::SOM;
@@ -49,24 +49,19 @@ std::ostream& operator<<(std::ostream& out, const std::pair<size_t, size_t>& pai
   out << '[' << pair.first << ", " << pair.second << ']';
   return out;
 }
-}
+}  // namespace std
 
 struct SerializationFixture {
-  SOM<2> m_som {5, 5, InitFunc::uniformRandom(0, 1)};
+  SOM<2> m_som{5, 5, InitFunc::uniformRandom(0, 1)};
 
   SerializationFixture() {
     m_som.findBMU({1, 2});
     m_som.findBMU({1, 2}, {0.1, 0.4});
 
-    std::vector <std::pair<double, double>> trainset{
-      {1, 1},
-      {0, 0},
-      {0, 1},
-      {1, 0}
-    };
+    std::vector<std::pair<double, double>> trainset{{1, 1}, {0, 0}, {0, 1}, {1, 0}};
 
     SOMTrainer trainer{NeighborhoodFunc::linearUnitDisk(3), LearningRestraintFunc::linear()};
-    auto weight_func = [](const std::pair<double, double>& p) {
+    auto       weight_func = [](const std::pair<double, double>& p) {
       std::array<double, 2> res;
       res[0] = p.first;
       res[1] = p.second;
@@ -78,7 +73,7 @@ struct SerializationFixture {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (SOM_test)
+BOOST_AUTO_TEST_SUITE(SOM_test)
 
 template <typename I, typename O>
 struct archive {
@@ -87,7 +82,7 @@ struct archive {
 };
 
 typedef archive<boost::archive::binary_iarchive, boost::archive::binary_oarchive> binary_archive;
-typedef archive<boost::archive::text_iarchive, boost::archive::text_oarchive> text_archive;
+typedef archive<boost::archive::text_iarchive, boost::archive::text_oarchive>     text_archive;
 
 typedef boost::mpl::list<binary_archive, text_archive> archive_types;
 
@@ -105,4 +100,4 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(serialize_som_test, T, archive_types, Serializa
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/SOM/tests/src/SOM_test.cpp
+++ b/SOM/tests/src/SOM_test.cpp
@@ -24,10 +24,10 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include "SOM/SOM.h"
-#include "SOM/SOMTrainer.h"
 #include "SOM/InitFunc.h"
+#include "SOM/SOM.h"
 #include "SOM/SOMProjector.h"
+#include "SOM/SOMTrainer.h"
 #include "SOM/UMatrix.h"
 
 #include <iostream>
@@ -36,22 +36,20 @@ using namespace Euclid::SOM;
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (SOM_test)
+BOOST_AUTO_TEST_SUITE(SOM_test)
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_CASE( example_test ) {
+BOOST_AUTO_TEST_CASE(example_test) {
 
-  SOM<2> som {5, 5, InitFunc::uniformRandom(0, 1)};
-  som.findBMU({1,2});
-  som.findBMU({1,2}, {0.1, 0.4});
+  SOM<2> som{5, 5, InitFunc::uniformRandom(0, 1)};
+  som.findBMU({1, 2});
+  som.findBMU({1, 2}, {0.1, 0.4});
 
-  std::vector<std::pair<double,double>> trainset {
-    {1,1}, {0,0}, {0,1}, {1,0}
-  };
+  std::vector<std::pair<double, double>> trainset{{1, 1}, {0, 0}, {0, 1}, {1, 0}};
 
-  SOMTrainer trainer {NeighborhoodFunc::linearUnitDisk(3), LearningRestraintFunc::linear()};
-  auto weight_func = [](const std::pair<double,double>& p) {
+  SOMTrainer trainer{NeighborhoodFunc::linearUnitDisk(3), LearningRestraintFunc::linear()};
+  auto       weight_func = [](const std::pair<double, double>& p) {
     std::array<double, 2> res;
     res[0] = p.first;
     res[1] = p.second;
@@ -59,21 +57,15 @@ BOOST_AUTO_TEST_CASE( example_test ) {
   };
   trainer.train(som, 5, trainset.begin(), trainset.end(), weight_func);
 
-
-  auto adder = [](int& cell, const std::pair<double, double>&) {
-    cell += 1;
-  };
+  auto adder      = [](int& cell, const std::pair<double, double>&) { cell += 1; };
   auto projection = SOMProjector::project<int>(som, trainset.begin(), trainset.end(), weight_func, adder);
-  for (auto it=projection.begin(); it!= projection.end(); ++it) {
+  for (auto it = projection.begin(); it != projection.end(); ++it) {
     std::cout << '(' << it.axisValue<0>() << ',' << it.axisValue<1>() << ") : " << *it << '\n';
   }
 
   auto u_matrix = computeUMatrix(som);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/SourceCatalog/SourceCatalog/Attribute.h
+++ b/SourceCatalog/SourceCatalog/Attribute.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file SourceCatalog/Attribute.h
  *
  * Created on: Jan 20, 2014
@@ -40,11 +40,10 @@ namespace SourceCatalog {
  */
 class Attribute {
 public:
-  virtual ~Attribute() { }
-
+  virtual ~Attribute() {}
 };
 
-} // namespace ChDataModel 
-} // end of namespace Euclid
+}  // namespace SourceCatalog
+}  // end of namespace Euclid
 
-#endif // ATTRIBUTE_H_ 
+#endif  // ATTRIBUTE_H_

--- a/SourceCatalog/SourceCatalog/AttributeFromRow.h
+++ b/SourceCatalog/SourceCatalog/AttributeFromRow.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file SourceCatalog/AttributeFromRow.h
  *
  * @date Apr 17, 2014
@@ -45,8 +45,7 @@ namespace SourceCatalog {
 class AttributeFromRow {
 
 public:
-  virtual ~AttributeFromRow() {
-  }
+  virtual ~AttributeFromRow() {}
 
   /**
    * @brief The createAttribute method for creating an Attribute from a Table row
@@ -54,12 +53,10 @@ public:
    * @param row A reference to a Row of a Table
    * @return A unique pointer to the newly created Attribute
    */
-  virtual std::unique_ptr<Attribute> createAttribute(
-      const Euclid::Table::Row& row) = 0;
-
+  virtual std::unique_ptr<Attribute> createAttribute(const Euclid::Table::Row& row) = 0;
 };
 
-} // namespace SourceCatalog 
-} // end of namespace Euclid
+}  // namespace SourceCatalog
+}  // end of namespace Euclid
 
-#endif // ATTRIBUTEHANDLER_H_ 
+#endif  // ATTRIBUTEHANDLER_H_

--- a/SourceCatalog/SourceCatalog/Catalog.h
+++ b/SourceCatalog/SourceCatalog/Catalog.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file SourceCatalog/Catalog.h
  *
  * @author Nicolas Morisset
@@ -44,11 +44,9 @@ namespace SourceCatalog {
  *  Catalog contains a container of sources
  *
  */
-class ELEMENTS_API Catalog
-{
+class ELEMENTS_API Catalog {
 
 public:
-
   /**
    * @brief
    *  Build a catalog of Source objects
@@ -79,7 +77,9 @@ public:
    *  Returns a const_iterator pointing to the first element in the m_source_vector
    *  container
    */
-  const_iterator begin() const { return m_source_vector.cbegin() ; }
+  const_iterator begin() const {
+    return m_source_vector.cbegin();
+  }
 
   /**
    * @brief
@@ -89,7 +89,9 @@ public:
    *  Returns a const_iterator pointing to the past-the-end element in the
    *  m_source_vector container
    */
-  const_iterator end() const { return m_source_vector.cend() ; }
+  const_iterator end() const {
+    return m_source_vector.cend();
+  }
 
   /**
    * @brief
@@ -100,7 +102,7 @@ public:
    * A shared pointer to the Source object or a null pointer in case of
    * no object was found for this source_id
    */
-  std::shared_ptr<Source> find(const Source::id_type &source_id) const;
+  std::shared_ptr<Source> find(const Source::id_type& source_id) const;
 
   /**
    * @brief
@@ -108,18 +110,19 @@ public:
    * @return
    *  The size of the container which is the number of Source objects
    */
-  size_t size() const { return m_source_vector.size();}
+  size_t size() const {
+    return m_source_vector.size();
+  }
 
 private:
   // Vector of Source objects
-  std::vector<Source>        m_source_vector { };
+  std::vector<Source> m_source_vector{};
   // Map of the Source identification and their location
   // in the Source vector
-  std::map<Source::id_type, size_t> m_source_index_map { };
-
+  std::map<Source::id_type, size_t> m_source_index_map{};
 };
 
 } /* namespace SourceCatalog */
-} // end of namespace Euclid
+}  // end of namespace Euclid
 
 #endif /* CATALOG_H_ */

--- a/SourceCatalog/SourceCatalog/CatalogFromTable.h
+++ b/SourceCatalog/SourceCatalog/CatalogFromTable.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file SourceCatalog/CatalogFromTable.h
  *
  * Created on: Apr 15, 2014
@@ -24,25 +24,23 @@
  */
 #ifndef CATALOGFACTORY_H_
 #define CATALOGFACTORY_H_
-#include <string>
-#include <utility>
 #include <map>
 #include <memory>
+#include <string>
+#include <utility>
 
 #include "ElementsKernel/Export.h"
 
-#include "SourceCatalog/Catalog.h"
 #include "SourceCatalog/AttributeFromRow.h"
+#include "SourceCatalog/Catalog.h"
 #include "Table/Table.h"
-
 
 namespace Euclid {
 namespace SourceCatalog {
 
 class ELEMENTS_API CatalogFromTable {
 public:
-  CatalogFromTable(std::shared_ptr<Euclid::Table::ColumnInfo> column_info_ptr,
-                   const std::string& source_id_column_name,
+  CatalogFromTable(std::shared_ptr<Euclid::Table::ColumnInfo> column_info_ptr, const std::string& source_id_column_name,
                    std::vector<std::shared_ptr<AttributeFromRow>> attribute_from_row_ptr_vector);
 
   virtual ~CatalogFromTable();
@@ -53,10 +51,9 @@ private:
   size_t m_source_id_index;
 
   std::vector<std::shared_ptr<AttributeFromRow>> m_attribute_from_row_ptr_vector;
-
 };
 
-} // namespace SourceCatalog
-} // end of namespace Euclid
+}  // namespace SourceCatalog
+}  // end of namespace Euclid
 
-#endif // CATALOGFACTORY_H_
+#endif  // CATALOGFACTORY_H_

--- a/SourceCatalog/SourceCatalog/PhotometryParsingException.h
+++ b/SourceCatalog/SourceCatalog/PhotometryParsingException.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file SourceCatalog/PhotometryParsingException.h
  *
  * Created on: Jan 20, 2017
@@ -25,35 +25,34 @@
 #ifndef PHOTOMETRYPARSINGEXCEPTION_H_
 #define PHOTOMETRYPARSINGEXCEPTION_H_
 
-#include <string>
 #include "ElementsKernel/Exception.h"
+#include <string>
 
 namespace Euclid {
 namespace SourceCatalog {
 
-
-class PhotometryParsingException: public Elements::Exception {
+class PhotometryParsingException : public Elements::Exception {
 public:
-
-  explicit  PhotometryParsingException(const char* message, double flux, double error):
-  Elements::Exception(message),m_flux(flux),m_error(error){
+  explicit PhotometryParsingException(const char* message, double flux, double error)
+      : Elements::Exception(message), m_flux(flux), m_error(error) {
     *this << " ( Flux=" << flux << ", Error=" << error << ")";
   }
 
-  virtual ~PhotometryParsingException() noexcept { }
+  virtual ~PhotometryParsingException() noexcept {}
 
-  const double & GetFlux() const {return m_flux;}
-  const double & GetError() const {return m_error;}
+  const double& GetFlux() const {
+    return m_flux;
+  }
+  const double& GetError() const {
+    return m_error;
+  }
 
 private:
-
   double m_flux;
   double m_error;
-
-
 };
 
-} // namespace ChDataModel
-} // end of namespace Euclid
+}  // namespace SourceCatalog
+}  // end of namespace Euclid
 
-#endif // PHOTOMETRYPARSINGEXCEPTION_H_
+#endif  // PHOTOMETRYPARSINGEXCEPTION_H_

--- a/SourceCatalog/SourceCatalog/Source.h
+++ b/SourceCatalog/SourceCatalog/Source.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file SourceCatalog/Source.h
  *
  * Created on: Jan 21, 2014
@@ -25,17 +25,17 @@
 #ifndef SOURCE_H_
 #define SOURCE_H_
 
+#include <boost/variant.hpp>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
-#include <boost/variant.hpp>
 
 #include "ElementsKernel/Exception.h"
 
+#include "SourceCatalog/Attribute.h"
+#include "SourceCatalog/SourceAttributes/Coordinates.h"
 #include "SourceCatalog/SourceAttributes/Photometry.h"
 #include "SourceCatalog/SourceAttributes/SpectroscopicRedshift.h"
-#include "SourceCatalog/SourceAttributes/Coordinates.h"
-#include "SourceCatalog/Attribute.h"
 
 namespace Euclid {
 namespace SourceCatalog {
@@ -48,7 +48,7 @@ namespace SourceCatalog {
 class Source {
 
 public:
-    typedef boost::variant<int64_t, std::string> id_type;
+  typedef boost::variant<int64_t, std::string> id_type;
 
   /**
    * @brief Constructor
@@ -58,11 +58,10 @@ public:
    * Vector of shared pointers on Attribute objects
    */
   Source(id_type source_id, std::vector<std::shared_ptr<Attribute>> attributeVector)
-        : m_source_id(source_id), m_attribute_vector( std::move(attributeVector) ) {
-  }
+      : m_source_id(source_id), m_attribute_vector(std::move(attributeVector)) {}
 
   /// Virtual default destructor
-  virtual ~Source() { }
+  virtual ~Source() {}
 
   /**
    * @brief Get the source ID
@@ -85,18 +84,15 @@ public:
    * @return The pointer to the attribute or nullptr if the attribute is
    *  not found
    */
-  template<typename T>
+  template <typename T>
   std::shared_ptr<T> getAttribute() const;
 
-
- private:
-
+private:
   // Source identification
-  id_type m_source_id { };
+  id_type m_source_id{};
 
   // Vector of shared pointers to attribute
   std::vector<std::shared_ptr<Attribute>> m_attribute_vector;
-
 };
 // Eof class Source
 
@@ -106,7 +102,7 @@ public:
  * This type can be used together with boost::apply_visitor to cast boost::variant
  * with an unknown underlying type, to a Source::id_type
  */
-class CastSourceIdVisitor: public boost::static_visitor<Source::id_type> {
+class CastSourceIdVisitor : public boost::static_visitor<Source::id_type> {
   template <typename From>
   static constexpr bool is_integer() {
     return std::is_integral<From>::value && !std::is_same<From, bool>::value;
@@ -115,19 +111,19 @@ class CastSourceIdVisitor: public boost::static_visitor<Source::id_type> {
 public:
   CastSourceIdVisitor() {}
 
-  Source::id_type operator() (const std::string &from) const {
+  Source::id_type operator()(const std::string& from) const {
     return from;
   }
 
   template <typename From>
-  Source::id_type operator() (const From &from, typename std::enable_if<is_integer<From>()>::type* = 0) const {
+  Source::id_type operator()(const From& from, typename std::enable_if<is_integer<From>()>::type* = 0) const {
     return Source::id_type(static_cast<int64_t>(from));
   }
 
   template <typename From>
-  Source::id_type operator() (const From &, typename std::enable_if<!is_integer<From>()>::type* = 0) const {
-    throw Elements::Exception() << "Only std::string and int64_t are supported types for a source ID, got "
-                                << typeid(From).name() << " instead";
+  Source::id_type operator()(const From&, typename std::enable_if<!is_integer<From>()>::type* = 0) const {
+    throw Elements::Exception() << "Only std::string and int64_t are supported types for a source ID, got " << typeid(From).name()
+                                << " instead";
   }
 };
 
@@ -136,7 +132,7 @@ public:
 #undef SOURCE_IMPL
 
 } /* namespace SourceCatalog */
-} // end of namespace Euclid
+}  // end of namespace Euclid
 
 #if BOOST_VERSION < 105800
 namespace boost {
@@ -146,12 +142,11 @@ namespace boost {
  *  boost::variant specifies an equality operator (==), but, in older boost versions, *not* an inequality one
  *  CCfits expects != to be defined, so we do it here
  */
-inline bool operator!=(const Euclid::SourceCatalog::Source::id_type& a,
-  const Euclid::SourceCatalog::Source::id_type& b) {
+inline bool operator!=(const Euclid::SourceCatalog::Source::id_type& a, const Euclid::SourceCatalog::Source::id_type& b) {
   return !(a == b);
 }
 
-}
+}  // namespace boost
 #endif
 
 #endif /* SOURCE_H_ */

--- a/SourceCatalog/SourceCatalog/SourceAttributes/Coordinates.h
+++ b/SourceCatalog/SourceCatalog/SourceAttributes/Coordinates.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file SourceCatalog/SourceAttributes/Coordinates.h
  *
  * Created on: Jan 22, 2014
@@ -43,17 +43,20 @@ public:
   Coordinates(double ra, double dec) : m_ra(ra), m_dec(dec) {}
   virtual ~Coordinates() {}
 
-  double getDec() const { return m_dec; }
+  double getDec() const {
+    return m_dec;
+  }
 
-  double getRa() const { return m_ra; }
+  double getRa() const {
+    return m_ra;
+  }
 
 private:
-  double m_ra {};
-  double m_dec {};
-
+  double m_ra{};
+  double m_dec{};
 };
 
-} // namespace SourceCatalog
-} // end of namespace Euclid
+}  // namespace SourceCatalog
+}  // end of namespace Euclid
 
-#endif // COORDINATES_H_ 
+#endif  // COORDINATES_H_

--- a/SourceCatalog/SourceCatalog/SourceAttributes/Pdf.h
+++ b/SourceCatalog/SourceCatalog/SourceAttributes/Pdf.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /*
+/*
  * Copyright (C) 2012-2020 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
@@ -42,11 +42,11 @@
 #ifndef SOURCE_CATALOG_PDF_H
 #define SOURCE_CATALOG_PDF_H
 
+#include "GridContainer/GridContainer.h"
+#include "SourceCatalog/Attribute.h"
 #include <map>
 #include <string>
 #include <vector>
-#include "GridContainer/GridContainer.h"
-#include "SourceCatalog/Attribute.h"
 
 namespace Euclid {
 namespace SourceCatalog {
@@ -55,10 +55,9 @@ template <typename T>
 class Pdf : public Attribute {
 
 public:
-
   using PdfType = GridContainer::GridContainer<std::vector<double>, T>;
 
-  explicit Pdf(std::map<std::string, PdfType> pdfs) : m_pdfs(std::move(pdfs)) { }
+  explicit Pdf(std::map<std::string, PdfType> pdfs) : m_pdfs(std::move(pdfs)) {}
 
   virtual ~Pdf() = default;
 
@@ -67,13 +66,10 @@ public:
   }
 
 private:
-
   std::map<std::string, PdfType> m_pdfs;
-
 };
 
-}
-}
+}  // namespace SourceCatalog
+}  // namespace Euclid
 
 #endif /* SOURCE_CATALOG_PDF_H */
-

--- a/SourceCatalog/SourceCatalog/SourceAttributes/PdfFromRow.h
+++ b/SourceCatalog/SourceCatalog/SourceAttributes/PdfFromRow.h
@@ -1,40 +1,40 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */
- 
- /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
- * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
  * @file PdfFromRow.h
  * @author nikoapos
  */
@@ -42,65 +42,59 @@
 #ifndef SOURCECATALOG_PDFFROMROW_H
 #define SOURCECATALOG_PDFFROMROW_H
 
+#include "AlexandriaKernel/memory_tools.h"
+#include "ElementsKernel/Exception.h"
+#include "SourceCatalog/AttributeFromRow.h"
+#include "SourceCatalog/SourceAttributes/Pdf.h"
+#include "Table/CastVisitor.h"
 #include <map>
 #include <string>
 #include <vector>
-#include "ElementsKernel/Exception.h"
-#include "AlexandriaKernel/memory_tools.h"
-#include "Table/CastVisitor.h"
-#include "SourceCatalog/AttributeFromRow.h"
-#include "SourceCatalog/SourceAttributes/Pdf.h"
 
 namespace Euclid {
 namespace SourceCatalog {
 
 template <typename T>
 class PdfFromRow : public AttributeFromRow {
-  
+
 public:
-  
-  PdfFromRow(std::map<std::string, std::vector<T>> keys,
-             std::map<std::string, std::string> column_names)
-          : m_keys(std::move(keys)), m_column_names(std::move(column_names)) {
-  }
-  
+  PdfFromRow(std::map<std::string, std::vector<T>> keys, std::map<std::string, std::string> column_names)
+      : m_keys(std::move(keys)), m_column_names(std::move(column_names)) {}
+
   virtual ~PdfFromRow() = default;
 
   std::unique_ptr<Attribute> createAttribute(const Euclid::Table::Row& row) override {
-    std::map<std::string, typename Pdf<T>::PdfType> pdf_map {};
-    
+    std::map<std::string, typename Pdf<T>::PdfType> pdf_map{};
+
     for (auto& pair : m_keys) {
       // Use the key values to create the axis of the PDF
-      GridContainer::GridAxis<T> axis {pair.first, pair.second};
+      GridContainer::GridAxis<T> axis{pair.first, pair.second};
       // Create a PDF with zero values
-      typename Pdf<T>::PdfType pdf {axis};
-      
+      typename Pdf<T>::PdfType pdf{axis};
+
       // Get the PDF data from the row
       auto& col_name = m_column_names.at(pair.first);
-      auto data = boost::apply_visitor(Table::CastVisitor<std::vector<double>>{}, row[col_name]);
+      auto  data     = boost::apply_visitor(Table::CastVisitor<std::vector<double>>{}, row[col_name]);
       if (data.size() != pdf.size()) {
         throw Elements::Exception() << "Incompatible PDF size";
       }
-      
+
       // Copy the data in the PDF
       std::copy(data.begin(), data.end(), pdf.begin());
-      
+
       // Put the PDF in the map
       pdf_map.emplace(pair.first, std::move(pdf));
     }
-    
+
     return make_unique<Pdf<T>>(std::move(pdf_map));
   }
 
 private:
-  
   std::map<std::string, std::vector<T>> m_keys;
-  std::map<std::string, std::string> m_column_names;
-  
+  std::map<std::string, std::string>    m_column_names;
 };
 
-}
-}
+}  // namespace SourceCatalog
+}  // namespace Euclid
 
 #endif /* SOURCECATALOG_PDFFROMROW_H */
-

--- a/SourceCatalog/SourceCatalog/SourceAttributes/Photometry.h
+++ b/SourceCatalog/SourceCatalog/SourceAttributes/Photometry.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file SourceCatalog/SourceAttributes/Photometry.h
  *
  * Created on: Jan 17, 2014
@@ -26,12 +26,12 @@
 #ifndef PHOTOMETRY_H_
 #define PHOTOMETRY_H_
 
+#include <iterator>
 #include <memory>
 #include <vector>
-#include <iterator>
 
-#include "ElementsKernel/Export.h"
 #include "ElementsKernel/Exception.h"
+#include "ElementsKernel/Export.h"
 
 #include "SourceCatalog/Attribute.h"
 
@@ -43,8 +43,7 @@ struct FluxErrorPair {
   double error;
   bool   missing_photometry_flag;
   bool   upper_limit_flag;
-  FluxErrorPair(double flux, double error, bool missing_photometry_flag=false,
-                bool upper_limit_flag=false);
+  FluxErrorPair(double flux, double error, bool missing_photometry_flag = false, bool upper_limit_flag = false);
   FluxErrorPair(const FluxErrorPair&) = default;
   bool operator==(const FluxErrorPair& other) const;
   bool operator!=(const FluxErrorPair& other) const;
@@ -64,27 +63,26 @@ struct FluxErrorPair {
  * Always use the PhotometryAttributeHandler to build Photometry objects.
  *
  */
-class ELEMENTS_API Photometry: public Attribute {
+class ELEMENTS_API Photometry : public Attribute {
 
 public:
-
   /**
    * Iterator class, implemented as a template to avoid repetition for const and non const iterators
    * @tparam Const
    *    A boolean. If true, this will be a const iterator
    */
-  template<bool Const>
+  template <bool Const>
   class PhotometryIterator : public std::iterator<std::forward_iterator_tag,
-    typename std::conditional<Const, const FluxErrorPair, FluxErrorPair>::type> {
+                                                  typename std::conditional<Const, const FluxErrorPair, FluxErrorPair>::type> {
   public:
     using value_t = typename std::conditional<Const, const FluxErrorPair, FluxErrorPair>::type;
     using typename std::iterator<std::forward_iterator_tag, value_t>::reference;
     using typename std::iterator<std::forward_iterator_tag, value_t>::pointer;
 
-    using filters_iter_t = typename std::conditional<
-      Const, std::vector<std::string>::const_iterator, std::vector<std::string>::iterator>::type;
-    using values_iter_t = typename std::conditional<
-      Const, std::vector<FluxErrorPair>::const_iterator, std::vector<FluxErrorPair>::iterator>::type;
+    using filters_iter_t =
+        typename std::conditional<Const, std::vector<std::string>::const_iterator, std::vector<std::string>::iterator>::type;
+    using values_iter_t =
+        typename std::conditional<Const, std::vector<FluxErrorPair>::const_iterator, std::vector<FluxErrorPair>::iterator>::type;
 
     /**
      * Constructor from non-const iterator
@@ -99,12 +97,12 @@ public:
     /**
      * @return true if this iterator and other point to the same position
      */
-    bool operator == (const PhotometryIterator& other) const;
+    bool operator==(const PhotometryIterator& other) const;
 
     /**
      * @return true if this iterator and other do *not* point to the same position
      */
-    bool operator != (const PhotometryIterator& other) const;
+    bool operator!=(const PhotometryIterator& other) const;
 
     /**
      * @return A reference to the FluxErrorPair pointed by this iterator
@@ -114,12 +112,12 @@ public:
     /**
      * @return A pointer to the FluxErrorPair pointed by this iterator
      */
-    pointer operator ->();
+    pointer operator->();
 
     /**
      * @return The number of elements between this iterator and other
      */
-    ssize_t operator - (const PhotometryIterator& other) const;
+    ssize_t operator-(const PhotometryIterator& other) const;
 
     /**
      * @return The filter name corresponding to this FluxErrorPair
@@ -140,12 +138,11 @@ public:
 
   private:
     filters_iter_t m_filters_iter;
-    values_iter_t m_values_iter;
+    values_iter_t  m_values_iter;
   };
 
-  typedef PhotometryIterator<true> const_iterator;
+  typedef PhotometryIterator<true>  const_iterator;
   typedef PhotometryIterator<false> iterator;
-
 
   /**
    * @brief Constructor which should never be called directly. Use the
@@ -157,17 +154,14 @@ public:
    *  the vector of ValuePair, i..e, the flux values with their errors
    *
    */
-  Photometry(std::shared_ptr<std::vector<std::string>> filter_name_vector_ptr,
-      std::vector<FluxErrorPair> value_vector) :
-      m_filter_name_vector_ptr(filter_name_vector_ptr), m_value_vector(
-          std::move(value_vector)) {
+  Photometry(std::shared_ptr<std::vector<std::string>> filter_name_vector_ptr, std::vector<FluxErrorPair> value_vector)
+      : m_filter_name_vector_ptr(filter_name_vector_ptr), m_value_vector(std::move(value_vector)) {
     if (m_filter_name_vector_ptr == nullptr) {
       throw Elements::Exception() << "Photometry filter names vector pointer is null";
     }
     // Only check the size, but not the consistency
     if (m_filter_name_vector_ptr->size() != m_value_vector.size()) {
-      throw Elements::Exception()
-          << "Photometry filter names vector has different size than the values vector";
+      throw Elements::Exception() << "Photometry filter names vector has different size than the values vector";
     }
   }
 
@@ -220,13 +214,11 @@ public:
   const std::shared_ptr<std::vector<std::string>>& getFilterNames() const;
 
 private:
-
   /// Shared pointer to the common list of filter names
   std::shared_ptr<std::vector<std::string>> m_filter_name_vector_ptr;
 
   /// The photometry map
   std::vector<FluxErrorPair> m_value_vector;
-
 };
 // Eof class Photometry
 
@@ -235,6 +227,6 @@ private:
 #undef PHOTOMETRY_IMPL
 
 } /* namespace SourceCatalog */
-} // end of namespace Euclid
+}  // end of namespace Euclid
 
 #endif /* PHOTOMETRY_H_ */

--- a/SourceCatalog/SourceCatalog/SourceAttributes/PhotometryAttributeFromRow.h
+++ b/SourceCatalog/SourceCatalog/SourceAttributes/PhotometryAttributeFromRow.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file SourceCatalog/SourceAttributes/PhotometryAttributeFromRow.h
  *
  * @date Apr 17, 2014
@@ -26,10 +26,9 @@
 #ifndef PHOTOMETRYATTRIBUTEFROMROW_H_
 #define PHOTOMETRYATTRIBUTEFROMROW_H_
 #include <map>
-#include <utility>
-#include <string>
 #include <memory>
-
+#include <string>
+#include <utility>
 
 #include "ElementsKernel/Export.h"
 
@@ -39,7 +38,6 @@
 
 namespace Euclid {
 namespace SourceCatalog {
-
 
 /**
  * @class PhotometryAttributeFromRow
@@ -81,13 +79,11 @@ public:
    * @exception
    *  An exception is thrown if the names provided in the mapping are not present in the columnInfo.
    */
-  PhotometryAttributeFromRow(std::shared_ptr<Euclid::Table::ColumnInfo> column_info_ptr,
-      const std::vector<std::pair<std::string, std::pair<std::string, std::string>>>& filter_name_mapping,
-      const bool missing_photometry_enabled,
-      const double missing_photometry_flag,
-      const bool upper_limit_enabled,
-      const std::vector<std::pair<std::string, float>> n_map,
-      const double n_upper_limit_flag);
+  PhotometryAttributeFromRow(std::shared_ptr<Euclid::Table::ColumnInfo>                                      column_info_ptr,
+                             const std::vector<std::pair<std::string, std::pair<std::string, std::string>>>& filter_name_mapping,
+                             const bool missing_photometry_enabled, const double missing_photometry_flag,
+                             const bool upper_limit_enabled, const std::vector<std::pair<std::string, float>> n_map,
+                             const double n_upper_limit_flag);
 
   virtual ~PhotometryAttributeFromRow();
 
@@ -103,7 +99,7 @@ private:
   /*
    * Map the correspondence between the filterName and the indexes used in the Table columns
    */
-  std::vector<std::pair<size_t, size_t> > m_table_index_vector;
+  std::vector<std::pair<size_t, size_t>> m_table_index_vector;
 
   /*
    * Pointer to the shared filter name vector
@@ -122,10 +118,9 @@ private:
   std::vector<std::pair<std::string, float>> m_n_map;
 
   double m_n_upper_limit_flag;
-
 };
 
-} // namespace SourceCatalog
-} // end of namespace Euclid
+}  // namespace SourceCatalog
+}  // end of namespace Euclid
 
-#endif // PHOTOMETRYATTRIBUTEFROMROW_H_
+#endif  // PHOTOMETRYATTRIBUTEFROMROW_H_

--- a/SourceCatalog/SourceCatalog/SourceAttributes/SpectroscopicRedshift.h
+++ b/SourceCatalog/SourceCatalog/SourceAttributes/SpectroscopicRedshift.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file SourceCatalog/SourceAttributes/SpectroscopicRedshift.h
  *
  * @date Jan 16, 2014
@@ -39,28 +39,30 @@ namespace SourceCatalog {
  */
 class SpectroscopicRedshift : public Attribute {
 public:
-
   /**
- * @brief Constructor
- * @param value
- *  Value of the redshift
- * @param error
- *  Error value of the value parameter
- */
+   * @brief Constructor
+   * @param value
+   *  Value of the redshift
+   * @param error
+   *  Error value of the value parameter
+   */
   SpectroscopicRedshift(double value, double error) : m_value(value), m_error(error) {}
 
   virtual ~SpectroscopicRedshift() {}
 
-  double getValue() const { return m_value; }
-  double getError() const { return m_error; }
+  double getValue() const {
+    return m_value;
+  }
+  double getError() const {
+    return m_error;
+  }
 
 private:
-
-  double m_value {};
-  double m_error {};
+  double m_value{};
+  double m_error{};
 };
 
-} // namespace SourceCatalog
-} // end of namespace Euclid
+}  // namespace SourceCatalog
+}  // end of namespace Euclid
 
-#endif // SPECTROSCOPICREDSHIFT_H_ 
+#endif  // SPECTROSCOPICREDSHIFT_H_

--- a/SourceCatalog/SourceCatalog/SourceAttributes/SpectroscopicRedshiftAttributeFromRow.h
+++ b/SourceCatalog/SourceCatalog/SourceAttributes/SpectroscopicRedshiftAttributeFromRow.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file SourceCatalog/SourceAttributes/SpectroscopicRedshiftAttributeFromRow.h
  *
  * @date Apr 17, 2014
@@ -26,16 +26,15 @@
 #ifndef SPECTROSCOPICATTRIBUTEFROMROW_H_
 #define SPECTROSCOPICATTRIBUTEFROMROW_H_
 #include <map>
-#include <utility>
-#include <string>
 #include <memory>
+#include <string>
+#include <utility>
 
 #include "ElementsKernel/Logging.h"
 #include "SourceCatalog/AttributeFromRow.h"
 #include "SourceCatalog/Catalog.h"
-#include "Table/Table.h"
 #include "Table/CastVisitor.h"
-
+#include "Table/Table.h"
 
 namespace Euclid {
 namespace SourceCatalog {
@@ -50,7 +49,7 @@ static Elements::Logging logger = Elements::Logging::getLogger("SpectroscopicRed
  * create SpectroscopicRedshift objects.
  *
  */
-class SpectroscopicRedshiftAttributeFromRow: public AttributeFromRow {
+class SpectroscopicRedshiftAttributeFromRow : public AttributeFromRow {
 public:
   /**
    * @brief Create a SpectroscopicRedshiftAttributeFromRow object
@@ -73,8 +72,7 @@ public:
    *  An exception is thrown if the names provided in the mapping are not present in the columnInfo.
    */
   SpectroscopicRedshiftAttributeFromRow(std::shared_ptr<Euclid::Table::ColumnInfo> column_info_ptr,
-                                        const std::string&                         specz_value_column_name,
-                                        const std::string&                         specz_error_column_name) {
+                                        const std::string& specz_value_column_name, const std::string& specz_error_column_name) {
 
     std::unique_ptr<size_t> specz_value_column_index_ptr = column_info_ptr->find(specz_value_column_name);
     if (specz_value_column_index_ptr == nullptr) {
@@ -86,11 +84,10 @@ public:
       throw Elements::Exception() << "Column info does not have the spectroscopic redshift error column!";
     }
 
-    m_has_error_column=true;
+    m_has_error_column   = true;
     m_error_column_index = *(specz_error_column_index_ptr);
     m_value_column_index = *(specz_value_column_index_ptr);
-
- }
+  }
 
   /**
    * @brief Create a SpectroscopicRedshiftAttributeFromRow object
@@ -109,25 +106,23 @@ public:
    * @exception
    *  An exception is thrown if the names provided in the mapping are not present in the columnInfo.
    */
- SpectroscopicRedshiftAttributeFromRow(std::shared_ptr<Euclid::Table::ColumnInfo> column_info_ptr,
-                                       const std::string&                         specz_value_column_name) {
+  SpectroscopicRedshiftAttributeFromRow(std::shared_ptr<Euclid::Table::ColumnInfo> column_info_ptr,
+                                        const std::string&                         specz_value_column_name) {
 
     std::unique_ptr<size_t> specz_value_column_index_ptr = column_info_ptr->find(specz_value_column_name);
     if (specz_value_column_index_ptr == nullptr) {
       throw Elements::Exception() << "Column info does not have the spectroscopic redshift value column!";
     }
 
-    m_has_error_column=false;
+    m_has_error_column   = false;
     m_error_column_index = 0;
     m_value_column_index = *(specz_value_column_index_ptr);
 
     // Log a warning as row is set to zero
     logger.warn() << "specz error values are set to zero by default! ";
- }
-
-  virtual ~SpectroscopicRedshiftAttributeFromRow() {
-
   }
+
+  virtual ~SpectroscopicRedshiftAttributeFromRow() {}
 
   /**
    * @brief Create a photometricAttribute from a Table row
@@ -141,7 +136,7 @@ public:
     if (m_has_error_column) {
       e = boost::apply_visitor(Table::CastVisitor<double>{}, row[m_error_column_index]);
     }
-    return std::unique_ptr<Attribute> {new SpectroscopicRedshift {z, e}};
+    return std::unique_ptr<Attribute>{new SpectroscopicRedshift{z, e}};
   }
 
 private:
@@ -151,11 +146,9 @@ private:
   size_t m_value_column_index;
   bool   m_has_error_column;
   size_t m_error_column_index;
-
 };
 
+}  // namespace SourceCatalog
+}  // end of namespace Euclid
 
-} // namespace SourceCatalog
-} // end of namespace Euclid
-
-#endif // SPECTROSCOPICATTRIBUTEFROMROW_H_
+#endif  // SPECTROSCOPICATTRIBUTEFROMROW_H_

--- a/SourceCatalog/SourceCatalog/SourceAttributes/TableRowAttribute.h
+++ b/SourceCatalog/SourceCatalog/SourceAttributes/TableRowAttribute.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /*
+/*
  * Copyright (C) 2012-2020 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
@@ -42,8 +42,8 @@
 #ifndef _SOURCECATALOG_SOURCEATTRIBUTES_TABLEROWATTRIBUTE_H
 #define _SOURCECATALOG_SOURCEATTRIBUTES_TABLEROWATTRIBUTE_H
 
-#include "Table/Row.h"
 #include "SourceCatalog/Attribute.h"
+#include "Table/Row.h"
 
 namespace Euclid {
 namespace SourceCatalog {
@@ -54,10 +54,9 @@ namespace SourceCatalog {
  * @brief Source attribute which can be used to retrieve the table row used
  * to create the source
  */
-class TableRowAttribute  : public Attribute {
+class TableRowAttribute : public Attribute {
 
 public:
-
   /// Constructs a new TableRowAttribute with the given row
   explicit TableRowAttribute(Table::Row row);
 
@@ -68,13 +67,10 @@ public:
   const Table::Row& getRow() const;
 
 private:
-
   Table::Row m_row;
-
 };
 
-} // namespace SourceCatalog
-} // end of namespace Euclid
+}  // namespace SourceCatalog
+}  // end of namespace Euclid
 
 #endif /* _SOURCECATALOG_SOURCEATTRIBUTES_TABLEROWATTRIBUTE_H */
-

--- a/SourceCatalog/SourceCatalog/SourceAttributes/TableRowAttributeFromRow.h
+++ b/SourceCatalog/SourceCatalog/SourceAttributes/TableRowAttributeFromRow.h
@@ -1,40 +1,40 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */
- 
- /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
- * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
  * @file TableRowAttributeFromRow.h
  * @author nikoapos
  */
@@ -49,24 +49,21 @@ namespace SourceCatalog {
 
 /**
  * @class TableRowAttributeFromRow
- * 
+ *
  * @brief Implementation of the AttributeFromRow interfaces for the
  * TableRowAttribute
  */
 class TableRowAttributeFromRow : public AttributeFromRow {
-  
+
 public:
-  
   /// Destructor
   virtual ~TableRowAttributeFromRow() = default;
-  
+
   /// Create a TableRowAttribute from the given row
   std::unique_ptr<Attribute> createAttribute(const Euclid::Table::Row& row) override;
-  
 };
 
-} // namespace SourceCatalog
-} // end of namespace Euclid
+}  // namespace SourceCatalog
+}  // end of namespace Euclid
 
 #endif /* _SOURCECATALOG_SOURCEATTRIBUTES_TABLEROWATTRIBUTEFROMROW_H */
-

--- a/SourceCatalog/SourceCatalog/_impl/Photometry.icpp
+++ b/SourceCatalog/SourceCatalog/_impl/Photometry.icpp
@@ -21,50 +21,47 @@
 //-----------------------------------------------------------------------------
 // Implementation of the iterator
 
-template<bool Const>
-Photometry::PhotometryIterator<Const>::PhotometryIterator(const filters_iter_t& filters_iter,
-                                                          const values_iter_t& values_iter)
-  : m_filters_iter{filters_iter}, m_values_iter{values_iter} {
-}
+template <bool Const>
+Photometry::PhotometryIterator<Const>::PhotometryIterator(const filters_iter_t& filters_iter, const values_iter_t& values_iter)
+    : m_filters_iter{filters_iter}, m_values_iter{values_iter} {}
 
-template<bool Const>
+template <bool Const>
 Photometry::PhotometryIterator<Const>::PhotometryIterator(const PhotometryIterator<false>& other)
-  : m_filters_iter{other.m_filters_iter}, m_values_iter{other.m_values_iter} {
-}
+    : m_filters_iter{other.m_filters_iter}, m_values_iter{other.m_values_iter} {}
 
-template<bool Const>
+template <bool Const>
 Photometry::PhotometryIterator<Const>& Photometry::PhotometryIterator<Const>::operator++() {
   ++m_filters_iter;
   ++m_values_iter;
   return *this;
 }
 
-template<bool Const>
+template <bool Const>
 bool Photometry::PhotometryIterator<Const>::operator==(const PhotometryIterator& other) const {
   return m_filters_iter == other.m_filters_iter;
 }
 
-template<bool Const>
+template <bool Const>
 bool Photometry::PhotometryIterator<Const>::operator!=(const PhotometryIterator& other) const {
   return m_filters_iter != other.m_filters_iter;
 }
 
-template<bool Const>
+template <bool Const>
 auto Photometry::PhotometryIterator<Const>::operator*() -> reference {
   return *m_values_iter;
 }
 
-template<bool Const>
+template <bool Const>
 auto Photometry::PhotometryIterator<Const>::operator->() -> pointer {
   return m_values_iter.operator->();
 }
 
-template<bool Const>
+template <bool Const>
 ssize_t Photometry::PhotometryIterator<Const>::operator-(const PhotometryIterator& other) const {
   return m_values_iter - other.m_values_iter;
 }
 
-template<bool Const>
+template <bool Const>
 const std::string& Photometry::PhotometryIterator<Const>::filterName() const {
   return *m_filters_iter;
 }

--- a/SourceCatalog/SourceCatalog/_impl/Source.icpp
+++ b/SourceCatalog/SourceCatalog/_impl/Source.icpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file SourceCatalog/_impl/Source.icpp
  *
  * Created on: Jan 22, 2014
@@ -27,9 +27,9 @@
 
 #ifdef SOURCE_IMPL
 
-template<typename T>
+template <typename T>
 std::shared_ptr<T> Source::getAttribute() const {
-  std::shared_ptr<T> result {};
+  std::shared_ptr<T> result{};
   // loop over all source attribute
   for (auto attribute_ptr : m_attribute_vector) {
     result = std::dynamic_pointer_cast<T>(attribute_ptr);

--- a/SourceCatalog/src/lib/Catalog.cpp
+++ b/SourceCatalog/src/lib/Catalog.cpp
@@ -16,56 +16,50 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * Catalog.cpp
  *
  *  Created on : Feb 4, 2014
  *      Author : Nicolas Morisset
  */
 
-
 #include "SourceCatalog/Catalog.h"
 #include "SourceCatalog/Source.h"
 
 #include "ElementsKernel/Exception.h"
-
 
 namespace Euclid {
 namespace SourceCatalog {
 
 //-----------------------------------------------------------------------------
 // Constructor
-Catalog::Catalog(std::vector<Source> source_vector): m_source_vector(source_vector)
-{
+Catalog::Catalog(std::vector<Source> source_vector) : m_source_vector(source_vector) {
   // Set the m_indices_map map
-  for (size_t index=0; index < m_source_vector.size(); ++index) {
-     auto it = m_source_index_map.emplace(m_source_vector[index].getId(), index);
-     // Make sure the element does not already exist
-     if (!it.second)
-     {
-       throw Elements::Exception() << "Euclid::SourceCatalog::Catalog: Source object already exist "
-             << "in the map for source ID : " << m_source_vector[index].getId() << ", index: " << index;
-     }
+  for (size_t index = 0; index < m_source_vector.size(); ++index) {
+    auto it = m_source_index_map.emplace(m_source_vector[index].getId(), index);
+    // Make sure the element does not already exist
+    if (!it.second) {
+      throw Elements::Exception() << "Euclid::SourceCatalog::Catalog: Source object already exist "
+                                  << "in the map for source ID : " << m_source_vector[index].getId() << ", index: " << index;
+    }
   }
-} // Eof Euclid::SourceCatalog::Catalog
-
+}  // Eof Euclid::SourceCatalog::Catalog
 
 //-----------------------------------------------------------------------------
 // find source in the map
 // return source otherwise null pointer
-std::shared_ptr<Source> Catalog::find(const Source::id_type &source_id) const
-{
+std::shared_ptr<Source> Catalog::find(const Source::id_type& source_id) const {
   std::shared_ptr<Source> ptr(nullptr);
-  auto it = m_source_index_map.find(source_id);
+  auto                    it = m_source_index_map.find(source_id);
   if (it != m_source_index_map.end()) {
     ptr = std::make_shared<Source>(m_source_vector[it->second]);
   }
 
   return ptr;
 
-} // Eof Catalog::find
+}  // Eof Catalog::find
 
 //-----------------------------------------------------------------------------
 
 } /* namespace SourceCatalog */
-} // end of namespace Euclid
+}  // end of namespace Euclid

--- a/SourceCatalog/src/lib/CatalogFromTable.cpp
+++ b/SourceCatalog/src/lib/CatalogFromTable.cpp
@@ -16,26 +16,24 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/CatalogFromTable.cpp
  *
  * Created on: Apr 16, 2014
  *     Author: Pierre Dubath
  */
-#include <vector>
 #include "SourceCatalog/CatalogFromTable.h"
 #include "SourceCatalog/SourceAttributes/Photometry.h"
-#include "Table/ColumnInfo.h"
 #include "Table/CastVisitor.h"
-
+#include "Table/ColumnInfo.h"
+#include <vector>
 
 namespace Euclid {
 namespace SourceCatalog {
 
-CatalogFromTable::CatalogFromTable(
-    std::shared_ptr<Euclid::Table::ColumnInfo> column_info_ptr,
-    const std::string& source_id_column_name,
-    std::vector<std::shared_ptr<AttributeFromRow>> attribute_from_row_ptr_vector) {
+CatalogFromTable::CatalogFromTable(std::shared_ptr<Euclid::Table::ColumnInfo>     column_info_ptr,
+                                   const std::string&                             source_id_column_name,
+                                   std::vector<std::shared_ptr<AttributeFromRow>> attribute_from_row_ptr_vector) {
 
   std::unique_ptr<size_t> source_id_index_ptr = column_info_ptr->find(source_id_column_name);
   if (source_id_index_ptr == nullptr) {
@@ -43,16 +41,14 @@ CatalogFromTable::CatalogFromTable(
   }
   m_source_id_index = *(source_id_index_ptr);
 
-  m_attribute_from_row_ptr_vector = std::move(
-      attribute_from_row_ptr_vector);
+  m_attribute_from_row_ptr_vector = std::move(attribute_from_row_ptr_vector);
 }
 
 CatalogFromTable::~CatalogFromTable() {
   // @todo Auto-generated destructor stub
 }
 
-Euclid::SourceCatalog::Catalog CatalogFromTable::createCatalog(
-    const Euclid::Table::Table& input_table) {
+Euclid::SourceCatalog::Catalog CatalogFromTable::createCatalog(const Euclid::Table::Table& input_table) {
 
   std::vector<Source> source_vector;
 
@@ -67,15 +63,14 @@ Euclid::SourceCatalog::Catalog CatalogFromTable::createCatalog(
     std::vector<std::shared_ptr<Attribute>> attribute_ptr_vector;
 
     for (auto& attribute_from_table_ptr : m_attribute_from_row_ptr_vector) {
-      attribute_ptr_vector.push_back(
-          attribute_from_table_ptr->createAttribute(row));
+      attribute_ptr_vector.push_back(attribute_from_table_ptr->createAttribute(row));
     }
 
-    source_vector.push_back(Source { source_id, move(attribute_ptr_vector) });
+    source_vector.push_back(Source{source_id, move(attribute_ptr_vector)});
   }
 
-  return Catalog { source_vector };
+  return Catalog{source_vector};
 }
 
-} // namespace SourceCatalog
-} // end of namespace Euclid
+}  // namespace SourceCatalog
+}  // end of namespace Euclid

--- a/SourceCatalog/src/lib/FluxErrorPair.cpp
+++ b/SourceCatalog/src/lib/FluxErrorPair.cpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file FluxErrorPair.cpp
  * @date January 22, 2015
  * @author Nikolaos Apostolakos
@@ -28,18 +28,16 @@ namespace Euclid {
 namespace SourceCatalog {
 
 FluxErrorPair::FluxErrorPair(double input_flux, double input_error, bool no_data, bool upper_limit)
-        : flux(input_flux), error(input_error), missing_photometry_flag(no_data),
-          upper_limit_flag(upper_limit) { }
+    : flux(input_flux), error(input_error), missing_photometry_flag(no_data), upper_limit_flag(upper_limit) {}
 
-bool FluxErrorPair::operator ==(const FluxErrorPair& other) const {
-  return (this->missing_photometry_flag && other.missing_photometry_flag)
-         || (this->flux == other.flux && this->error == other.error &&
-             this->upper_limit_flag == other.upper_limit_flag);
+bool FluxErrorPair::operator==(const FluxErrorPair& other) const {
+  return (this->missing_photometry_flag && other.missing_photometry_flag) ||
+         (this->flux == other.flux && this->error == other.error && this->upper_limit_flag == other.upper_limit_flag);
 }
 
-bool FluxErrorPair::operator !=(const FluxErrorPair& other) const {
+bool FluxErrorPair::operator!=(const FluxErrorPair& other) const {
   return !(*this == other);
 }
 
-} // end of namespace SourceCatalog
-} // end of namespace Euclid
+}  // end of namespace SourceCatalog
+}  // end of namespace Euclid

--- a/SourceCatalog/src/lib/Photometry.cpp
+++ b/SourceCatalog/src/lib/Photometry.cpp
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/Photometry.cpp
  *
  * @date Feb 5, 2014
@@ -25,18 +25,16 @@
 
 #include "SourceCatalog/SourceAttributes/Photometry.h"
 
-
 namespace Euclid {
 namespace SourceCatalog {
 
 //-----------------------------------------------------------------------------
 // find the value and error in the map for a specific filter name
 // return a ptr to a ValuePair(value, error) and null pointer otherwise
-std::unique_ptr<FluxErrorPair> Photometry::find(const std::string& filter_name) const
-{
-  std::unique_ptr<FluxErrorPair> flux_found_ptr {};
-  auto filter_iter = m_filter_name_vector_ptr->begin();
-  auto photometry_iter = m_value_vector.begin();
+std::unique_ptr<FluxErrorPair> Photometry::find(const std::string& filter_name) const {
+  std::unique_ptr<FluxErrorPair> flux_found_ptr{};
+  auto                           filter_iter     = m_filter_name_vector_ptr->begin();
+  auto                           photometry_iter = m_value_vector.begin();
   while (filter_iter != m_filter_name_vector_ptr->end()) {
     if (*filter_iter == filter_name) {
       break;
@@ -45,15 +43,15 @@ std::unique_ptr<FluxErrorPair> Photometry::find(const std::string& filter_name) 
     ++photometry_iter;
   }
   if (filter_iter != m_filter_name_vector_ptr->end()) {
-    flux_found_ptr = std::unique_ptr<FluxErrorPair>{new FluxErrorPair{*photometry_iter} };
+    flux_found_ptr = std::unique_ptr<FluxErrorPair>{new FluxErrorPair{*photometry_iter}};
   }
 
   return flux_found_ptr;
-} // Eof Photometry::find
+}  // Eof Photometry::find
 
 const std::shared_ptr<std::vector<std::string>>& Photometry::getFilterNames() const {
   return m_filter_name_vector_ptr;
 }
 
-} // namespace SourceCatalog
-} // end of namespace Euclid
+}  // namespace SourceCatalog
+}  // end of namespace Euclid

--- a/SourceCatalog/src/lib/PhotometryAttributeFromRow.cpp
+++ b/SourceCatalog/src/lib/PhotometryAttributeFromRow.cpp
@@ -16,105 +16,92 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/PhotometryAttributeFromRow.cpp
  *
  * @date Apr 17, 2014
  * @author dubath
  */
 
-#include <typeindex>
-#include <cmath>
-#include "ElementsKernel/Real.h"
 #include "SourceCatalog/SourceAttributes/PhotometryAttributeFromRow.h"
+#include "ElementsKernel/Real.h"
+#include <cmath>
+#include <typeindex>
 
 #include "../../SourceCatalog/PhotometryParsingException.h"
 #include "ElementsKernel/Exception.h"
 #include "ElementsKernel/Real.h"
 #include "Table/CastVisitor.h"
 
-
 namespace Euclid {
 namespace SourceCatalog {
 
 PhotometryAttributeFromRow::PhotometryAttributeFromRow(
-    std::shared_ptr<Euclid::Table::ColumnInfo> column_info_ptr,
+    std::shared_ptr<Euclid::Table::ColumnInfo>                                      column_info_ptr,
     const std::vector<std::pair<std::string, std::pair<std::string, std::string>>>& filter_name_mapping,
-    const bool missing_photometry_enabled,
-    const double missing_photometry_flag,
-    const bool upper_limit_enabled,
-    const std::vector<std::pair<std::string, float>> n_map,
-    const double n_upper_limit_flag) :
-    m_missing_photometry_enabled(missing_photometry_enabled),
-    m_missing_photometry_flag(missing_photometry_flag),
-    m_upper_limit_enabled(upper_limit_enabled),
-    m_n_map(n_map),
-    m_n_upper_limit_flag(n_upper_limit_flag) {
+    const bool missing_photometry_enabled, const double missing_photometry_flag, const bool upper_limit_enabled,
+    const std::vector<std::pair<std::string, float>> n_map, const double n_upper_limit_flag)
+    : m_missing_photometry_enabled(missing_photometry_enabled)
+    , m_missing_photometry_flag(missing_photometry_flag)
+    , m_upper_limit_enabled(upper_limit_enabled)
+    , m_n_map(n_map)
+    , m_n_upper_limit_flag(n_upper_limit_flag) {
 
   std::unique_ptr<size_t> flux_column_index_ptr;
   std::unique_ptr<size_t> error_column_index_ptr;
 
   for (auto filter_name_pair : filter_name_mapping) {
-    flux_column_index_ptr = column_info_ptr->find(filter_name_pair.second.first);
+    flux_column_index_ptr  = column_info_ptr->find(filter_name_pair.second.first);
     error_column_index_ptr = column_info_ptr->find(filter_name_pair.second.second);
 
     if (flux_column_index_ptr == nullptr) {
-      throw Elements::Exception() << "Column info does not have the flux column "
-                                  << filter_name_pair.second.first;
+      throw Elements::Exception() << "Column info does not have the flux column " << filter_name_pair.second.first;
     }
     if (error_column_index_ptr == nullptr) {
-      throw Elements::Exception() << "Column info does not have the flux error column "
-                                  << filter_name_pair.second.second;
+      throw Elements::Exception() << "Column info does not have the flux error column " << filter_name_pair.second.second;
     }
     m_table_index_vector.push_back(std::make_pair(*(flux_column_index_ptr), *(error_column_index_ptr)));
   }
 
   // create and filled the shared pointer to the filter name vector
   m_filter_name_vector_ptr = std::make_shared<std::vector<std::string>>();
-  for(auto a_filter_name_map: filter_name_mapping) {
+  for (auto a_filter_name_map : filter_name_mapping) {
     m_filter_name_vector_ptr->push_back(a_filter_name_map.first);
   }
-
 }
 
 PhotometryAttributeFromRow::~PhotometryAttributeFromRow() {
   // @todo Auto-generated destructor stub
 }
 
-std::unique_ptr<Attribute> PhotometryAttributeFromRow::createAttribute(
-    const Euclid::Table::Row& row) {
+std::unique_ptr<Attribute> PhotometryAttributeFromRow::createAttribute(const Euclid::Table::Row& row) {
 
-  std::vector<FluxErrorPair> photometry_vector {};
+  std::vector<FluxErrorPair> photometry_vector{};
 
   auto n_threshod_iter = m_n_map.begin();
   for (auto& filter_index_pair : m_table_index_vector) {
-    Euclid::Table::Row::cell_type flux_cell = row[filter_index_pair.first];
+    Euclid::Table::Row::cell_type flux_cell  = row[filter_index_pair.first];
     Euclid::Table::Row::cell_type error_cell = row[filter_index_pair.second];
 
-    double flux = boost::apply_visitor(Table::CastVisitor<double>{}, flux_cell);
+    double flux  = boost::apply_visitor(Table::CastVisitor<double>{}, flux_cell);
     double error = boost::apply_visitor(Table::CastVisitor<double>{}, error_cell);
 
     bool missing_data = false;
-    bool upper_limit = false;
+    bool upper_limit  = false;
     if (std::isinf(flux)) {
-      throw SourceCatalog::PhotometryParsingException(
-        "Infinite flux encountered when parsing the Photometry",
-        flux,
-        error);
+      throw SourceCatalog::PhotometryParsingException("Infinite flux encountered when parsing the Photometry", flux, error);
     }
     if (m_missing_photometry_enabled) {
       /** Missing photometry enabled **/
       missing_data = Elements::isEqual(flux, m_missing_photometry_flag) || std::isnan(flux);
-      if (missing_data){
-        error=0;
+      if (missing_data) {
+        error = 0;
       } else {
         if (m_upper_limit_enabled) {
           /** Upper limit enabled **/
           if (error == 0.) {
             throw SourceCatalog::PhotometryParsingException(
-              "Zero error encountered when parsing the Photometry with 'missing data' and 'upper limit' enabled",
-              flux,
-              error);
+                "Zero error encountered when parsing the Photometry with 'missing data' and 'upper limit' enabled", flux, error);
           }
           if (error < 0) {
             /** Actual upper limit **/
@@ -124,42 +111,34 @@ std::unique_ptr<Attribute> PhotometryAttributeFromRow::createAttribute(
             upper_limit = true;
             if (flux <= 0) {
               throw SourceCatalog::PhotometryParsingException(
-                "Negative or Zero flux encountered when parsing the Photometry in the context of an 'upper limit'",
-                flux,
-                error);
+                  "Negative or Zero flux encountered when parsing the Photometry in the context of an 'upper limit'", flux, error);
             }
 
             error = std::abs(error);
           }
-        }
-        else {
+        } else {
           /** Upper limit disabled **/
           if (error <= 0) {
             throw SourceCatalog::PhotometryParsingException(
-              "Negative or Zero error encountered when parsing the Photometry with 'missing data' enabled "
-              "and 'upper limit' disabled",
-              flux,
-              error);
+                "Negative or Zero error encountered when parsing the Photometry with 'missing data' enabled "
+                "and 'upper limit' disabled",
+                flux, error);
           }
         }
       }
-    }
-    else {
+    } else {
       /** Missing photometry disabled **/
       if (std::isnan(flux)) {
         throw SourceCatalog::PhotometryParsingException(
-          "NAN flux encountered when parsing the Photometry with 'missing data' disabled",
-          flux,
-          error);
+            "NAN flux encountered when parsing the Photometry with 'missing data' disabled", flux, error);
       }
 
       if (m_upper_limit_enabled) {
         /** Upper limit enabled **/
         if (error == 0.) {
           throw SourceCatalog::PhotometryParsingException(
-            "Zero error encountered when parsing the Photometry with 'missing data' disabled and 'upper limit' enabled",
-            flux,
-            error);
+              "Zero error encountered when parsing the Photometry with 'missing data' disabled and 'upper limit' enabled", flux,
+              error);
         }
         if (error < 0) {
           /** Actual upper limit **/
@@ -169,34 +148,29 @@ std::unique_ptr<Attribute> PhotometryAttributeFromRow::createAttribute(
           }
           if (flux <= 0) {
             throw SourceCatalog::PhotometryParsingException(
-              "Negative or Zero flux encountered when parsing the Photometry in the context of an 'upper limit'",
-              flux,
-              error);
+                "Negative or Zero flux encountered when parsing the Photometry in the context of an 'upper limit'", flux, error);
           }
           error = std::abs(error);
         }
-      }
-      else {
+      } else {
         /** Upper limit disabled **/
-        if (error<=0){
+        if (error <= 0) {
           throw SourceCatalog::PhotometryParsingException(
               "Negative or Zero error encountered when parsing the Photometry with 'missing data' "
               "and 'upper limit' disabled",
-              flux,
-              error);
+              flux, error);
         }
       }
     }
 
     photometry_vector.push_back(FluxErrorPair{flux, error, missing_data, upper_limit});
     ++n_threshod_iter;
-  }//Eof for
+  }  // Eof for
 
-  std::unique_ptr<Attribute> photometry_ptr { new Photometry{m_filter_name_vector_ptr, photometry_vector } };
+  std::unique_ptr<Attribute> photometry_ptr{new Photometry{m_filter_name_vector_ptr, photometry_vector}};
 
   return photometry_ptr;
 }
 
-} // namespace SourceCatalog
-} // end of namespace Euclid
-
+}  // namespace SourceCatalog
+}  // end of namespace Euclid

--- a/SourceCatalog/src/lib/TableRowAttribute.cpp
+++ b/SourceCatalog/src/lib/TableRowAttribute.cpp
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /*
+/*
  * Copyright (C) 2012-2020 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
@@ -44,12 +44,11 @@
 namespace Euclid {
 namespace SourceCatalog {
 
-TableRowAttribute::TableRowAttribute(Table::Row row) : m_row(std::move(row)) {
-}
+TableRowAttribute::TableRowAttribute(Table::Row row) : m_row(std::move(row)) {}
 
 const Table::Row& TableRowAttribute::getRow() const {
   return m_row;
 }
 
-} // namespace SourceCatalog
-} // end of namespace Euclid
+}  // namespace SourceCatalog
+}  // end of namespace Euclid

--- a/SourceCatalog/src/lib/TableRowAttributeFromRow.cpp
+++ b/SourceCatalog/src/lib/TableRowAttributeFromRow.cpp
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /*
+/*
  * Copyright (C) 2012-2020 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
@@ -39,8 +39,8 @@
  * @author nikoapos
  */
 
-#include "AlexandriaKernel/memory_tools.h"
 #include "SourceCatalog/SourceAttributes/TableRowAttributeFromRow.h"
+#include "AlexandriaKernel/memory_tools.h"
 #include "SourceCatalog/SourceAttributes/TableRowAttribute.h"
 
 namespace Euclid {
@@ -50,5 +50,5 @@ std::unique_ptr<Attribute> TableRowAttributeFromRow::createAttribute(const Eucli
   return make_unique<TableRowAttribute>(row);
 }
 
-} // namespace SourceCatalog
-} // end of namespace Euclid
+}  // namespace SourceCatalog
+}  // end of namespace Euclid

--- a/SourceCatalog/tests/src/CatalogFixture.h
+++ b/SourceCatalog/tests/src/CatalogFixture.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/CatalogFixture.h
  *
  * @date May 13, 2014
@@ -26,14 +26,14 @@
 #ifndef CATALOGFIXTURE_H_
 #define CATALOGFIXTURE_H_
 
-#include <memory>
-#include <vector>
-#include <utility>
-#include "SourceCatalog/Source.h"
-#include "SourceCatalog/SourceAttributes/Photometry.h"
-#include "SourceCatalog/SourceAttributes/Coordinates.h"
-#include "SourceCatalog/SourceAttributes/SpectroscopicRedshift.h"
 #include "SourceCatalog/Catalog.h"
+#include "SourceCatalog/Source.h"
+#include "SourceCatalog/SourceAttributes/Coordinates.h"
+#include "SourceCatalog/SourceAttributes/Photometry.h"
+#include "SourceCatalog/SourceAttributes/SpectroscopicRedshift.h"
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace Euclid {
 namespace SourceCatalog {
@@ -47,18 +47,17 @@ struct CatalogFixture {
   // Values for building a Photometry object
   const std::string expected_filter_name_1{"COSMOS/g_SDSS"};
   const std::string expected_filter_name_2{"COSMOS/r_SDSS"};
-  const double expected_flux_1 = 0.46575674;
-  const double expected_error_1 = 0.00001534;
-  const double expected_flux_2 = 0.01537575674;
-  const double expected_error_2 = 0.00354616;
+  const double      expected_flux_1  = 0.46575674;
+  const double      expected_error_1 = 0.00001534;
+  const double      expected_flux_2  = 0.01537575674;
+  const double      expected_error_2 = 0.00354616;
 
   // Shared pointer of filter name vector
   std::shared_ptr<std::vector<std::string>> filter_name_vector_ptr{
-    new std::vector<std::string>{expected_filter_name_1, expected_filter_name_2}};
+      new std::vector<std::string>{expected_filter_name_1, expected_filter_name_2}};
 
   // photometry values vector
-  std::vector<FluxErrorPair> photometry_vector{FluxErrorPair(expected_flux_1,
-                                                             expected_error_1),
+  std::vector<FluxErrorPair> photometry_vector{FluxErrorPair(expected_flux_1, expected_error_1),
                                                FluxErrorPair(expected_flux_2, expected_error_2)};
 
   // Photometry
@@ -67,9 +66,9 @@ struct CatalogFixture {
   //
   // Building coordinates and spectroscopic redshift attribute mock objects
   //
-  double expected_ra_1 = 181.4657;
+  double expected_ra_1  = 181.4657;
   double expected_dec_1 = -36.27363;
-  double expected_ra_2 = 281.4657;
+  double expected_ra_2  = 281.4657;
   double expected_dec_2 = -26.27363;
 
   double expected_z_value = 3.;
@@ -78,8 +77,8 @@ struct CatalogFixture {
   std::shared_ptr<Attribute> coordinates_1_ptr{new Coordinates{expected_ra_1, expected_dec_1}};
   std::shared_ptr<Attribute> coordinates_2_ptr{new Coordinates{expected_ra_2, expected_dec_2}};
 
-  std::shared_ptr<Attribute> spec_redshift_ptr{new SpectroscopicRedshift{expected_z_value, expected_z_error}};
-  std::shared_ptr<Attribute> photometry_ptr{new Photometry{filter_name_vector_ptr, photometry_vector}};
+  std::shared_ptr<Attribute>              spec_redshift_ptr{new SpectroscopicRedshift{expected_z_value, expected_z_error}};
+  std::shared_ptr<Attribute>              photometry_ptr{new Photometry{filter_name_vector_ptr, photometry_vector}};
   std::vector<std::shared_ptr<Attribute>> attribute_vector_1{coordinates_1_ptr, spec_redshift_ptr, photometry_ptr};
   std::vector<std::shared_ptr<Attribute>> attribute_vector_2{coordinates_2_ptr, spec_redshift_ptr};
 
@@ -95,40 +94,36 @@ struct CatalogFixture {
   // create the catalog
   Catalog catalog{source_vector};
 
-
   CatalogFixture() {
 
-//    // First source
-//    shared_ptr<Coordinates> coordinates_ptr1(new Coordinates(expectedRa1, expectedDec1));
-//    shared_ptr<SpectroscopicRedshift> spec_redshift_ptr1(new SpectroscopicRedshift(expectedZvalue1, expectedZerror1));
-//    shared_ptr<Photometry> photometry_ptr1(new Photometry{createPhotometryMap()});
-//    attribute_vector1.push_back(coordinates_ptr1);
-//    attribute_vector1.push_back(spec_redshift_ptr1);
-//    attribute_vector1.push_back(photometry_ptr1);
-//
-//    // Second source
-//    shared_ptr<Coordinates> coordinates_ptr2(new Coordinates(expectedRa2, expectedDec2));
-//    shared_ptr<SpectroscopicRedshift> spec_redshift_ptr2(new SpectroscopicRedshift(expectedZvalue2, expectedZerror2));
-//    attribute_vector2.push_back(coordinates_ptr2);
-//    attribute_vector2.push_back(spec_redshift_ptr2);
-//
-//    // Store sources in a vector
-//    source_vector.push_back(Source(expectedSourceId1, attribute_vector1));
-//    source_vector.push_back(Source(expectedSourceId2, attribute_vector2));
-//
-//    catPtr = new Catalog(source_vector);
-
+    //    // First source
+    //    shared_ptr<Coordinates> coordinates_ptr1(new Coordinates(expectedRa1, expectedDec1));
+    //    shared_ptr<SpectroscopicRedshift> spec_redshift_ptr1(new SpectroscopicRedshift(expectedZvalue1, expectedZerror1));
+    //    shared_ptr<Photometry> photometry_ptr1(new Photometry{createPhotometryMap()});
+    //    attribute_vector1.push_back(coordinates_ptr1);
+    //    attribute_vector1.push_back(spec_redshift_ptr1);
+    //    attribute_vector1.push_back(photometry_ptr1);
+    //
+    //    // Second source
+    //    shared_ptr<Coordinates> coordinates_ptr2(new Coordinates(expectedRa2, expectedDec2));
+    //    shared_ptr<SpectroscopicRedshift> spec_redshift_ptr2(new SpectroscopicRedshift(expectedZvalue2, expectedZerror2));
+    //    attribute_vector2.push_back(coordinates_ptr2);
+    //    attribute_vector2.push_back(spec_redshift_ptr2);
+    //
+    //    // Store sources in a vector
+    //    source_vector.push_back(Source(expectedSourceId1, attribute_vector1));
+    //    source_vector.push_back(Source(expectedSourceId2, attribute_vector2));
+    //
+    //    catPtr = new Catalog(source_vector);
   }
 
   virtual ~CatalogFixture() noexcept {
     // teardown
-    //delete catPtr;
+    // delete catPtr;
   }
-
-
 };
 
-} // end of namespace SourceCatalog
-} // end of namespace Euclid
+}  // end of namespace SourceCatalog
+}  // end of namespace Euclid
 
-#endif // CATALOGFIXTURE_H_
+#endif  // CATALOGFIXTURE_H_

--- a/SourceCatalog/tests/src/CatalogFromTable_test.cpp
+++ b/SourceCatalog/tests/src/CatalogFromTable_test.cpp
@@ -16,18 +16,17 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/CatalogFromTable_test.cpp
  *
  * @date Apr 15, 2014
  * @author Pierre Dubath
  */
 
-#include <boost/test/unit_test.hpp>
-#include "SourceCatalog/CatalogFromTable.h"
 #include "SourceCatalog/AttributeFromRow.h"
+#include "SourceCatalog/CatalogFromTable.h"
 #include "SourceCatalog/SourceAttributes/PhotometryAttributeFromRow.h"
-
+#include <boost/test/unit_test.hpp>
 
 //-----------------------------------------------------------------------------
 // Include the TableFixture which contain a complete table mock object use here
@@ -40,7 +39,7 @@ namespace SourceCatalog {
 //-----------------------------------------------------------------------------
 //
 
-BOOST_AUTO_TEST_SUITE (CatalogFromTable_test)
+BOOST_AUTO_TEST_SUITE(CatalogFromTable_test)
 
 //-----------------------------------------------------------------------------
 
@@ -48,41 +47,39 @@ BOOST_FIXTURE_TEST_CASE(createCatalog_test, TableFixture) {
 
   BOOST_TEST_MESSAGE("Create Catalog test");
   std::unique_ptr<AttributeFromRow> photmetryAft_ptr{
-    new PhotometryAttributeFromRow{column_info_ptr, filter_name_mapping, true, -99., true, threshold_mapping, -99}};
+      new PhotometryAttributeFromRow{column_info_ptr, filter_name_mapping, true, -99., true, threshold_mapping, -99}};
   std::vector<std::shared_ptr<AttributeFromRow>> attribute_from_table_vector;
 
-  attribute_from_table_vector.push_back( move(photmetryAft_ptr) );
+  attribute_from_table_vector.push_back(move(photmetryAft_ptr));
 
-  CatalogFromTable cft {table.getColumnInfo(), source_id_name, move(attribute_from_table_vector)};
+  CatalogFromTable cft{table.getColumnInfo(), source_id_name, move(attribute_from_table_vector)};
 
   Euclid::SourceCatalog::Catalog catalog = cft.createCatalog(table);
 
-  BOOST_CHECK_EQUAL(catalog.size(),2);
-  BOOST_CHECK_EQUAL(boost::get<int64_t>(catalog.find(source_id_1)->getId()),  source_id_1 );
-  BOOST_CHECK_CLOSE(catalog.find(source_id_2)->getAttribute<Photometry>()->find(r_filter_name)->flux,  flux2_row1, tolerance );
-
+  BOOST_CHECK_EQUAL(catalog.size(), 2);
+  BOOST_CHECK_EQUAL(boost::get<int64_t>(catalog.find(source_id_1)->getId()), source_id_1);
+  BOOST_CHECK_CLOSE(catalog.find(source_id_2)->getAttribute<Photometry>()->find(r_filter_name)->flux, flux2_row1, tolerance);
 }
 
 BOOST_FIXTURE_TEST_CASE(createCatalogWithStringId_test, TableFixture) {
 
   BOOST_TEST_MESSAGE("Create Catalog with string ID test");
   std::unique_ptr<AttributeFromRow> photmetryAft_ptr{
-    new PhotometryAttributeFromRow{column_info_ptr, filter_name_mapping, true, -99., true, threshold_mapping, -99}};
+      new PhotometryAttributeFromRow{column_info_ptr, filter_name_mapping, true, -99., true, threshold_mapping, -99}};
   std::vector<std::shared_ptr<AttributeFromRow>> attribute_from_table_vector;
 
-  attribute_from_table_vector.push_back( move(photmetryAft_ptr) );
+  attribute_from_table_vector.push_back(move(photmetryAft_ptr));
 
-  CatalogFromTable cft {table.getColumnInfo(), source_id_str_name, move(attribute_from_table_vector)};
+  CatalogFromTable cft{table.getColumnInfo(), source_id_str_name, move(attribute_from_table_vector)};
 
   Euclid::SourceCatalog::Catalog catalog = cft.createCatalog(table);
 
-  BOOST_CHECK_EQUAL(catalog.size(),2);
-  BOOST_CHECK_EQUAL(boost::get<std::string>(catalog.find(source_str_id_1)->getId()),  source_str_id_1 );
-  BOOST_CHECK_CLOSE(catalog.find(source_str_id_2)->getAttribute<Photometry>()->find(r_filter_name)->flux,  flux2_row1, tolerance );
-
+  BOOST_CHECK_EQUAL(catalog.size(), 2);
+  BOOST_CHECK_EQUAL(boost::get<std::string>(catalog.find(source_str_id_1)->getId()), source_str_id_1);
+  BOOST_CHECK_CLOSE(catalog.find(source_str_id_2)->getAttribute<Photometry>()->find(r_filter_name)->flux, flux2_row1, tolerance);
 }
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()
 
-} // namespace SourceCatalog
-} // end of namespace Euclid
+}  // namespace SourceCatalog
+}  // end of namespace Euclid

--- a/SourceCatalog/tests/src/Catalog_test.cpp
+++ b/SourceCatalog/tests/src/Catalog_test.cpp
@@ -16,16 +16,16 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/Catalog_test.cpp
  *
  *  Created on: March 1, 2013
  *      Author: Pierre Dubath
  */
 
-#include <boost/test/unit_test.hpp>
-#include "SourceCatalog/Source.h"
 #include "SourceCatalog/Catalog.h"
+#include "SourceCatalog/Source.h"
+#include <boost/test/unit_test.hpp>
 
 #include "ElementsKernel/Exception.h"
 
@@ -38,54 +38,50 @@
 
 using namespace Euclid::SourceCatalog;
 
-
 //-----------------------------------------------------------------------------
 //
 
-BOOST_AUTO_TEST_SUITE (Catalog_test)
+BOOST_AUTO_TEST_SUITE(Catalog_test)
 
 //-----------------------------------------------------------------------------
 
-BOOST_FIXTURE_TEST_CASE( size_test, CatalogFixture ) {
+BOOST_FIXTURE_TEST_CASE(size_test, CatalogFixture) {
 
   BOOST_TEST_MESSAGE("--> size test ");
   BOOST_CHECK_EQUAL(source_vector.size(), catalog.size());
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_FIXTURE_TEST_CASE( find_test, CatalogFixture ) {
+BOOST_FIXTURE_TEST_CASE(find_test, CatalogFixture) {
 
   BOOST_TEST_MESSAGE("--> find test ");
 
-  std::shared_ptr<Source> a_source(catalog.find(expected_source_id_2));
+  std::shared_ptr<Source>      a_source(catalog.find(expected_source_id_2));
   std::shared_ptr<Coordinates> coordinates(a_source->getAttribute<Coordinates>());
 
   BOOST_CHECK_EQUAL(expected_ra_2, coordinates->getRa());
   BOOST_CHECK_EQUAL(expected_dec_2, coordinates->getDec());
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_FIXTURE_TEST_CASE( find_missig_source_test, CatalogFixture ) {
+BOOST_FIXTURE_TEST_CASE(find_missig_source_test, CatalogFixture) {
 
   BOOST_TEST_MESSAGE("--> find test ");
 
   std::shared_ptr<Source> pSource(catalog.find(999999));
 
   BOOST_CHECK(nullptr == pSource);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_FIXTURE_TEST_CASE( identical_sources_test, CatalogFixture ) {
+BOOST_FIXTURE_TEST_CASE(identical_sources_test, CatalogFixture) {
 
   BOOST_TEST_MESSAGE("--> identical_sources test ");
 
-  std::vector<Source> source_vector_identical {};
+  std::vector<Source> source_vector_identical{};
 
   source_vector_identical.push_back(Source(expected_source_id_1, attribute_vector_1));
   source_vector_identical.push_back(Source(expected_source_id_2, attribute_vector_2));
@@ -94,16 +90,14 @@ BOOST_FIXTURE_TEST_CASE( identical_sources_test, CatalogFixture ) {
   bool identical = false;
 
   try {
-    Catalog catalog_test_value {source_vector_identical};
-  }
-  catch (Elements::Exception& e) {
+    Catalog catalog_test_value{source_vector_identical};
+  } catch (Elements::Exception& e) {
     identical = true;
-  };
+  }
 
   BOOST_CHECK_EQUAL(identical, true);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/SourceCatalog/tests/src/SourceAttributes/Coordinates_test.cpp
+++ b/SourceCatalog/tests/src/SourceAttributes/Coordinates_test.cpp
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/SourceAttributes/Coordinates_test.cpp
  *
  * @author Nicolas Morisset
@@ -24,14 +24,13 @@
  * Created on: Feb 5, 2014
  */
 
+#include "SourceCatalog/SourceAttributes/Coordinates.h"
 #include <boost/test/unit_test.hpp>
 #include <iostream>
-#include "SourceCatalog/SourceAttributes/Coordinates.h"
 
 using namespace Euclid::SourceCatalog;
 
 //-----------------------------------------------------------------------------
-
 
 struct CoordinatesFixture {
 
@@ -42,15 +41,14 @@ struct CoordinatesFixture {
     expected_ra  = 1.5;
     expected_dec = 2.8;
   }
-  ~CoordinatesFixture() {
-  }
+  ~CoordinatesFixture() {}
 };
 
 //----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (Coordinates_test)
+BOOST_AUTO_TEST_SUITE(Coordinates_test)
 
-BOOST_FIXTURE_TEST_CASE( getter_test, CoordinatesFixture ) {
+BOOST_FIXTURE_TEST_CASE(getter_test, CoordinatesFixture) {
 
   Coordinates coordinates(expected_ra, expected_dec);
 
@@ -59,7 +57,6 @@ BOOST_FIXTURE_TEST_CASE( getter_test, CoordinatesFixture ) {
 
   BOOST_CHECK_EQUAL(expected_ra, ra_result);
   BOOST_CHECK_EQUAL(expected_dec, dec_result);
-
 }
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/SourceCatalog/tests/src/SourceAttributes/PhotometryAttributeFromRow_test.cpp
+++ b/SourceCatalog/tests/src/SourceAttributes/PhotometryAttributeFromRow_test.cpp
@@ -17,30 +17,29 @@
  */
 
 /**
-* @file tests/src/SourceAttributes/PhotometryAttributeFromRow_test.cpp
-*
-* @date Apr 17, 2014
-* @author Pierre Dubath
-*/
+ * @file tests/src/SourceAttributes/PhotometryAttributeFromRow_test.cpp
+ *
+ * @date Apr 17, 2014
+ * @author Pierre Dubath
+ */
 
-#include <boost/test/unit_test.hpp>
-#include <memory>
-#include <map>
 #include "SourceCatalog/SourceAttributes/PhotometryAttributeFromRow.h"
+#include <boost/test/unit_test.hpp>
+#include <map>
+#include <memory>
 
 #include "../../../SourceCatalog/PhotometryParsingException.h"
-#include "SourceCatalog/SourceAttributes/Photometry.h"
 #include "ElementsKernel/Exception.h"
 #include "SourceCatalog/AttributeFromRow.h"
+#include "SourceCatalog/SourceAttributes/Photometry.h"
 #include "tests/src/TableFixture.h"
 
 using namespace Euclid::SourceCatalog;
 
-
 //-----------------------------------------------------------------------------
 //
 
-BOOST_AUTO_TEST_SUITE (PhotometryAttributeFromRow_test)
+BOOST_AUTO_TEST_SUITE(PhotometryAttributeFromRow_test)
 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
@@ -48,18 +47,17 @@ BOOST_AUTO_TEST_SUITE (PhotometryAttributeFromRow_test)
 BOOST_FIXTURE_TEST_CASE(createAttribute_test, TableFixture) {
   BOOST_TEST_MESSAGE("--> createAttribute test ");
 
-  PhotometryAttributeFromRow paft{column_info_ptr, filter_name_mapping, true, 1.12345e-12, true, threshold_mapping,
-                                  -99};
+  PhotometryAttributeFromRow paft{column_info_ptr, filter_name_mapping, true, 1.12345e-12, true, threshold_mapping, -99};
 
   std::unique_ptr<Euclid::SourceCatalog::Attribute> attribute_ptr = paft.createAttribute(row1);
 
-  BOOST_CHECK( dynamic_cast<Euclid::SourceCatalog::Photometry*>(attribute_ptr.get()) != nullptr);
+  BOOST_CHECK(dynamic_cast<Euclid::SourceCatalog::Photometry*>(attribute_ptr.get()) != nullptr);
 
-  Euclid::SourceCatalog::Photometry* photometry = dynamic_cast<Euclid::SourceCatalog::Photometry*>( attribute_ptr.get() );
+  Euclid::SourceCatalog::Photometry* photometry = dynamic_cast<Euclid::SourceCatalog::Photometry*>(attribute_ptr.get());
   if (photometry) {
     BOOST_CHECK_CLOSE(photometry->find(v_filter_name)->flux, flux1_row1, tolerance);
     BOOST_CHECK_CLOSE(photometry->find(v_filter_name)->error, 0,
-                      tolerance); // When the missing photometry is set the error is 0
+                      tolerance);  // When the missing photometry is set the error is 0
     BOOST_CHECK(photometry->find(v_filter_name)->missing_photometry_flag);
     BOOST_CHECK_CLOSE(photometry->find(r_filter_name)->flux, flux2_row1, tolerance);
     BOOST_CHECK_CLOSE(photometry->find(r_filter_name)->error, error2_row1, tolerance);
@@ -102,9 +100,7 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseNoMissingNoUpper_test, TableFixture) {
   BOOST_CHECK_THROW(paft_nn.createAttribute(row_zero_error), PhotometryParsingException);
   // error negatif: error
   BOOST_CHECK_THROW(paft_nn.createAttribute(row_neg_error), PhotometryParsingException);
-
 }
-
 
 BOOST_FIXTURE_TEST_CASE(exceptionalCaseMissingNoUpper_test, TableFixture) {
   BOOST_TEST_MESSAGE("--> Missing Data, No Upper Limit ");
@@ -117,7 +113,7 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseMissingNoUpper_test, TableFixture) {
   BOOST_CHECK_CLOSE(photometry->find(v_filter_name)->error, 0.5, tolerance);
   BOOST_CHECK(!photometry->find(v_filter_name)->missing_photometry_flag);
   BOOST_CHECK(!photometry->find(v_filter_name)->upper_limit_flag);
-  
+
   // flux zero: read as it, no flags
   std::unique_ptr<Euclid::SourceCatalog::Attribute> attribute_yn_f0_ptr = paft_yn.createAttribute(row_zero_flux);
   photometry = dynamic_cast<Euclid::SourceCatalog::Photometry*>(attribute_yn_f0_ptr.get());
@@ -126,7 +122,7 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseMissingNoUpper_test, TableFixture) {
   BOOST_CHECK_CLOSE(photometry->find(v_filter_name)->error, 0.5, tolerance);
   BOOST_CHECK(!photometry->find(v_filter_name)->missing_photometry_flag);
   BOOST_CHECK(!photometry->find(v_filter_name)->upper_limit_flag);
-  
+
   // flux negatif: read as it, no flags
   std::unique_ptr<Euclid::SourceCatalog::Attribute> attribute_yn_fm_ptr = paft_yn.createAttribute(row_neg_flux);
   photometry = dynamic_cast<Euclid::SourceCatalog::Photometry*>(attribute_yn_fm_ptr.get());
@@ -135,7 +131,6 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseMissingNoUpper_test, TableFixture) {
   BOOST_CHECK_CLOSE(photometry->find(v_filter_name)->error, 0.5, tolerance);
   BOOST_CHECK(!photometry->find(v_filter_name)->missing_photometry_flag);
   BOOST_CHECK(!photometry->find(v_filter_name)->upper_limit_flag);
-  
 
   // flux =Flag: Missing photometry Flag Error=0
   std::unique_ptr<Euclid::SourceCatalog::Attribute> attribute_yn_fF_ptr = paft_yn.createAttribute(row_flag_flux);
@@ -144,10 +139,9 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseMissingNoUpper_test, TableFixture) {
   BOOST_CHECK_CLOSE(photometry->find(v_filter_name)->error, 0., tolerance);
   BOOST_CHECK(photometry->find(v_filter_name)->missing_photometry_flag);
   BOOST_CHECK(!photometry->find(v_filter_name)->upper_limit_flag);
- 
+
   // flux =Flag error<0: Missing photometry Flag Error=0
-  std::unique_ptr<Euclid::SourceCatalog::Attribute> attribute_yn_fFem_ptr = paft_yn.createAttribute(
-    row_flag_flux_neg_error);
+  std::unique_ptr<Euclid::SourceCatalog::Attribute> attribute_yn_fFem_ptr = paft_yn.createAttribute(row_flag_flux_neg_error);
   photometry = dynamic_cast<Euclid::SourceCatalog::Photometry*>(attribute_yn_fFem_ptr.get());
   BOOST_CHECK(photometry != nullptr);
   BOOST_CHECK_CLOSE(photometry->find(v_filter_name)->error, 0., tolerance);
@@ -161,7 +155,6 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseMissingNoUpper_test, TableFixture) {
   BOOST_CHECK_THROW(paft_yn.createAttribute(row_neg_error), PhotometryParsingException);
 }
 
-
 BOOST_FIXTURE_TEST_CASE(exceptionalCaseNoMissingUpper_test, TableFixture) {
   BOOST_TEST_MESSAGE("--> No Missing Data, Upper Limit ");
   PhotometryAttributeFromRow paft_ny{column_info_ptr, filter_name_mapping, false, -99., true, threshold_mapping, -99};
@@ -173,7 +166,7 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseNoMissingUpper_test, TableFixture) {
   BOOST_CHECK_CLOSE(photometry->find(v_filter_name)->error, 0.5, tolerance);
   BOOST_CHECK(!photometry->find(v_filter_name)->missing_photometry_flag);
   BOOST_CHECK(!photometry->find(v_filter_name)->upper_limit_flag);
- 
+
   // flux zero: read as it, no flags
   std::unique_ptr<Euclid::SourceCatalog::Attribute> attribute_ny_f0_ptr = paft_ny.createAttribute(row_zero_flux);
   photometry = dynamic_cast<Euclid::SourceCatalog::Photometry*>(attribute_ny_f0_ptr.get());
@@ -191,7 +184,7 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseNoMissingUpper_test, TableFixture) {
   BOOST_CHECK_CLOSE(photometry->find(v_filter_name)->error, 0.5, tolerance);
   BOOST_CHECK(!photometry->find(v_filter_name)->missing_photometry_flag);
   BOOST_CHECK(!photometry->find(v_filter_name)->upper_limit_flag);
-  
+
   // Error==0: error
   BOOST_CHECK_THROW(paft_ny.createAttribute(row_zero_error), PhotometryParsingException);
   // Error<0 Flux<0: error
@@ -207,11 +200,9 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseNoMissingUpper_test, TableFixture) {
   BOOST_CHECK_CLOSE(photometry->find(v_filter_name)->error, 0.5, tolerance);
   BOOST_CHECK(!photometry->find(v_filter_name)->missing_photometry_flag);
   BOOST_CHECK(photometry->find(v_filter_name)->upper_limit_flag);
- 
 
   // error negative = Threshold Flag: flag as upper limit,  Error = |Error|, Flux=Flux/n
-  std::unique_ptr<Euclid::SourceCatalog::Attribute> attribute_ny_em_fl_ptr = paft_ny.createAttribute(
-    row_neg_error_flag);
+  std::unique_ptr<Euclid::SourceCatalog::Attribute> attribute_ny_em_fl_ptr = paft_ny.createAttribute(row_neg_error_flag);
   photometry = dynamic_cast<Euclid::SourceCatalog::Photometry*>(attribute_ny_em_fl_ptr.get());
   BOOST_CHECK(photometry != nullptr);
   BOOST_CHECK_CLOSE(photometry->find(v_filter_name)->flux, 1., tolerance);
@@ -223,9 +214,6 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseNoMissingUpper_test, TableFixture) {
   BOOST_CHECK_CLOSE(photometry->find(r_filter_name)->error, 3. / 5., tolerance);
   BOOST_CHECK(!photometry->find(r_filter_name)->missing_photometry_flag);
   BOOST_CHECK(photometry->find(r_filter_name)->upper_limit_flag);
-
-
-
 }
 
 BOOST_FIXTURE_TEST_CASE(exceptionalCaseMissingUpper_test, TableFixture) {
@@ -239,7 +227,7 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseMissingUpper_test, TableFixture) {
   BOOST_CHECK_CLOSE(photometry->find(v_filter_name)->error, 0.5, tolerance);
   BOOST_CHECK(!photometry->find(v_filter_name)->missing_photometry_flag);
   BOOST_CHECK(!photometry->find(v_filter_name)->upper_limit_flag);
- 
+
   // flux zero: read as it, no flags
   std::unique_ptr<Euclid::SourceCatalog::Attribute> attribute_yy_f0_ptr = paft_yy.createAttribute(row_zero_flux);
   photometry = dynamic_cast<Euclid::SourceCatalog::Photometry*>(attribute_yy_f0_ptr.get());
@@ -258,7 +246,6 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseMissingUpper_test, TableFixture) {
   BOOST_CHECK(!photometry->find(v_filter_name)->missing_photometry_flag);
   BOOST_CHECK(!photometry->find(v_filter_name)->upper_limit_flag);
 
-
   // Error==0: error
   BOOST_CHECK_THROW(paft_yy.createAttribute(row_zero_error), PhotometryParsingException);
 
@@ -269,16 +256,14 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseMissingUpper_test, TableFixture) {
   BOOST_CHECK_CLOSE(photometry->find(v_filter_name)->error, 0., tolerance);
   BOOST_CHECK(photometry->find(v_filter_name)->missing_photometry_flag);
   BOOST_CHECK(!photometry->find(v_filter_name)->upper_limit_flag);
-  
+
   // flux = Flag error<0: Missing photometry Flag Error=0
-  std::unique_ptr<Euclid::SourceCatalog::Attribute> attribute_yy_fFem_ptr = paft_yy.createAttribute(
-    row_flag_flux_neg_error);
+  std::unique_ptr<Euclid::SourceCatalog::Attribute> attribute_yy_fFem_ptr = paft_yy.createAttribute(row_flag_flux_neg_error);
   photometry = dynamic_cast<Euclid::SourceCatalog::Photometry*>(attribute_yy_fFem_ptr.get());
   BOOST_CHECK(photometry != nullptr);
   BOOST_CHECK_CLOSE(photometry->find(v_filter_name)->error, 0., tolerance);
   BOOST_CHECK(photometry->find(v_filter_name)->missing_photometry_flag);
   BOOST_CHECK(!photometry->find(v_filter_name)->upper_limit_flag);
-
 
   // error negatif: flag as upper limit Error = |Error|
   std::unique_ptr<Euclid::SourceCatalog::Attribute> attribute_yy_em_ptr = paft_yy.createAttribute(row_neg_error);
@@ -289,7 +274,6 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseMissingUpper_test, TableFixture) {
   BOOST_CHECK(!photometry->find(v_filter_name)->missing_photometry_flag);
   BOOST_CHECK(photometry->find(v_filter_name)->upper_limit_flag);
 
-
   // Error<0 Flux=0: error
   BOOST_CHECK_THROW(paft_yy.createAttribute(row_zero_flux_neg_error), PhotometryParsingException);
   // Error<0 Flux<0: error
@@ -298,6 +282,4 @@ BOOST_FIXTURE_TEST_CASE(exceptionalCaseMissingUpper_test, TableFixture) {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/SourceCatalog/tests/src/SourceAttributes/Photometry_test.cpp
+++ b/SourceCatalog/tests/src/SourceAttributes/Photometry_test.cpp
@@ -16,15 +16,14 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/SourceAttributes/Photometry_test.cpp
  *
  * Created on: Jan 20, 2014
  *     Author: Pierre Dubath
  */
-#include <boost/test/unit_test.hpp>
 #include "SourceCatalog/SourceAttributes/Photometry.h"
-
+#include <boost/test/unit_test.hpp>
 
 //-----------------------------------------------------------------------------
 // Include the CatalogFixture which comprises a photometry mock object use here
@@ -35,9 +34,9 @@ using namespace Euclid::SourceCatalog;
 
 //----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (Photometry_test)
+BOOST_AUTO_TEST_SUITE(Photometry_test)
 
-BOOST_FIXTURE_TEST_CASE( find_test, CatalogFixture ) {
+BOOST_FIXTURE_TEST_CASE(find_test, CatalogFixture) {
 
   BOOST_TEST_MESSAGE("--> find test ");
 
@@ -50,7 +49,7 @@ BOOST_FIXTURE_TEST_CASE( find_test, CatalogFixture ) {
   BOOST_CHECK_CLOSE(expected_error_2, ptr2->error, tolerance);
 }
 
-BOOST_FIXTURE_TEST_CASE( not_found_test, CatalogFixture ) {
+BOOST_FIXTURE_TEST_CASE(not_found_test, CatalogFixture) {
 
   BOOST_TEST_MESSAGE("--> not found find test! ");
 
@@ -58,8 +57,7 @@ BOOST_FIXTURE_TEST_CASE( not_found_test, CatalogFixture ) {
   BOOST_CHECK(ptr1 == nullptr);
 }
 
-
-BOOST_FIXTURE_TEST_CASE( iterator_test, CatalogFixture ) {
+BOOST_FIXTURE_TEST_CASE(iterator_test, CatalogFixture) {
 
   BOOST_TEST_MESSAGE("--> iterator test ");
 
@@ -72,17 +70,16 @@ BOOST_FIXTURE_TEST_CASE( iterator_test, CatalogFixture ) {
 
   // loop over the photometry object to check the different filter names, values and errors
   for (auto photo_iter = photometry.begin(); photo_iter != photometry.end(); ++photo_iter) {
-    BOOST_CHECK( photo_iter.filterName() ==  *expected_filter_name_iter );
+    BOOST_CHECK(photo_iter.filterName() == *expected_filter_name_iter);
     ++expected_filter_name_iter;
     BOOST_CHECK_CLOSE((*photo_iter).flux, expected_photo_iter->flux, tolerance);
     BOOST_CHECK_CLOSE((*photo_iter).error, expected_photo_iter->error, tolerance);
     ++expected_photo_iter;
   }
-
 }
 
 // This is how to iterate through the photometry values in most cases
-BOOST_FIXTURE_TEST_CASE( iterator_getter_test, CatalogFixture ) {
+BOOST_FIXTURE_TEST_CASE(iterator_getter_test, CatalogFixture) {
 
   BOOST_TEST_MESSAGE("--> iterator getter test ");
 
@@ -90,7 +87,7 @@ BOOST_FIXTURE_TEST_CASE( iterator_getter_test, CatalogFixture ) {
   auto expected_photo_iter = photometry_vector.cbegin();
 
   // loop over the photometry object to check the different values and errors
-  for (auto FluxErrorPair :  photometry) {
+  for (auto FluxErrorPair : photometry) {
     BOOST_CHECK_CLOSE(FluxErrorPair.flux, expected_photo_iter->flux, tolerance);
     BOOST_CHECK_CLOSE(FluxErrorPair.error, expected_photo_iter->error, tolerance);
     ++expected_photo_iter;
@@ -98,21 +95,21 @@ BOOST_FIXTURE_TEST_CASE( iterator_getter_test, CatalogFixture ) {
 }
 
 // Iterate modifying the values
-BOOST_FIXTURE_TEST_CASE ( iterator_modify_test, CatalogFixture ) {
+BOOST_FIXTURE_TEST_CASE(iterator_modify_test, CatalogFixture) {
   BOOST_TEST_MESSAGE("--> iterator set test ");
 
-  std::vector<FluxErrorPair> new_values {{1.56, 0.3}, {4.4, 1e-3}};
+  std::vector<FluxErrorPair> new_values{{1.56, 0.3}, {4.4, 1e-3}};
 
   // Modify the photometries
   size_t i = 0;
   for (auto iter = photometry.begin(); iter != photometry.end(); ++iter, ++i) {
-    iter->flux = new_values[i].flux;
+    iter->flux  = new_values[i].flux;
     iter->error = new_values[i].error;
   }
 
   // make sure they have been modified
   i = 0;
-  for (auto FluxErrorPair :  photometry) {
+  for (auto FluxErrorPair : photometry) {
     BOOST_CHECK_CLOSE(FluxErrorPair.flux, new_values[i].flux, tolerance);
     BOOST_CHECK_CLOSE(FluxErrorPair.error, new_values[i].error, tolerance);
     ++i;
@@ -120,10 +117,10 @@ BOOST_FIXTURE_TEST_CASE ( iterator_modify_test, CatalogFixture ) {
 }
 
 // Cast a non-const iterator to a const iterator
-BOOST_FIXTURE_TEST_CASE ( iterator_cast_test, CatalogFixture ) {
+BOOST_FIXTURE_TEST_CASE(iterator_cast_test, CatalogFixture) {
   BOOST_TEST_MESSAGE("--> iterator const cast ");
 
-  auto f = [this](Photometry::const_iterator begin, Photometry::const_iterator end){
+  auto f = [this](Photometry::const_iterator begin, Photometry::const_iterator end) {
     BOOST_CHECK_EQUAL(end - begin, 2);
     auto expected_photo_iter = photometry_vector.begin();
     for (auto i = begin; i != end; ++i) {
@@ -136,5 +133,4 @@ BOOST_FIXTURE_TEST_CASE ( iterator_cast_test, CatalogFixture ) {
   f(photometry.begin(), photometry.end());
 }
 
-
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/SourceCatalog/tests/src/SourceAttributes/SpectroscopicRedshiftAttributeFromRow_test.cpp
+++ b/SourceCatalog/tests/src/SourceAttributes/SpectroscopicRedshiftAttributeFromRow_test.cpp
@@ -16,20 +16,20 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/SourceAttributes/SpectroscopicRedshiftAttributeFromRow_test.cpp
  *
  * @date Apr 17, 2014
  * @author Pierre Dubath
  */
 
-#include <boost/test/unit_test.hpp>
-#include <memory>
-#include <map>
-#include "SourceCatalog/SourceAttributes/SpectroscopicRedshiftAttributeFromRow.h"
-#include "SourceCatalog/SourceAttributes/SpectroscopicRedshift.h"
 #include "ElementsKernel/Exception.h"
 #include "SourceCatalog/AttributeFromRow.h"
+#include "SourceCatalog/SourceAttributes/SpectroscopicRedshift.h"
+#include "SourceCatalog/SourceAttributes/SpectroscopicRedshiftAttributeFromRow.h"
+#include <boost/test/unit_test.hpp>
+#include <map>
+#include <memory>
 
 //-----------------------------------------------------------------------------
 // Include the TableFixture which contain a complete table mock object use here
@@ -38,15 +38,14 @@
 
 using namespace Euclid::SourceCatalog;
 
-
 //-----------------------------------------------------------------------------
 //
 
-BOOST_AUTO_TEST_SUITE (SpectroscopicRedshiftAttributeFromRow_test)
+BOOST_AUTO_TEST_SUITE(SpectroscopicRedshiftAttributeFromRow_test)
 
 //-----------------------------------------------------------------------------
 
-//BOOST_FIXTURE_TEST_CASE(createAttribute_test, TableFixture) {
+// BOOST_FIXTURE_TEST_CASE(createAttribute_test, TableFixture) {
 //
 //  BOOST_TEST_MESSAGE("--> createAttribute test ");
 //
@@ -62,32 +61,31 @@ BOOST_AUTO_TEST_SUITE (SpectroscopicRedshiftAttributeFromRow_test)
 
 //-----------------------------------------------------------------------------
 
-BOOST_FIXTURE_TEST_CASE( createAttribute_test, TableFixture ) {
+BOOST_FIXTURE_TEST_CASE(createAttribute_test, TableFixture) {
 
   BOOST_TEST_MESSAGE("--> createAttribute test ");
 
-  SpectroscopicRedshiftAttributeFromRow srafr {column_info_ptr, spec_z_val_col_name, spec_z_err_col_name};
+  SpectroscopicRedshiftAttributeFromRow srafr{column_info_ptr, spec_z_val_col_name, spec_z_err_col_name};
 
-//  unique_ptr<Euclid::SourceCatalog::Attribute> attribute_ptr_0 = srafr.createAttribute(row0);
-//
-//  BOOST_CHECK( typeid(*attribute_ptr_0) == typeid(Euclid::SourceCatalog::SpectroscopicRedshift) );
-//
-//  if(typeid(*attribute_ptr_0) == typeid(Euclid::SourceCatalog::SpectroscopicRedshift)) {
-//      Euclid::SourceCatalog::SpectroscopicRedshift& spectroscopicRedshift = dynamic_cast<Euclid::SourceCatalog::SpectroscopicRedshift&>( *attribute_ptr_0 );
-//      BOOST_CHECK_CLOSE(spectroscopicRedshift.getValue(), spec_z_val_row0 , tolerance);
-//      BOOST_CHECK_CLOSE(spectroscopicRedshift.getError(), spec_z_err_row0 , tolerance);
-//  }
+  //  unique_ptr<Euclid::SourceCatalog::Attribute> attribute_ptr_0 = srafr.createAttribute(row0);
+  //
+  //  BOOST_CHECK( typeid(*attribute_ptr_0) == typeid(Euclid::SourceCatalog::SpectroscopicRedshift) );
+  //
+  //  if(typeid(*attribute_ptr_0) == typeid(Euclid::SourceCatalog::SpectroscopicRedshift)) {
+  //      Euclid::SourceCatalog::SpectroscopicRedshift& spectroscopicRedshift =
+  //      dynamic_cast<Euclid::SourceCatalog::SpectroscopicRedshift&>( *attribute_ptr_0 );
+  //      BOOST_CHECK_CLOSE(spectroscopicRedshift.getValue(), spec_z_val_row0 , tolerance);
+  //      BOOST_CHECK_CLOSE(spectroscopicRedshift.getError(), spec_z_err_row0 , tolerance);
+  //  }
 
   std::unique_ptr<Euclid::SourceCatalog::Attribute> attribute_ptr_1 = srafr.createAttribute(row1);
-  Euclid::SourceCatalog::SpectroscopicRedshift* spectroscopicRedshift = dynamic_cast<Euclid::SourceCatalog::SpectroscopicRedshift*>(attribute_ptr_1.get());
+  Euclid::SourceCatalog::SpectroscopicRedshift*     spectroscopicRedshift =
+      dynamic_cast<Euclid::SourceCatalog::SpectroscopicRedshift*>(attribute_ptr_1.get());
   BOOST_CHECK(spectroscopicRedshift != nullptr);
-  BOOST_CHECK_CLOSE(spectroscopicRedshift->getValue(), spec_z_val_row1 , tolerance);
-  BOOST_CHECK_CLOSE(spectroscopicRedshift->getError(), spec_z_err_row1 , tolerance);
-
+  BOOST_CHECK_CLOSE(spectroscopicRedshift->getValue(), spec_z_val_row1, tolerance);
+  BOOST_CHECK_CLOSE(spectroscopicRedshift->getError(), spec_z_err_row1, tolerance);
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/SourceCatalog/tests/src/SourceAttributes/SpectroscopicRedshift_test.cpp
+++ b/SourceCatalog/tests/src/SourceAttributes/SpectroscopicRedshift_test.cpp
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/SourceAttributes/SpectroscopicRedshift_test.cpp
  *
  * @author Nicolas Morisset
@@ -24,14 +24,13 @@
  * Created on: Feb 5, 2014
  */
 
+#include "SourceCatalog/SourceAttributes/SpectroscopicRedshift.h"
 #include <boost/test/unit_test.hpp>
 #include <iostream>
-#include "SourceCatalog/SourceAttributes/SpectroscopicRedshift.h"
 
 using namespace Euclid::SourceCatalog;
 
 //-----------------------------------------------------------------------------
-
 
 struct SpectroscopicRedshiftFixture {
 
@@ -42,15 +41,14 @@ struct SpectroscopicRedshiftFixture {
     expected_value = 1.5;
     expected_error = 0.01;
   }
-  ~SpectroscopicRedshiftFixture() {
-  }
+  ~SpectroscopicRedshiftFixture() {}
 };
 
 //----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (SpectroscopicRedshift_test)
+BOOST_AUTO_TEST_SUITE(SpectroscopicRedshift_test)
 
-BOOST_FIXTURE_TEST_CASE( getter_test, SpectroscopicRedshiftFixture ) {
+BOOST_FIXTURE_TEST_CASE(getter_test, SpectroscopicRedshiftFixture) {
 
   SpectroscopicRedshift spectroscopicRedshift(expected_value, expected_error);
 
@@ -59,7 +57,6 @@ BOOST_FIXTURE_TEST_CASE( getter_test, SpectroscopicRedshiftFixture ) {
 
   BOOST_CHECK_EQUAL(expected_value, value_result);
   BOOST_CHECK_EQUAL(expected_error, error_result);
-
 }
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/SourceCatalog/tests/src/Source_test.cpp
+++ b/SourceCatalog/tests/src/Source_test.cpp
@@ -16,19 +16,19 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/Source_test.cpp
  *
  *  Created on: Jan 14, 2013
  *      Author: dubath
  */
 
-#include <boost/test/unit_test.hpp>
-#include "SourceCatalog/Source.h"
 #include "SourceCatalog/Attribute.h"
+#include "SourceCatalog/Source.h"
 #include "SourceCatalog/SourceAttributes/Coordinates.h"
 #include "SourceCatalog/SourceAttributes/Photometry.h"
 #include "SourceCatalog/SourceAttributes/SpectroscopicRedshift.h"
+#include <boost/test/unit_test.hpp>
 
 #include "ElementsKernel/Exception.h"
 
@@ -43,54 +43,52 @@ using namespace Euclid::SourceCatalog;
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (Source_test)
+BOOST_AUTO_TEST_SUITE(Source_test)
 
-BOOST_FIXTURE_TEST_CASE( getAttribute_test, CatalogFixture ) {
+BOOST_FIXTURE_TEST_CASE(getAttribute_test, CatalogFixture) {
 
-   BOOST_TEST_MESSAGE("--> getAttribute test ");
+  BOOST_TEST_MESSAGE("--> getAttribute test ");
 
   std::shared_ptr<Photometry> test_photometry_ptr(source_1.getAttribute<Photometry>());
-//   cout << " Flux  : " << (ptrPhoto->find(expectedFilterName))->flux
-//        << " Error : " << (ptrPhoto->find(expectedFilterName))->error
-//        << endl;
-   BOOST_CHECK_CLOSE(expected_flux_1, (test_photometry_ptr->find(expected_filter_name_1))->flux, tolerance);
-   BOOST_CHECK_CLOSE(expected_error_2, (test_photometry_ptr->find(expected_filter_name_2))->error, tolerance);
+  //   cout << " Flux  : " << (ptrPhoto->find(expectedFilterName))->flux
+  //        << " Error : " << (ptrPhoto->find(expectedFilterName))->error
+  //        << endl;
+  BOOST_CHECK_CLOSE(expected_flux_1, (test_photometry_ptr->find(expected_filter_name_1))->flux, tolerance);
+  BOOST_CHECK_CLOSE(expected_error_2, (test_photometry_ptr->find(expected_filter_name_2))->error, tolerance);
 
   std::shared_ptr<Coordinates> coordinate_ptr(source_1.getAttribute<Coordinates>());
-//   cout << " Ra  : " << ptrCoord->getRa()
-//        << " Dec : " << ptrCoord->getDec()
-//        << endl;
-   BOOST_CHECK_CLOSE(expected_ra_1, coordinate_ptr->getRa(), tolerance);
-   BOOST_CHECK_CLOSE(expected_dec_1, coordinate_ptr->getDec(), tolerance);
+  //   cout << " Ra  : " << ptrCoord->getRa()
+  //        << " Dec : " << ptrCoord->getDec()
+  //        << endl;
+  BOOST_CHECK_CLOSE(expected_ra_1, coordinate_ptr->getRa(), tolerance);
+  BOOST_CHECK_CLOSE(expected_dec_1, coordinate_ptr->getDec(), tolerance);
 
   std::shared_ptr<SpectroscopicRedshift> redshift_ptr(source_1.getAttribute<SpectroscopicRedshift>());
-//   cout << " Zvalue : " << ptrRedshift->getValue()
-//        << " Error  : " << ptrRedshift->getError()
-//        << endl;
-   BOOST_CHECK_CLOSE(expected_z_value, redshift_ptr->getValue(), tolerance);
-   BOOST_CHECK_CLOSE(expected_z_error, redshift_ptr->getError(), tolerance);
-
+  //   cout << " Zvalue : " << ptrRedshift->getValue()
+  //        << " Error  : " << ptrRedshift->getError()
+  //        << endl;
+  BOOST_CHECK_CLOSE(expected_z_value, redshift_ptr->getValue(), tolerance);
+  BOOST_CHECK_CLOSE(expected_z_error, redshift_ptr->getError(), tolerance);
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_FIXTURE_TEST_CASE( getId_test, CatalogFixture ) {
+BOOST_FIXTURE_TEST_CASE(getId_test, CatalogFixture) {
 
-   BOOST_TEST_MESSAGE("--> getId test ");
-   auto sourceId = source_1.getId();
-   BOOST_CHECK_EQUAL(expected_source_id_1, sourceId);
-
+  BOOST_TEST_MESSAGE("--> getId test ");
+  auto sourceId = source_1.getId();
+  BOOST_CHECK_EQUAL(expected_source_id_1, sourceId);
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_FIXTURE_TEST_CASE( missing_attribute_test, CatalogFixture ) {
+BOOST_FIXTURE_TEST_CASE(missing_attribute_test, CatalogFixture) {
 
-   BOOST_TEST_MESSAGE("--> missing_attribute test ");
-   std::shared_ptr<Photometry> ptrPhoto(source_2.getAttribute<Photometry>());
-   BOOST_CHECK(nullptr == ptrPhoto);
+  BOOST_TEST_MESSAGE("--> missing_attribute test ");
+  std::shared_ptr<Photometry> ptrPhoto(source_2.getAttribute<Photometry>());
+  BOOST_CHECK(nullptr == ptrPhoto);
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/SourceCatalog/tests/src/TableFixture.h
+++ b/SourceCatalog/tests/src/TableFixture.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/TableFixture.h
  *
  * @date May 16, 2014
@@ -26,14 +26,14 @@
 #ifndef TABLEFIXTURE_H_
 #define TABLEFIXTURE_H_
 
-#include <memory>
-#include <vector>
-#include <utility>
-#include <cmath>
-#include <cfloat>
+#include "Table/ColumnInfo.h"
 #include "Table/Row.h"
 #include "Table/Table.h"
-#include "Table/ColumnInfo.h"
+#include <cfloat>
+#include <cmath>
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace Euclid {
 namespace SourceCatalog {
@@ -41,30 +41,27 @@ namespace SourceCatalog {
 struct TableFixture {
   double tolerance = 1e-12;
 
-  std::string source_id_name = "Test_source_id";
-  std::string source_id_str_name = "Test_source_id_str";
+  std::string source_id_name      = "Test_source_id";
+  std::string source_id_str_name  = "Test_source_id_str";
   std::string spec_z_val_col_name = "SpecZval";
   std::string spec_z_err_col_name = "SpecZerr";
 
-
   // A test table with two flux columns and two rows
-  const std::vector <Euclid::Table::ColumnInfo::info_type> info_list{
-    Euclid::Table::ColumnInfo::info_type(source_id_name, typeid(int64_t)),
-    Euclid::Table::ColumnInfo::info_type(source_id_str_name, typeid(std::string)),
-    Euclid::Table::ColumnInfo::info_type("Boolean", typeid(bool)),
-    Euclid::Table::ColumnInfo::info_type("Integer", typeid(int32_t)),
-    Euclid::Table::ColumnInfo::info_type("Long", typeid(int64_t)),
-    Euclid::Table::ColumnInfo::info_type("Float", typeid(float)),
-    Euclid::Table::ColumnInfo::info_type("Double_flux1", typeid(double)),
-    Euclid::Table::ColumnInfo::info_type("Double_flux2", typeid(double)),
-    Euclid::Table::ColumnInfo::info_type("Double_error1", typeid(double)),
-    Euclid::Table::ColumnInfo::info_type("Double_error2", typeid(double)),
-    Euclid::Table::ColumnInfo::info_type("String", typeid(std::string)),
-    Euclid::Table::ColumnInfo::info_type(spec_z_val_col_name, typeid(double)),
-    Euclid::Table::ColumnInfo::info_type(spec_z_err_col_name, typeid(double))
-  };
-  const std::shared_ptr <Euclid::Table::ColumnInfo> column_info_ptr{
-    new Euclid::Table::ColumnInfo{info_list}};
+  const std::vector<Euclid::Table::ColumnInfo::info_type> info_list{
+      Euclid::Table::ColumnInfo::info_type(source_id_name, typeid(int64_t)),
+      Euclid::Table::ColumnInfo::info_type(source_id_str_name, typeid(std::string)),
+      Euclid::Table::ColumnInfo::info_type("Boolean", typeid(bool)),
+      Euclid::Table::ColumnInfo::info_type("Integer", typeid(int32_t)),
+      Euclid::Table::ColumnInfo::info_type("Long", typeid(int64_t)),
+      Euclid::Table::ColumnInfo::info_type("Float", typeid(float)),
+      Euclid::Table::ColumnInfo::info_type("Double_flux1", typeid(double)),
+      Euclid::Table::ColumnInfo::info_type("Double_flux2", typeid(double)),
+      Euclid::Table::ColumnInfo::info_type("Double_error1", typeid(double)),
+      Euclid::Table::ColumnInfo::info_type("Double_error2", typeid(double)),
+      Euclid::Table::ColumnInfo::info_type("String", typeid(std::string)),
+      Euclid::Table::ColumnInfo::info_type(spec_z_val_col_name, typeid(double)),
+      Euclid::Table::ColumnInfo::info_type(spec_z_err_col_name, typeid(double))};
+  const std::shared_ptr<Euclid::Table::ColumnInfo> column_info_ptr{new Euclid::Table::ColumnInfo{info_list}};
 
   int64_t source_id_1{756330785};
   int64_t source_id_2{127548910};
@@ -72,8 +69,8 @@ struct TableFixture {
   std::string source_str_id_1{"ID0"};
   std::string source_str_id_2{"ID1"};
 
-  double flux1_row1 = 1.12345e-12;
-  double flux2_row1 = 1.12345e-1;
+  double flux1_row1  = 1.12345e-12;
+  double flux2_row1  = 1.12345e-1;
   double error1_row1 = 1.12345e-18;
   double error2_row1 = 1.1e-2;
 
@@ -82,77 +79,73 @@ struct TableFixture {
   double spec_z_val_row1 = 0.1296457;
   double spec_z_err_row1 = 0.003647;
 
-  const std::vector <Euclid::Table::Row::cell_type> values0{source_id_1, source_str_id_1, true, 1,
-                                                       int64_t{123}, 0.F, 0.1, 0.2, 0.3, 0.4, std::string{"first"},
-                                                       spec_z_val_row0,
-                                                       spec_z_err_row0};
+  const std::vector<Euclid::Table::Row::cell_type> values0{
+      source_id_1,          source_str_id_1, true,           1, int64_t{123}, 0.F, 0.1, 0.2, 0.3, 0.4,
+      std::string{"first"}, spec_z_val_row0, spec_z_err_row0};
   const Euclid::Table::Row row0{values0, column_info_ptr};
 
-
-  const std::vector <Euclid::Table::Row::cell_type> values1{source_id_2, source_str_id_2, false, 12345,
-                                                       int64_t{123456789}, 2.3e-2F, flux1_row1, flux2_row1, error1_row1,
-                                                       error2_row1, std::string{"second"}, spec_z_val_row1, spec_z_err_row1};
+  const std::vector<Euclid::Table::Row::cell_type> values1{
+      source_id_2,    source_str_id_2, false,       12345,       int64_t{123456789},    2.3e-2F,
+      flux1_row1,     flux2_row1,      error1_row1, error2_row1, std::string{"second"}, spec_z_val_row1,
+      spec_z_err_row1};
   const Euclid::Table::Row row1{values1, column_info_ptr};
 
+  const std::vector<Euclid::Table::Row> row_list{row0, row1};
+  const Euclid::Table::Table            table{row_list};
 
-  const std::vector <Euclid::Table::Row> row_list{row0, row1};
-  const Euclid::Table::Table table{row_list};
-
-
-  const std::vector<Euclid::Table::Row::cell_type> values2{int64_t(999), std::string{"ID2"}, true, 1, int64_t{123}, 0.F,
-                                                           -1., 3., 0.5, 0.3,
-                                                           std::string{"first"}, spec_z_val_row0, spec_z_err_row0};
+  const std::vector<Euclid::Table::Row::cell_type> values2{
+      int64_t(999),         std::string{"ID2"}, true,           1, int64_t{123}, 0.F, -1., 3., 0.5, 0.3,
+      std::string{"first"}, spec_z_val_row0,    spec_z_err_row0};
   const Euclid::Table::Row row_neg_flux{values2, column_info_ptr};
 
-  const std::vector<Euclid::Table::Row::cell_type> values3{int64_t(1000), std::string{"ID3"}, true, 1, int64_t{123},
-                                                           0.F, 0., 3., 0.5, 0.3,
-                                                           std::string{"first"}, spec_z_val_row0, spec_z_err_row0};
+  const std::vector<Euclid::Table::Row::cell_type> values3{
+      int64_t(1000),        std::string{"ID3"}, true,           1, int64_t{123}, 0.F, 0., 3., 0.5, 0.3,
+      std::string{"first"}, spec_z_val_row0,    spec_z_err_row0};
   const Euclid::Table::Row row_zero_flux{values3, column_info_ptr};
 
-  const std::vector<Euclid::Table::Row::cell_type> values4{int64_t(1001), std::string{"ID4"}, true, 1, int64_t{123},
-                                                           0.F, 1., 3., 0.5, 0.3,
-                                                           std::string{"first"}, spec_z_val_row0, spec_z_err_row0};
+  const std::vector<Euclid::Table::Row::cell_type> values4{
+      int64_t(1001),        std::string{"ID4"}, true,           1, int64_t{123}, 0.F, 1., 3., 0.5, 0.3,
+      std::string{"first"}, spec_z_val_row0,    spec_z_err_row0};
   const Euclid::Table::Row row_nominal_case{values4, column_info_ptr};
 
-  const std::vector<Euclid::Table::Row::cell_type> values5{int64_t(1002), std::string{"ID5"}, true, 1, int64_t{123},
-                                                           0.F, -99., 3., 0.5, 0.3,
-                                                           std::string{"first"}, spec_z_val_row0, spec_z_err_row0};
+  const std::vector<Euclid::Table::Row::cell_type> values5{
+      int64_t(1002),        std::string{"ID5"}, true,           1, int64_t{123}, 0.F, -99., 3., 0.5, 0.3,
+      std::string{"first"}, spec_z_val_row0,    spec_z_err_row0};
   const Euclid::Table::Row row_flag_flux{values5, column_info_ptr};
 
-  const std::vector <Euclid::Table::Row::cell_type> values6{int64_t(1005), std::string{"ID6"}, true, 1, int64_t{123},
-                                                            0.F, 1., 3., -0.5, 0.3,
-                                                            std::string{"first"}, spec_z_val_row0, spec_z_err_row0};
+  const std::vector<Euclid::Table::Row::cell_type> values6{
+      int64_t(1005),        std::string{"ID6"}, true,           1, int64_t{123}, 0.F, 1., 3., -0.5, 0.3,
+      std::string{"first"}, spec_z_val_row0,    spec_z_err_row0};
   const Euclid::Table::Row row_neg_error{values6, column_info_ptr};
 
-  const std::vector <Euclid::Table::Row::cell_type> values7{int64_t(1006), std::string{"ID7"}, true, 1, int64_t{123},
-                                                            0.F, 1., 3., 0., 0.3,
-                                                            std::string{"first"}, spec_z_val_row0, spec_z_err_row0};
+  const std::vector<Euclid::Table::Row::cell_type> values7{
+      int64_t(1006),        std::string{"ID7"}, true,           1, int64_t{123}, 0.F, 1., 3., 0., 0.3,
+      std::string{"first"}, spec_z_val_row0,    spec_z_err_row0};
   const Euclid::Table::Row row_zero_error{values7, column_info_ptr};
 
-  const std::vector <Euclid::Table::Row::cell_type> values8{int64_t(1007), std::string{"ID8"}, true, 1, int64_t{123},
-                                                            0.F, -99., 3., -0.5, 0.3,
-                                                            std::string{"first"}, spec_z_val_row0, spec_z_err_row0};
+  const std::vector<Euclid::Table::Row::cell_type> values8{
+      int64_t(1007),        std::string{"ID8"}, true,           1, int64_t{123}, 0.F, -99., 3., -0.5, 0.3,
+      std::string{"first"}, spec_z_val_row0,    spec_z_err_row0};
   const Euclid::Table::Row row_flag_flux_neg_error{values8, column_info_ptr};
 
-  const std::vector<Euclid::Table::Row::cell_type> values9{int64_t(1008), std::string{"ID9"}, true, 1, int64_t{123},
-                                                           0.F, -99., 3., 0., 0.3,
-                                                           std::string{"first"}, spec_z_val_row0, spec_z_err_row0};
+  const std::vector<Euclid::Table::Row::cell_type> values9{
+      int64_t(1008),        std::string{"ID9"}, true,           1, int64_t{123}, 0.F, -99., 3., 0., 0.3,
+      std::string{"first"}, spec_z_val_row0,    spec_z_err_row0};
   const Euclid::Table::Row row_flag_flux_zero_error{values9, column_info_ptr};
 
-  const std::vector <Euclid::Table::Row::cell_type> values10{int64_t(1009), std::string{"ID10"}, true, 1, int64_t{123},
-                                                             0.F, 0., 3., -0.5, 0.3,
-                                                             std::string{"first"}, spec_z_val_row0, spec_z_err_row0};
-  const Euclid::Table::Row row_zero_flux_neg_error{values10, column_info_ptr};
-  const std::vector <Euclid::Table::Row::cell_type> values11{int64_t(1010), std::string{"ID11"}, true, 1, int64_t{123},
-                                                             0.F, -1., 3., -0.5, 0.3,
-                                                             std::string{"first"}, spec_z_val_row0, spec_z_err_row0};
+  const std::vector<Euclid::Table::Row::cell_type> values10{
+      int64_t(1009),        std::string{"ID10"}, true,           1, int64_t{123}, 0.F, 0., 3., -0.5, 0.3,
+      std::string{"first"}, spec_z_val_row0,     spec_z_err_row0};
+  const Euclid::Table::Row                         row_zero_flux_neg_error{values10, column_info_ptr};
+  const std::vector<Euclid::Table::Row::cell_type> values11{
+      int64_t(1010),        std::string{"ID11"}, true,           1, int64_t{123}, 0.F, -1., 3., -0.5, 0.3,
+      std::string{"first"}, spec_z_val_row0,     spec_z_err_row0};
   const Euclid::Table::Row row_neg_flux_neg_error{values11, column_info_ptr};
 
-  const std::vector<Euclid::Table::Row::cell_type> values12{int64_t(1011), std::string{"ID12"}, true, 1, int64_t{123},
-                                                            0.F, 1., 3., -99., -99.,
-                                                            std::string{"first"}, spec_z_val_row0, spec_z_err_row0};
+  const std::vector<Euclid::Table::Row::cell_type> values12{
+      int64_t(1011),        std::string{"ID12"}, true,           1, int64_t{123}, 0.F, 1., 3., -99., -99.,
+      std::string{"first"}, spec_z_val_row0,     spec_z_err_row0};
   const Euclid::Table::Row row_neg_error_flag{values12, column_info_ptr};
-
 
   // Two filter names
   const std::string v_filter_name{"TestGroup/VtestName"};
@@ -160,7 +153,7 @@ struct TableFixture {
 
   // the mapping variable
   std::vector<std::pair<std::string, std::pair<std::string, std::string>>> filter_name_mapping;
-  std::vector<std::pair<std::string, float>> threshold_mapping;
+  std::vector<std::pair<std::string, float>>                               threshold_mapping;
 
   TableFixture() {
     // This is how the mapping must be defined
@@ -176,7 +169,7 @@ struct TableFixture {
   }
 };
 
-} // end of namespace SourceCatalog
-} // end of namespace Euclid
+}  // end of namespace SourceCatalog
+}  // end of namespace Euclid
 
-#endif // TABLEFIXTURE_H_
+#endif  // TABLEFIXTURE_H_

--- a/Table/Table/AsciiReader.h
+++ b/Table/Table/AsciiReader.h
@@ -87,7 +87,6 @@ namespace Table {
 class AsciiReader : public TableReader {
 
 public:
-
   /**
    * @brief Constructs an AsciiReader which contains an object of type StreamType
    *
@@ -202,7 +201,6 @@ public:
   std::size_t rowsLeft() override;
 
 protected:
-
   /**
    * @brief Reads the next rows into a Table
    * @details
@@ -222,17 +220,16 @@ protected:
   Table readImpl(long rows) override;
 
 private:
-
   explicit AsciiReader(std::unique_ptr<InstOrRefHolder<std::istream>> stream_holder);
 
   void readColumnInfo();
 
   std::unique_ptr<InstOrRefHolder<std::istream>> m_stream_holder;
-  bool m_reading_started = false;
-  std::string m_comment = "#";
-  std::vector<std::type_index> m_column_types {};
-  std::vector<std::string> m_column_names {};
-  std::shared_ptr<ColumnInfo> m_column_info;
+  bool                                           m_reading_started = false;
+  std::string                                    m_comment         = "#";
+  std::vector<std::type_index>                   m_column_types{};
+  std::vector<std::string>                       m_column_names{};
+  std::shared_ptr<ColumnInfo>                    m_column_info;
 
 }; /* End of AsciiReader class */
 

--- a/Table/Table/AsciiWriter.h
+++ b/Table/Table/AsciiWriter.h
@@ -80,7 +80,6 @@ namespace Table {
 class AsciiWriter : public TableWriter {
 
 public:
-
   /**
    * @brief Constructs an AsciiWriter which contains an object of type StreamType
    *
@@ -167,7 +166,6 @@ public:
   void addComment(const std::string& message) override;
 
 protected:
-
   /// Writes to the stream the column info, following the rules explained at the
   /// class documentation
   void init(const Table& table) override;
@@ -177,20 +175,19 @@ protected:
   void append(const Table& table) override;
 
 private:
-
   AsciiWriter(std::unique_ptr<InstOrRefHolder<std::ostream>> stream_holder);
 
   std::unique_ptr<InstOrRefHolder<std::ostream>> m_stream_holder;
-  bool m_writing_started = false;
-  bool m_initialized = false;
-  std::string m_comment = "#";
-  bool m_show_column_info = true;
-  std::vector<size_t> m_column_lengths;
+  bool                                           m_writing_started  = false;
+  bool                                           m_initialized      = false;
+  std::string                                    m_comment          = "#";
+  bool                                           m_show_column_info = true;
+  std::vector<size_t>                            m_column_lengths;
 
-}; // End of AsciiWriter class
+};  // End of AsciiWriter class
 
-} // namespace Table
-} // namespace Euclid
+}  // namespace Table
+}  // namespace Euclid
 
 #include "Table/_impl/AsciiWriter.icpp"
 

--- a/Table/Table/CastVisitor.h
+++ b/Table/Table/CastVisitor.h
@@ -25,14 +25,14 @@
 #ifndef _TABLE_CASTVISITOR_H
 #define _TABLE_CASTVISITOR_H
 
+#include "ElementsKernel/Exception.h"
+#include <boost/tokenizer.hpp>
+#include <boost/variant/static_visitor.hpp>
+#include <cmath>
 #include <sstream>
+#include <type_traits>
 #include <typeinfo>
 #include <vector>
-#include <type_traits>
-#include <boost/variant/static_visitor.hpp>
-#include <boost/tokenizer.hpp>
-#include <cmath>
-#include "ElementsKernel/Exception.h"
 
 namespace Euclid {
 namespace Table {
@@ -41,32 +41,27 @@ template <typename To>
 class CastVisitor : public boost::static_visitor<To> {
 
 public:
-
   template <typename From>
-  To operator() (const From& from, typename std::enable_if<std::is_same<From, To>::value>::type* = 0) const {
+  To operator()(const From& from, typename std::enable_if<std::is_same<From, To>::value>::type* = 0) const {
     return from;
   }
 
   template <typename From>
-  To operator() (const From&, typename std::enable_if<!std::is_same<From, To>::value>::type* = 0) const {
-    throw Elements::Exception() << "CastVisitor cannot convert "
-            << typeid(From).name() << " type to " << typeid(To).name();
+  To operator()(const From&, typename std::enable_if<!std::is_same<From, To>::value>::type* = 0) const {
+    throw Elements::Exception() << "CastVisitor cannot convert " << typeid(From).name() << " type to " << typeid(To).name();
   }
-
 };
 
 template <>
 class CastVisitor<std::string> : public boost::static_visitor<std::string> {
 
 public:
-
   template <typename From>
-  std::string operator() (const From& from) const {
-    std::stringstream result {};
+  std::string operator()(const From& from) const {
+    std::stringstream result{};
     result << from;
     return result.str();
   }
-
 };
 
 template <>
@@ -74,37 +69,31 @@ class CastVisitor<double> : public boost::static_visitor<double> {
 
   template <typename From>
   static constexpr bool generic() {
-    return std::is_arithmetic<From>::value ||
-           std::is_same<From, typename std::vector<bool>::const_reference>::value;
+    return std::is_arithmetic<From>::value || std::is_same<From, typename std::vector<bool>::const_reference>::value;
   }
 
 public:
-
   template <typename From>
-  double operator() (const From& , typename std::enable_if<!generic<From>()>::type* = 0) const {
-    throw Elements::Exception() << "CastVisitor cannot convert "
-            << typeid(From).name() << " type to " << typeid(double).name();
+  double operator()(const From&, typename std::enable_if<!generic<From>()>::type* = 0) const {
+    throw Elements::Exception() << "CastVisitor cannot convert " << typeid(From).name() << " type to " << typeid(double).name();
   }
 
   template <typename From>
-  double operator() (const From& from, typename std::enable_if<generic<From>()>::type* = 0) const {
+  double operator()(const From& from, typename std::enable_if<generic<From>()>::type* = 0) const {
     return from;
   }
 
-  double operator() (const std::string& from) const {
-    char *endptr = nullptr;
-    double value = std::strtod(from.c_str(), &endptr);
+  double operator()(const std::string& from) const {
+    char*  endptr = nullptr;
+    double value  = std::strtod(from.c_str(), &endptr);
     if (endptr == from.c_str()) {
-      throw Elements::Exception() << "CastVisitor cannot convert the string '"
-                                  << from << "' to " << typeid(double).name();
+      throw Elements::Exception() << "CastVisitor cannot convert the string '" << from << "' to " << typeid(double).name();
     }
     if (value == HUGE_VAL || value == -HUGE_VAL) {
-      throw Elements::Exception() << "CastVisitor overflows converting the string '"
-                                  << from << "' to " << typeid(double).name();
+      throw Elements::Exception() << "CastVisitor overflows converting the string '" << from << "' to " << typeid(double).name();
     }
     return value;
   }
-
 };
 
 template <>
@@ -117,32 +106,27 @@ class CastVisitor<float> : public boost::static_visitor<float> {
   }
 
 public:
-
   template <typename From>
-  double operator() (const From& , typename std::enable_if<!generic<From>()>::type* = 0) const {
-    throw Elements::Exception() << "CastVisitor cannot convert "
-            << typeid(From).name() << " type to " << typeid(float).name();
+  double operator()(const From&, typename std::enable_if<!generic<From>()>::type* = 0) const {
+    throw Elements::Exception() << "CastVisitor cannot convert " << typeid(From).name() << " type to " << typeid(float).name();
   }
 
   template <typename From>
-  float operator() (const From& from, typename std::enable_if<generic<From>()>::type* = 0) const {
+  float operator()(const From& from, typename std::enable_if<generic<From>()>::type* = 0) const {
     return from;
   }
 
-  float operator() (const std::string& from) const {
-    char *endptr = nullptr;
-    float value = std::strtof(from.c_str(), &endptr);
+  float operator()(const std::string& from) const {
+    char* endptr = nullptr;
+    float value  = std::strtof(from.c_str(), &endptr);
     if (endptr == from.c_str()) {
-      throw Elements::Exception() << "CastVisitor cannot convert the string '"
-                                  << from << "' to " << typeid(float).name();
+      throw Elements::Exception() << "CastVisitor cannot convert the string '" << from << "' to " << typeid(float).name();
     }
     if (value == HUGE_VALF || value == -HUGE_VALF) {
-      throw Elements::Exception() << "CastVisitor overflows converting the string '"
-                                  << from << "' to " << typeid(float).name();
+      throw Elements::Exception() << "CastVisitor overflows converting the string '" << from << "' to " << typeid(float).name();
     }
     return value;
   }
-
 };
 
 template <>
@@ -150,33 +134,28 @@ class CastVisitor<int64_t> : public boost::static_visitor<int64_t> {
 
   template <typename From>
   static constexpr bool generic() {
-    return std::is_integral<From>::value ||
-           std::is_same<From, typename std::vector<bool>::const_reference>::value;
+    return std::is_integral<From>::value || std::is_same<From, typename std::vector<bool>::const_reference>::value;
   }
 
 public:
-
   template <typename From>
-  double operator() (const From& , typename std::enable_if<!generic<From>()>::type* = 0) const {
-    throw Elements::Exception() << "CastVisitor cannot convert "
-            << typeid(From).name() << " type to " << typeid(int64_t).name();
+  double operator()(const From&, typename std::enable_if<!generic<From>()>::type* = 0) const {
+    throw Elements::Exception() << "CastVisitor cannot convert " << typeid(From).name() << " type to " << typeid(int64_t).name();
   }
 
   template <typename From>
-  int64_t operator() (const From& from, typename std::enable_if<generic<From>()>::type* = 0) const {
+  int64_t operator()(const From& from, typename std::enable_if<generic<From>()>::type* = 0) const {
     return from;
   }
 
-  int64_t operator() (const std::string& from) const {
-    char *endptr = nullptr;
-    int64_t value = std::strtoll(from.c_str(), &endptr, 10);
+  int64_t operator()(const std::string& from) const {
+    char*   endptr = nullptr;
+    int64_t value  = std::strtoll(from.c_str(), &endptr, 10);
     if (endptr == from.c_str()) {
-      throw Elements::Exception() << "CastVisitor cannot convert the string '"
-            << from << "' to " << typeid(int64_t).name();
+      throw Elements::Exception() << "CastVisitor cannot convert the string '" << from << "' to " << typeid(int64_t).name();
     }
     return value;
   }
-
 };
 
 template <>
@@ -189,59 +168,53 @@ class CastVisitor<int32_t> : public boost::static_visitor<int32_t> {
   }
 
 public:
-
   template <typename From>
-  double operator() (const From& , typename std::enable_if<!generic<From>()>::type* = 0) const {
-    throw Elements::Exception() << "CastVisitor cannot convert "
-            << typeid(From).name() << " type to " << typeid(int32_t).name();
+  double operator()(const From&, typename std::enable_if<!generic<From>()>::type* = 0) const {
+    throw Elements::Exception() << "CastVisitor cannot convert " << typeid(From).name() << " type to " << typeid(int32_t).name();
   }
 
   template <typename From>
-  int32_t operator() (const From& from, typename std::enable_if<generic<From>()>::type* = 0) const {
+  int32_t operator()(const From& from, typename std::enable_if<generic<From>()>::type* = 0) const {
     return from;
   }
 
-  int32_t operator() (const std::string& from) const {
-    char *endptr = nullptr;
-    int64_t value = std::strtoll(from.c_str(), &endptr, 10);
+  int32_t operator()(const std::string& from) const {
+    char*   endptr = nullptr;
+    int64_t value  = std::strtoll(from.c_str(), &endptr, 10);
     if (endptr == from.c_str()) {
-      throw Elements::Exception() << "CastVisitor cannot convert the string '"
-                                  << from << "' to " << typeid(int32_t).name();
+      throw Elements::Exception() << "CastVisitor cannot convert the string '" << from << "' to " << typeid(int32_t).name();
     }
     if (value > INT32_MAX || value < INT32_MIN) {
-      throw Elements::Exception() << "CastVisitor overflows converting the string '"
-                                  << from << "' to " << typeid(int32_t).name();
+      throw Elements::Exception() << "CastVisitor overflows converting the string '" << from << "' to " << typeid(int32_t).name();
     }
     return static_cast<int32_t>(value);
   }
-
 };
 
 template <typename VectorType>
 class CastVisitor<std::vector<VectorType>> : public boost::static_visitor<std::vector<VectorType>> {
 
 public:
-
   template <typename From>
-  std::vector<VectorType> operator() (const From& from) const {
-    std::vector<VectorType> result {};
+  std::vector<VectorType> operator()(const From& from) const {
+    std::vector<VectorType> result{};
     result.push_back(CastVisitor<VectorType>{}(from));
     return result;
   }
 
   template <typename From>
-  std::vector<VectorType> operator() (const std::vector<From>& from) const {
-    std::vector<VectorType> result {};
+  std::vector<VectorType> operator()(const std::vector<From>& from) const {
+    std::vector<VectorType> result{};
     for (auto v : from) {
       result.push_back(CastVisitor<VectorType>{}(v));
     }
     return result;
   }
 
-  std::vector<VectorType> operator() (const std::string& from) const {
-    std::vector<VectorType> result {};
-    boost::char_separator<char> sep {","};
-    boost::tokenizer< boost::char_separator<char> > tok {from, sep};
+  std::vector<VectorType> operator()(const std::string& from) const {
+    std::vector<VectorType>                       result{};
+    boost::char_separator<char>                   sep{","};
+    boost::tokenizer<boost::char_separator<char>> tok{from, sep};
     for (auto& s : tok) {
       result.push_back(CastVisitor<VectorType>{}(s));
     }
@@ -249,14 +222,12 @@ public:
   }
 
   // If the types match exactly we avoid an expensive copying
-  const std::vector<VectorType>& operator() (const std::vector<VectorType>& from) const {
+  const std::vector<VectorType>& operator()(const std::vector<VectorType>& from) const {
     return from;
   }
-
 };
 
 } /* namespace Table */
 } /* namespace Euclid */
-
 
 #endif

--- a/Table/Table/ColumnDescription.h
+++ b/Table/Table/ColumnDescription.h
@@ -25,11 +25,11 @@
 #ifndef _TABLE_COLUMNDESCRIPTION_H
 #define _TABLE_COLUMNDESCRIPTION_H
 
+#include <functional>
+#include <iomanip>
+#include <ostream>
 #include <string>
 #include <typeindex>
-#include <iomanip>
-#include <functional>
-#include <ostream>
 
 namespace Euclid {
 namespace Table {
@@ -55,22 +55,20 @@ namespace Table {
 class ColumnDescription {
 
 public:
-
   /// Constructs a new ColumnDescription instance
   /// @throws Elements::Exception
   ///     if the name is the empty string or if it contains whitespaces
-  ColumnDescription(std::string name, std::type_index type=typeid(std::string),
-                    std::string unit="", std::string description="");
+  ColumnDescription(std::string name, std::type_index type = typeid(std::string), std::string unit = "",
+                    std::string description = "");
 
   ColumnDescription(const ColumnDescription&) = default;
-  ColumnDescription(ColumnDescription&&) = default;
+  ColumnDescription(ColumnDescription&&)      = default;
   ColumnDescription& operator=(const ColumnDescription&) = default;
   ColumnDescription& operator=(ColumnDescription&&) = default;
 
-
   /// Returns true if the two ColumnDescriptions do not describe the same column
   bool operator!=(const ColumnDescription& other) const {
-    return !(*this == other); // Reuse equals operator
+    return !(*this == other);  // Reuse equals operator
   }
 
   /// Returns true if the two ColumnDescriptions describe the same column
@@ -79,15 +77,14 @@ public:
     return name == other.name && type == other.type && unit == other.unit;
   }
 
-  std::string name;
+  std::string     name;
   std::type_index type;
-  std::string unit;
-  std::string description;
+  std::string     unit;
+  std::string     description;
 
 }; /* End of ColumnDescription class */
 
 } /* namespace Table */
 } /* namespace Euclid */
-
 
 #endif

--- a/Table/Table/ColumnInfo.h
+++ b/Table/Table/ColumnInfo.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file Table/ColumnInfo.h
  * @date April 7, 2014
  * @author Nikolaos Apostolakos
@@ -25,11 +25,11 @@
 #ifndef TABLE_COLUMNINFO_H
 #define TABLE_COLUMNINFO_H
 
-#include <string>
-#include <vector>
 #include <memory>
+#include <string>
 #include <typeindex>
 #include <utility>
+#include <vector>
 
 #include "ElementsKernel/Export.h"
 
@@ -52,7 +52,6 @@ namespace Table {
 class ELEMENTS_API ColumnInfo {
 
 public:
-
   using info_type = ColumnDescription;
 
   /**
@@ -140,11 +139,9 @@ public:
 
 private:
   std::vector<info_type> m_info_list;
-
 };
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid
 
-#endif  /* TABLE_COLUMNINFO_H */
-
+#endif /* TABLE_COLUMNINFO_H */

--- a/Table/Table/FitsReader.h
+++ b/Table/Table/FitsReader.h
@@ -25,9 +25,9 @@
 #ifndef _TABLE_FITSREADER_H
 #define _TABLE_FITSREADER_H
 
-#include <functional>
-#include <CCfits/CCfits>
 #include "Table/TableReader.h"
+#include <CCfits/CCfits>
+#include <functional>
 
 namespace Euclid {
 namespace Table {
@@ -75,7 +75,6 @@ namespace Table {
 class FitsReader : public TableReader {
 
 public:
-
   /**
    * @brief Creates a FitsReader that reads from the given HDU
    *
@@ -93,7 +92,7 @@ public:
 
   /// Creates a FitsReader that reads a table from a FITS file, based on the
   /// HDU index
-  FitsReader(const std::string& filename, int hdu_index=1);
+  FitsReader(const std::string& filename, int hdu_index = 1);
 
   /// Creates a FitsReader that reads a table from a FITS file, based on the
   /// HDU name
@@ -153,26 +152,23 @@ public:
   std::size_t rowsLeft() override;
 
 protected:
-
   /// Implements the TableReader::readImpl() contract
   Table readImpl(long rows) override;
 
 private:
-
   void readColumnInfo();
 
-  std::unique_ptr<CCfits::FITS> m_fits {nullptr};
+  std::unique_ptr<CCfits::FITS>             m_fits{nullptr};
   std::reference_wrapper<const CCfits::HDU> m_hdu;
-  bool m_reading_started = false;
-  long m_total_rows = -1;
-  long m_current_row = 1;
-  std::vector<std::string> m_column_names {};
-  std::shared_ptr<ColumnInfo> m_column_info;
+  bool                                      m_reading_started = false;
+  long                                      m_total_rows      = -1;
+  long                                      m_current_row     = 1;
+  std::vector<std::string>                  m_column_names{};
+  std::shared_ptr<ColumnInfo>               m_column_info;
 
 }; /* End of FitsReader class */
 
 } /* namespace Table */
 } /* namespace Euclid */
-
 
 #endif

--- a/Table/Table/FitsWriter.h
+++ b/Table/Table/FitsWriter.h
@@ -25,8 +25,8 @@
 #ifndef _TABLE_FITSWRITER_H
 #define _TABLE_FITSWRITER_H
 
-#include <CCfits/FITS.h>
 #include "Table/TableWriter.h"
+#include <CCfits/FITS.h>
 
 namespace Euclid {
 namespace Table {
@@ -76,7 +76,6 @@ namespace Table {
 class FitsWriter : public TableWriter {
 
 public:
-
   /// The format of the HDUs a FitsWriter creates
   enum class Format {
     /// FITS ASCII table HDU format
@@ -105,7 +104,7 @@ public:
    * @param override_flag
    *    When true, any existing file will be overridden
    */
-  explicit FitsWriter(const std::string& filename, bool override_flag=false);
+  explicit FitsWriter(const std::string& filename, bool override_flag = false);
 
   /**
    * @brief Creates a FitsWriter that writes to a specific CCfits::FITS object
@@ -181,7 +180,6 @@ public:
   void addComment(const std::string& message) override;
 
 protected:
-
   /// Creates the FITS file if it needs to be created, the table HDU if the
   /// name already exist and writes the comments.
   void init(const Table& table) override;
@@ -191,21 +189,19 @@ protected:
   void append(const Table& table) override;
 
 private:
-
-  std::string m_filename = "";
-  std::shared_ptr<CCfits::FITS> m_fits = nullptr;
-  bool m_initialized = false;
-  bool m_override_file = true;
-  Format m_format = Format::BINARY;
-  std::string m_hdu_name = "";
-  std::vector<std::string> m_comments {};
-  int m_hdu_index = -1;
-  long m_current_line = 0;
+  std::string                   m_filename      = "";
+  std::shared_ptr<CCfits::FITS> m_fits          = nullptr;
+  bool                          m_initialized   = false;
+  bool                          m_override_file = true;
+  Format                        m_format        = Format::BINARY;
+  std::string                   m_hdu_name      = "";
+  std::vector<std::string>      m_comments{};
+  int                           m_hdu_index    = -1;
+  long                          m_current_line = 0;
 
 }; /* End of FitsWriter class */
 
 } /* namespace Table */
 } /* namespace Euclid */
-
 
 #endif

--- a/Table/Table/Row.h
+++ b/Table/Table/Row.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file Table/Row.h
  * @date April 8, 2014
  * @author Nikolaos Apostolakos
@@ -25,21 +25,21 @@
 #ifndef TABLE_ROW_H
 #define TABLE_ROW_H
 
-#include <memory>
-#include <vector>
-#include <string>
-#include <iterator>
 #include <boost/variant.hpp>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "ElementsKernel/Export.h"
 
-#include "Table/ColumnInfo.h"
 #include "NdArray/NdArray.h"
+#include "Table/ColumnInfo.h"
 
 namespace std {
 
 template <typename T>
-std::ostream& operator<< (std::ostream& s, const std::vector<T>& v);
+std::ostream& operator<<(std::ostream& s, const std::vector<T>& v);
 
 }
 
@@ -64,23 +64,11 @@ namespace Table {
 class ELEMENTS_API Row {
 
 public:
-
   /// The possible cell types
-  typedef boost::variant<bool,
-                         int32_t,
-                         int64_t,
-                         float,
-                         double,
-                         std::string,
-                         std::vector<bool>,
-                         std::vector<int32_t>,
-                         std::vector<int64_t>,
-                         std::vector<float>,
-                         std::vector<double>,
-                         NdArray::NdArray<int32_t>,
-                         NdArray::NdArray<int64_t>,
-                         NdArray::NdArray<float>,
-                         NdArray::NdArray<double>> cell_type;
+  typedef boost::variant<bool, int32_t, int64_t, float, double, std::string, std::vector<bool>, std::vector<int32_t>,
+                         std::vector<int64_t>, std::vector<float>, std::vector<double>, NdArray::NdArray<int32_t>,
+                         NdArray::NdArray<int64_t>, NdArray::NdArray<float>, NdArray::NdArray<double>>
+      cell_type;
 
   typedef std::vector<cell_type>::const_iterator const_iterator;
 
@@ -166,12 +154,11 @@ public:
   const_iterator end() const;
 
 private:
-  std::vector<cell_type> m_values;
+  std::vector<cell_type>      m_values;
   std::shared_ptr<ColumnInfo> m_column_info;
 };
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid
 
-#endif  /* TABLE_ROW_H */
-
+#endif /* TABLE_ROW_H */

--- a/Table/Table/Table.h
+++ b/Table/Table/Table.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file Table/Table.h
  * @date April 9, 2014
  * @author Nikolaos Apostolakos
@@ -49,7 +49,6 @@ namespace Table {
 class ELEMENTS_API Table {
 
 public:
-
   typedef std::vector<Row>::const_iterator const_iterator;
 
   /**
@@ -113,12 +112,11 @@ public:
   const_iterator end() const;
 
 private:
-  std::vector<Row> m_row_list;
+  std::vector<Row>            m_row_list;
   std::shared_ptr<ColumnInfo> m_column_info;
 };
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid
 
-#endif  /* TABLE_TABLE_H */
-
+#endif /* TABLE_TABLE_H */

--- a/Table/Table/TableReader.h
+++ b/Table/Table/TableReader.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
  * @file TableReader.h
  * @author nikoapos
  */
@@ -31,29 +31,28 @@ namespace Table {
 
 /**
  * @class TableReader
- * 
+ *
  * @brief Interface for classes reading tables
- * 
+ *
  * @details
  * Each TableReader implementation should behave like a stream to a table. It
  * must implement the methods getComment(), getInfo(), readImpl(), skip() and hasMoreRows().
  * See the documentation of these methods for more information of how to
  * implement them.
- * 
+ *
  * Note that all TableReader implementations, as they are representing streams
  * to a single table, should not be able to be copied, something that is forced
  * by the TableReader interface. There is no such restriction for move operations.
- * 
+ *
  */
 class TableReader {
-  
+
 public:
-  
   TableReader() = default;
-  
+
   TableReader(TableReader&&) = default;
   TableReader& operator=(TableReader&&) = default;
-  
+
   TableReader(const TableReader&) = delete;
   TableReader& operator=(const TableReader&) = delete;
 
@@ -63,7 +62,7 @@ public:
    * @return Returns the comment associated to the table
    */
   virtual std::string getComment() = 0;
-  
+
   /**
    * @brief Returns the column information of the table
    * @details
@@ -73,7 +72,7 @@ public:
    * @return The table column information
    */
   virtual const ColumnInfo& getInfo() = 0;
-  
+
   /**
    * @brief Reads next rows as a table
    * @details
@@ -84,15 +83,15 @@ public:
    * is thrown.
    * @param rows
    *    The number of rows to read
-   * @return 
+   * @return
    *    A Table object containing the rows read
    * @throws Elements::Exception
    *    If the reader has already read all the available rows
    */
-  Table read(long rows=-1) {
+  Table read(long rows = -1) {
     return readImpl(rows);
   }
-  
+
   /**
    * @brief Skips next rows
    * @details
@@ -104,7 +103,7 @@ public:
    *    The number of rows to skip
    */
   virtual void skip(long rows) = 0;
-  
+
   /**
    * @brief Checks if there are any rows left to read
    * @details
@@ -113,23 +112,22 @@ public:
    * result of this method is true, a call to read() should successfully return
    * a table object, If the result of this method is false, a call th read()
    * will throw an Elements::Exception.
-   * @return 
+   * @return
    *    true if there are more rows to read
    */
   virtual bool hasMoreRows() = 0;
-  
+
   /**
    * @brief Returns the number of rows left to read
    * @details
    * When using this method keep in mind that some formats (like ASCII) might
    * require to parse the full file.
-   * @return 
+   * @return
    *    The number of rows left to read
    */
   virtual std::size_t rowsLeft() = 0;
-  
-protected:
 
+protected:
   /**
    * @brief Method to be implemented by subclasses for reading the table
    * @details
@@ -137,17 +135,15 @@ protected:
    * documentation of the read() method.
    * @param rows
    *    The number of rows to read
-   * @return 
+   * @return
    *    A Table object containing the rows read
    * @throws Elements::Exception
    *    If the reader has already read all the available rows
    */
   virtual Table readImpl(long rows) = 0;
-  
 };
 
-} // namespace Table
-} // namespace Euclid
+}  // namespace Table
+}  // namespace Euclid
 
 #endif /* _TABLE_TABLEREADER_H */
-

--- a/Table/Table/TableWriter.h
+++ b/Table/Table/TableWriter.h
@@ -25,9 +25,9 @@
 #ifndef _TABLE_TABLEWRITER_H
 #define _TABLE_TABLEWRITER_H
 
-#include <string>
-#include <memory>
 #include "Table/Table.h"
+#include <memory>
+#include <string>
 
 namespace Euclid {
 namespace Table {
@@ -117,11 +117,10 @@ protected:
   virtual void append(const Table& table) = 0;
 
 private:
-  std::unique_ptr<ColumnInfo> m_column_info {nullptr};
-}; // End of TableWriter class
+  std::unique_ptr<ColumnInfo> m_column_info{nullptr};
+};  // End of TableWriter class
 
-} // namespace Table
-} // namespace Euclid
-
+}  // namespace Table
+}  // namespace Euclid
 
 #endif

--- a/Table/Table/_impl/AsciiReader.icpp
+++ b/Table/Table/_impl/AsciiReader.icpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
  * @file AsciiReader.icpp
  * @author nikoapos
  */
@@ -29,6 +29,5 @@ AsciiReader AsciiReader::create(Args&&... args) {
   return AsciiReader(InstOrRefHolder<std::istream>::create<StreamType>(std::forward<Args>(args)...));
 }
 
-} // namespace Table
-} // namespace Euclid
-
+}  // namespace Table
+}  // namespace Euclid

--- a/Table/Table/_impl/AsciiWriter.icpp
+++ b/Table/Table/_impl/AsciiWriter.icpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* 
+/*
  * @file AsciiWriter.icpp
  * @author nikoapos
  */
@@ -29,5 +29,5 @@ AsciiWriter AsciiWriter::create(Args&&... args) {
   return AsciiWriter(InstOrRefHolder<std::ostream>::create<StreamType>(std::forward<Args>(args)...));
 }
 
-} // namespace Table
-} // namespace Euclid
+}  // namespace Table
+}  // namespace Euclid

--- a/Table/src/lib/AsciiReader.cpp
+++ b/Table/src/lib/AsciiReader.cpp
@@ -37,26 +37,23 @@ using boost::regex_match;
 #include "ElementsKernel/Exception.h"
 #include "Table/AsciiReader.h"
 
-#include "ReaderHelper.h"
 #include "AsciiReaderHelper.h"
+#include "ReaderHelper.h"
 
 namespace Euclid {
 namespace Table {
 
-AsciiReader::AsciiReader(std::istream& stream) : AsciiReader(InstOrRefHolder<std::istream>::create(stream)) {
-}
+AsciiReader::AsciiReader(std::istream& stream) : AsciiReader(InstOrRefHolder<std::istream>::create(stream)) {}
 
-AsciiReader::AsciiReader(const std::string& filename) : AsciiReader(create<std::ifstream>(filename)) {
-}
+AsciiReader::AsciiReader(const std::string& filename) : AsciiReader(create<std::ifstream>(filename)) {}
 
 AsciiReader::AsciiReader(std::unique_ptr<InstOrRefHolder<std::istream>> stream_holder)
-        : m_stream_holder(std::move(stream_holder)) {
-}
+    : m_stream_holder(std::move(stream_holder)) {}
 
 AsciiReader& AsciiReader::setCommentIndicator(const std::string& indicator) {
   if (m_reading_started) {
     throw Elements::Exception() << "Changing comment indicator after reading "
-            << "has started is not allowed";
+                                << "has started is not allowed";
   }
   if (indicator.empty()) {
     throw Elements::Exception() << "Empty string as comment indicator";
@@ -68,27 +65,26 @@ AsciiReader& AsciiReader::setCommentIndicator(const std::string& indicator) {
 AsciiReader& AsciiReader::fixColumnNames(std::vector<std::string> column_names) {
   if (m_reading_started) {
     throw Elements::Exception() << "Fixing the column names after reading "
-            << "has started is not allowed";
+                                << "has started is not allowed";
   }
 
   m_column_names = std::move(column_names);
 
-  std::set<std::string> set {};
-  regex vertical_whitespace {".*\\v.*"}; // Checks if input contains any whitespace characters
+  std::set<std::string> set{};
+  regex                 vertical_whitespace{".*\\v.*"};  // Checks if input contains any whitespace characters
   for (const auto& name : m_column_names) {
     if (name.empty()) {
       throw Elements::Exception() << "Empty string column names are not allowed";
     }
     if (regex_match(name, vertical_whitespace)) {
       throw Elements::Exception() << "Column name '" << name << "' contains "
-                                << "vertical whitespace characters";
+                                  << "vertical whitespace characters";
     }
     if (!set.insert(name).second) {  // Check for duplicate names
       throw Elements::Exception() << "Duplicate column name " << name;
     }
   }
-  if (!m_column_names.empty() && !m_column_types.empty()
-      && m_column_names.size() != m_column_types.size()) {
+  if (!m_column_names.empty() && !m_column_types.empty() && m_column_names.size() != m_column_types.size()) {
     throw Elements::Exception() << "Different number of column names and types";
   }
 
@@ -98,13 +94,12 @@ AsciiReader& AsciiReader::fixColumnNames(std::vector<std::string> column_names) 
 AsciiReader& AsciiReader::fixColumnTypes(std::vector<std::type_index> column_types) {
   if (m_reading_started) {
     throw Elements::Exception() << "Fixing the column types after reading "
-            << "has started is not allowed";
+                                << "has started is not allowed";
   }
 
   m_column_types = std::move(column_types);
 
-  if (!m_column_names.empty() && !m_column_types.empty()
-      && m_column_names.size() != m_column_types.size()) {
+  if (!m_column_names.empty() && !m_column_types.empty() && m_column_names.size() != m_column_types.size()) {
     throw Elements::Exception() << "Different number of column names and types";
   }
 
@@ -121,24 +116,22 @@ void AsciiReader::readColumnInfo() {
 
   size_t columns_number = countColumns(in, m_comment);
   if (!m_column_names.empty() && m_column_names.size() != columns_number) {
-    throw Elements::Exception() << "Columns number in stream (" << columns_number
-                                << ") does not match the column names number ("
+    throw Elements::Exception() << "Columns number in stream (" << columns_number << ") does not match the column names number ("
                                 << m_column_names.size() << ")";
   }
   if (!m_column_types.empty() && m_column_types.size() != columns_number) {
-    throw Elements::Exception() << "Columns number in stream (" << columns_number
-                                << ") does not match the column types number ("
+    throw Elements::Exception() << "Columns number in stream (" << columns_number << ") does not match the column types number ("
                                 << m_column_types.size() << ")";
   }
 
   auto auto_names = autoDetectColumnNames(in, m_comment, columns_number);
-  auto auto_desc = autoDetectColumnDescriptions(in, m_comment);
+  auto auto_desc  = autoDetectColumnDescriptions(in, m_comment);
 
-  std::vector<std::string> names {};
-  std::vector<std::type_index> types {};
-  std::vector<std::string> units {};
-  std::vector<std::string> descriptions {};
-  for (size_t i=0; i<columns_number; ++i) {
+  std::vector<std::string>     names{};
+  std::vector<std::type_index> types{};
+  std::vector<std::string>     units{};
+  std::vector<std::string>     descriptions{};
+  for (size_t i = 0; i < columns_number; ++i) {
     if (m_column_names.empty()) {
       names.emplace_back(auto_names[i]);
     } else {
@@ -164,18 +157,16 @@ void AsciiReader::readColumnInfo() {
     }
   }
   m_column_info = createColumnInfo(names, types, units, descriptions);
-
 }
-
 
 const ColumnInfo& AsciiReader::getInfo() {
   readColumnInfo();
   return *m_column_info;
 }
 
-static std::string _peekLine(std::istream &in) {
+static std::string _peekLine(std::istream& in) {
   std::string line;
-  auto pos = in.tellg();
+  auto        pos = in.tellg();
   getline(in, line);
   in.seekg(pos);
   return line;
@@ -185,7 +176,7 @@ std::string AsciiReader::getComment() {
   std::ostringstream comment;
 
   m_reading_started = true;
-  auto &in = m_stream_holder->ref();
+  auto& in          = m_stream_holder->ref();
   while (in && _peekLine(in).compare(0, m_comment.size(), m_comment) == 0) {
     std::string line;
     getline(in, line);
@@ -204,7 +195,7 @@ Table AsciiReader::readImpl(long rows) {
   auto& in = m_stream_holder->ref();
 
   std::vector<Row> row_list;
-  while(in && rows != 0) {
+  while (in && rows != 0) {
     std::string line;
     getline(in, line);
     size_t comment_pos = line.find(m_comment);
@@ -214,10 +205,10 @@ Table AsciiReader::readImpl(long rows) {
     boost::trim(line);
     if (!line.empty()) {
       --rows;
-      std::stringstream line_stream(line);
-      size_t count {0};
-      std::vector<Row::cell_type> values {};
-      std::string token;
+      std::stringstream           line_stream(line);
+      size_t                      count{0};
+      std::vector<Row::cell_type> values{};
+      std::string                 token;
       line_stream >> token;
       while (line_stream) {
         if (count >= m_column_info->size()) {
@@ -241,7 +232,7 @@ void AsciiReader::skip(long rows) {
   readColumnInfo();
   auto& in = m_stream_holder->ref();
 
-  while(in && rows != 0) {
+  while (in && rows != 0) {
     std::string line;
     getline(in, line);
     size_t comment_pos = line.find(m_comment);
@@ -263,5 +254,5 @@ std::size_t AsciiReader::rowsLeft() {
   return countRemainingRows(m_stream_holder->ref(), m_comment);
 }
 
-} // Table namespace
-} // Euclid namespace
+}  // namespace Table
+}  // namespace Euclid

--- a/Table/src/lib/AsciiReaderHelper.cpp
+++ b/Table/src/lib/AsciiReaderHelper.cpp
@@ -16,21 +16,21 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/AsciiReaderHelper.cpp
  * @date April 15, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <set>
-#include <sstream>
+#include "AsciiReaderHelper.h"
+#include "ElementsKernel/Exception.h"
+#include "ElementsKernel/Logging.h"
+#include "NdArray/NdArray.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
-#include "ElementsKernel/Exception.h"
-#include "ElementsKernel/Logging.h"
-#include "AsciiReaderHelper.h"
-#include "NdArray/NdArray.h"
+#include <set>
+#include <sstream>
 
 namespace Euclid {
 namespace Table {
@@ -40,8 +40,8 @@ using NdArray::NdArray;
 static Elements::Logging logger = Elements::Logging::getLogger("AsciiReader");
 
 size_t countColumns(std::istream& in, const std::string& comment) {
-  StreamRewinder rewinder {in};
-  size_t count = 0;
+  StreamRewinder rewinder{in};
+  size_t         count = 0;
 
   while (in) {
     std::string line;
@@ -53,7 +53,7 @@ size_t countColumns(std::istream& in, const std::string& comment) {
     }
     boost::trim(line);
     if (!line.empty()) {
-      std::string token;
+      std::string       token;
       std::stringstream line_stream(line);
       line_stream >> boost::io::quoted(token);
       while (line_stream) {
@@ -104,16 +104,15 @@ std::type_index keywordToType(const std::string& keyword) {
   throw Elements::Exception() << "Unknown column type keyword " << keyword;
 }
 
-std::map<std::string, ColumnDescription> autoDetectColumnDescriptions(
-                                      std::istream& in, const std::string& comment) {
-  StreamRewinder rewinder {in};
+std::map<std::string, ColumnDescription> autoDetectColumnDescriptions(std::istream& in, const std::string& comment) {
+  StreamRewinder                           rewinder{in};
   std::map<std::string, ColumnDescription> descriptions;
   while (in) {
     std::string line;
     getline(in, line);
     boost::trim(line);
     if (line.empty()) {
-      continue; // We skip empty lines
+      continue;  // We skip empty lines
     }
     if (boost::starts_with(line, comment)) {
       // If we have a comment we remove all comment characters and check if we have
@@ -124,9 +123,9 @@ std::map<std::string, ColumnDescription> autoDetectColumnDescriptions(
         line.erase(0, 7);
         boost::trim(line);
         if (!line.empty()) {
-          std::string token;
+          std::string       token;
           std::stringstream line_stream(line);
-          std::string name;
+          std::string       name;
           line_stream >> boost::io::quoted(name);
           if (descriptions.count(name) != 0) {
             throw Elements::Exception() << "Duplicate column name " << name;
@@ -144,7 +143,7 @@ std::map<std::string, ColumnDescription> autoDetectColumnDescriptions(
             if (boost::starts_with(token, "(")) {
               unit = token;
               unit.erase(unit.begin());
-              unit.erase(unit.end()-1);
+              unit.erase(unit.end() - 1);
               line_stream >> boost::io::quoted(token);
             }
           }
@@ -158,34 +157,31 @@ std::map<std::string, ColumnDescription> autoDetectColumnDescriptions(
           }
           std::string desc_str = desc.str();
           boost::trim(desc_str);
-          descriptions.emplace(std::piecewise_construct,
-                               std::forward_as_tuple(name),
+          descriptions.emplace(std::piecewise_construct, std::forward_as_tuple(name),
                                std::forward_as_tuple(name, type, unit, desc_str));
         }
       }
     } else {
-      break; // here we reached the first data line
+      break;  // here we reached the first data line
     }
   }
   return descriptions;
 }
 
-std::vector<std::string> autoDetectColumnNames(std::istream& in,
-                                               const std::string& comment,
-                                               size_t columns_number) {
-  StreamRewinder rewinder {in};
-  std::vector<std::string> names {};
+std::vector<std::string> autoDetectColumnNames(std::istream& in, const std::string& comment, size_t columns_number) {
+  StreamRewinder           rewinder{in};
+  std::vector<std::string> names{};
 
   // Find the last comment line and at the same time read the names of the
   // column info description comments
-  std::string last_comment {};
-  std::vector<std::string> desc_names {};
+  std::string              last_comment{};
+  std::vector<std::string> desc_names{};
   while (in) {
     std::string line;
     getline(in, line);
     boost::trim(line);
     if (line.empty()) {
-      continue; // We skip empty lines
+      continue;  // We skip empty lines
     }
     if (boost::starts_with(line, comment)) {
       // If we have a comment we remove all comment characters and check if we have
@@ -206,14 +202,14 @@ std::vector<std::string> autoDetectColumnNames(std::istream& in,
         desc_names.emplace_back(std::move(temp));
       }
     } else {
-      break; // here we reached the first data line
+      break;  // here we reached the first data line
     }
   }
 
   // Check if the last comment line contains the names of the columns
-  if (!last_comment.empty()){
+  if (!last_comment.empty()) {
     std::stringstream line_stream(last_comment);
-    std::string token;
+    std::string       token;
     line_stream >> boost::io::quoted(token);
     while (line_stream) {
       names.push_back(token);
@@ -228,18 +224,18 @@ std::vector<std::string> autoDetectColumnNames(std::istream& in,
   if (names.empty()) {
     if (desc_names.size() != 0 && desc_names.size() != columns_number) {
       logger.warn() << "Number of column descriptions does not matches the number"
-              << " of the columns";
+                    << " of the columns";
     }
     names = desc_names;
   }
 
   if (names.size() < columns_number) {
-    for (size_t i=names.size()+1; i<=columns_number; ++i) {
+    for (size_t i = names.size() + 1; i <= columns_number; ++i) {
       names.push_back("col" + std::to_string(i));
     }
   }
   // Check for duplicate names
-  std::set<std::string> set {};
+  std::set<std::string> set{};
   for (auto name : names) {
     if (!set.insert(name).second) {
       throw Elements::Exception() << "Duplicate column name " << name;
@@ -252,9 +248,9 @@ namespace {
 
 template <typename T>
 std::vector<T> convertStringToVector(const std::string& str) {
-  std::vector<T> result {};
-  boost::char_separator<char> sep {","};
-  boost::tokenizer< boost::char_separator<char> > tok {str, sep};
+  std::vector<T>                                result{};
+  boost::char_separator<char>                   sep{","};
+  boost::tokenizer<boost::char_separator<char>> tok{str, sep};
   for (auto& s : tok) {
     result.push_back(boost::get<T>(convertToCellType(s, typeid(T))));
   }
@@ -275,63 +271,63 @@ NdArray<T> convertStringToNdArray(const std::string& str) {
   }
 
   auto shape_str = str.substr(1, closing_char - 1);
-  auto shape_i = convertStringToVector<int32_t>(shape_str);
-  auto data = convertStringToVector<T>(str.substr(closing_char + 1));
+  auto shape_i   = convertStringToVector<int32_t>(shape_str);
+  auto data      = convertStringToVector<T>(str.substr(closing_char + 1));
 
   std::vector<size_t> shape_u;
   std::copy(shape_i.begin(), shape_i.end(), std::back_inserter(shape_u));
   return NdArray<T>(shape_u, data);
 }
 
-}
+}  // namespace
 
 Row::cell_type convertToCellType(const std::string& value, std::type_index type) {
   try {
     if (type == typeid(bool)) {
       if (value == "true" || value == "t" || value == "yes" || value == "y" || value == "1") {
-        return Row::cell_type {true};
+        return Row::cell_type{true};
       }
       if (value == "false" || value == "f" || value == "no" || value == "n" || value == "0") {
-        return Row::cell_type {false};
+        return Row::cell_type{false};
       }
     } else if (type == typeid(int32_t)) {
-      return Row::cell_type {boost::lexical_cast<int32_t>(value)};
+      return Row::cell_type{boost::lexical_cast<int32_t>(value)};
     } else if (type == typeid(int64_t)) {
-      return Row::cell_type {boost::lexical_cast<int64_t>(value)};
+      return Row::cell_type{boost::lexical_cast<int64_t>(value)};
     } else if (type == typeid(float)) {
-      return Row::cell_type {boost::lexical_cast<float>(value)};
+      return Row::cell_type{boost::lexical_cast<float>(value)};
     } else if (type == typeid(double)) {
-      return Row::cell_type {boost::lexical_cast<double>(value)};
+      return Row::cell_type{boost::lexical_cast<double>(value)};
     } else if (type == typeid(std::string)) {
-      return Row::cell_type {boost::lexical_cast<std::string>(value)};
+      return Row::cell_type{boost::lexical_cast<std::string>(value)};
     } else if (type == typeid(std::vector<bool>)) {
-      return Row::cell_type {convertStringToVector<bool>(value)};
+      return Row::cell_type{convertStringToVector<bool>(value)};
     } else if (type == typeid(std::vector<int32_t>)) {
-      return Row::cell_type {convertStringToVector<int32_t>(value)};
+      return Row::cell_type{convertStringToVector<int32_t>(value)};
     } else if (type == typeid(std::vector<int64_t>)) {
-      return Row::cell_type {convertStringToVector<int64_t>(value)};
+      return Row::cell_type{convertStringToVector<int64_t>(value)};
     } else if (type == typeid(std::vector<float>)) {
-      return Row::cell_type {convertStringToVector<float>(value)};
+      return Row::cell_type{convertStringToVector<float>(value)};
     } else if (type == typeid(std::vector<double>)) {
-      return Row::cell_type {convertStringToVector<double>(value)};
+      return Row::cell_type{convertStringToVector<double>(value)};
     } else if (type == typeid(NdArray<int32_t>)) {
-      return Row::cell_type {convertStringToNdArray<int32_t>(value)};
+      return Row::cell_type{convertStringToNdArray<int32_t>(value)};
     } else if (type == typeid(NdArray<int64_t>)) {
-      return Row::cell_type {convertStringToNdArray<int64_t>(value)};
+      return Row::cell_type{convertStringToNdArray<int64_t>(value)};
     } else if (type == typeid(NdArray<float>)) {
-      return Row::cell_type {convertStringToNdArray<float>(value)};
+      return Row::cell_type{convertStringToNdArray<float>(value)};
     } else if (type == typeid(NdArray<double>)) {
-      return Row::cell_type {convertStringToNdArray<double>(value)};
+      return Row::cell_type{convertStringToNdArray<double>(value)};
     }
-  } catch( boost::bad_lexical_cast const& ) {
+  } catch (boost::bad_lexical_cast const&) {
     throw Elements::Exception() << "Cannot convert " << value << " to " << type.name();
   }
   throw Elements::Exception() << "Unknown type name " << type.name();
 }
 
 bool hasNextRow(std::istream& in, const std::string& comment) {
-  StreamRewinder rewinder {in};
-  while(in) {
+  StreamRewinder rewinder{in};
+  while (in) {
     std::string line;
     getline(in, line);
     size_t comment_pos = line.find(comment);
@@ -347,9 +343,9 @@ bool hasNextRow(std::istream& in, const std::string& comment) {
 }
 
 std::size_t countRemainingRows(std::istream& in, const std::string& comment) {
-  StreamRewinder rewinder {in};
-  std::size_t count = 0;
-  while(in) {
+  StreamRewinder rewinder{in};
+  std::size_t    count = 0;
+  while (in) {
     std::string line;
     getline(in, line);
     size_t comment_pos = line.find(comment);
@@ -364,5 +360,5 @@ std::size_t countRemainingRows(std::istream& in, const std::string& comment) {
   return count;
 }
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid

--- a/Table/src/lib/AsciiReaderHelper.h
+++ b/Table/src/lib/AsciiReaderHelper.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/AsciiReaderHelper.h
  * @date April 15, 2014
  * @author Nikolaos Apostolakos
@@ -26,10 +26,9 @@
 #define TABLE_ASCIIREADERHELPER_H
 
 #include <istream>
+#include <map>
 #include <string>
 #include <typeindex>
-#include <map>
-
 
 #include "ElementsKernel/Export.h"
 #include "Table/Row.h"
@@ -47,17 +46,17 @@ namespace Table {
  */
 class StreamRewinder {
 public:
-  explicit StreamRewinder(std::istream& stream) : m_stream(stream), m_state(stream.exceptions()),
-                                                  m_position(stream.tellg()) {}
+  explicit StreamRewinder(std::istream& stream) : m_stream(stream), m_state(stream.exceptions()), m_position(stream.tellg()) {}
   ~StreamRewinder() {
     m_stream.clear();
     m_stream.seekg(m_position);
     m_stream.setstate(m_state);
   }
+
 private:
-  std::istream& m_stream;
+  std::istream&     m_stream;
   std::ios::iostate m_state;
-  int m_position;
+  int               m_position;
 };
 
 /**
@@ -92,8 +91,7 @@ ELEMENTS_API size_t countColumns(std::istream& in, const std::string& comment);
  * @throws Elements::Exception
  *    if any of the types is not one of the valid keywords
  */
-ELEMENTS_API std::map<std::string, ColumnDescription> autoDetectColumnDescriptions(
-                                      std::istream& in, const std::string& comment);
+ELEMENTS_API std::map<std::string, ColumnDescription> autoDetectColumnDescriptions(std::istream& in, const std::string& comment);
 
 /**
  * @brief
@@ -110,9 +108,7 @@ ELEMENTS_API std::map<std::string, ColumnDescription> autoDetectColumnDescriptio
  * @throws Elements::Exception
  *    if there are duplicate column names
  */
-ELEMENTS_API std::vector<std::string> autoDetectColumnNames(std::istream& in,
-                                               const std::string& comment,
-                                               size_t columns_number);
+ELEMENTS_API std::vector<std::string> autoDetectColumnNames(std::istream& in, const std::string& comment, size_t columns_number);
 
 /**
  * @brief
@@ -133,7 +129,7 @@ ELEMENTS_API bool hasNextRow(std::istream& in, const std::string& comment);
 
 ELEMENTS_API std::size_t countRemainingRows(std::istream& in, const std::string& comment);
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid
 
 #endif /* TABLE_ASCIIREADERHELPER_H */

--- a/Table/src/lib/AsciiWriter.cpp
+++ b/Table/src/lib/AsciiWriter.cpp
@@ -22,30 +22,27 @@
  * @author nikoapos
  */
 
-#include <fstream>
-#include <sstream>
-#include <boost/lexical_cast.hpp>
-#include "ElementsKernel/Exception.h"
 #include "Table/AsciiWriter.h"
 #include "AsciiWriterHelper.h"
+#include "ElementsKernel/Exception.h"
+#include <boost/lexical_cast.hpp>
+#include <fstream>
+#include <sstream>
 
 namespace Euclid {
 namespace Table {
 
-AsciiWriter::AsciiWriter(std::ostream& stream) : AsciiWriter(InstOrRefHolder<std::ostream>::create(stream)) {
-}
+AsciiWriter::AsciiWriter(std::ostream& stream) : AsciiWriter(InstOrRefHolder<std::ostream>::create(stream)) {}
 
-AsciiWriter::AsciiWriter(const std::string& filename) : AsciiWriter(create<std::ofstream>(filename)) {
-}
+AsciiWriter::AsciiWriter(const std::string& filename) : AsciiWriter(create<std::ofstream>(filename)) {}
 
 AsciiWriter::AsciiWriter(std::unique_ptr<InstOrRefHolder<std::ostream>> stream_holder)
-        : m_stream_holder(std::move(stream_holder)) {
-}
+    : m_stream_holder(std::move(stream_holder)) {}
 
 AsciiWriter& AsciiWriter::setCommentIndicator(const std::string& indicator) {
   if (m_writing_started) {
     throw Elements::Exception() << "Changing comment indicator after writing "
-            << "has started is not allowed";
+                                << "has started is not allowed";
   }
   if (indicator.empty()) {
     throw Elements::Exception() << "Empty string as comment indicator";
@@ -57,7 +54,7 @@ AsciiWriter& AsciiWriter::setCommentIndicator(const std::string& indicator) {
 AsciiWriter& AsciiWriter::showColumnInfo(bool show) {
   if (m_writing_started) {
     throw Elements::Exception() << "Changing column info visibility after writing "
-            << "has started is not allowed";
+                                << "has started is not allowed";
   }
   m_show_column_info = show;
   return *this;
@@ -66,11 +63,11 @@ AsciiWriter& AsciiWriter::showColumnInfo(bool show) {
 void AsciiWriter::addComment(const std::string& message) {
   if (m_initialized) {
     throw Elements::Exception() << "Adding comments after writing data in ASCII "
-            << "format is not allowed";
+                                << "format is not allowed";
   }
   m_writing_started = true;
 
-  std::stringstream message_stream {message};
+  std::stringstream message_stream{message};
   while (!message_stream.eof()) {
     std::string line;
     std::getline(message_stream, line);
@@ -91,7 +88,7 @@ void AsciiWriter::init(const Table& table) {
   // Write the column descriptions
   auto& info = *table.getColumnInfo();
   if (m_show_column_info) {
-    for (size_t i=0; i<info.size(); ++i) {
+    for (size_t i = 0; i < info.size(); ++i) {
       auto& desc = info.getDescription(i);
 
       out << m_comment << " Column: " << quoted(desc.name) << ' ' << typeToKeyword(desc.type);
@@ -109,26 +106,25 @@ void AsciiWriter::init(const Table& table) {
   // Write the column names
   auto column_lengths = calculateColumnLengths(table);
   out << m_comment.c_str();
-  for (size_t i=0; i<info.size(); ++i) {
+  for (size_t i = 0; i < info.size(); ++i) {
     out << std::setw(column_lengths[i]) << quoted(info.getDescription(i).name);
   }
   out << "\n\n";
 }
 
 void AsciiWriter::append(const Table& table) {
-  auto& out = m_stream_holder->ref();
-  auto column_lengths = calculateColumnLengths(table);
+  auto& out            = m_stream_holder->ref();
+  auto  column_lengths = calculateColumnLengths(table);
   // The data lines are not prefixed with the comment string, so we need to fix
   // the length of the first column to get the alignment correctly
   column_lengths[0] = column_lengths[0] + m_comment.size();
   for (auto row : table) {
-    for (size_t i=0; i<row.size(); ++i) {
+    for (size_t i = 0; i < row.size(); ++i) {
       out << std::setw(column_lengths[i]) << boost::apply_visitor(ToStringVisitor{}, row[i]);
     }
     out << "\n";
   }
 }
 
-
-} // Table namespace
-} // Euclid namespace
+}  // namespace Table
+}  // namespace Euclid

--- a/Table/src/lib/AsciiWriterHelper.cpp
+++ b/Table/src/lib/AsciiWriterHelper.cpp
@@ -16,71 +16,84 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/AsciiWriterHelper.cpp
  * @date April 16, 2014
  * @author Nikolaos Apostolakos
  */
 
+#include "AsciiWriterHelper.h"
+#include "ElementsKernel/Exception.h"
 #include <algorithm>
+#include <boost/io/detail/quoted_manip.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
-#include <boost/io/detail/quoted_manip.hpp>
-#include "ElementsKernel/Exception.h"
-#include "AsciiWriterHelper.h"
 
 namespace Euclid {
 namespace Table {
 
-using NdArray::NdArray;
 using boost::regex;
 using boost::regex_match;
+using NdArray::NdArray;
 
 std::string typeToKeyword(std::type_index type) {
   if (type == typeid(bool)) {
     return "bool";
-  } if (type == typeid(int32_t)) {
+  }
+  if (type == typeid(int32_t)) {
     return "int";
-  } if (type == typeid(int64_t)) {
+  }
+  if (type == typeid(int64_t)) {
     return "long";
-  } if (type == typeid(float)) {
+  }
+  if (type == typeid(float)) {
     return "float";
-  } if (type == typeid(double)) {
+  }
+  if (type == typeid(double)) {
     return "double";
-  } if (type == typeid(std::string)) {
+  }
+  if (type == typeid(std::string)) {
     return "string";
-  } if (type == typeid(std::vector<bool>)) {
+  }
+  if (type == typeid(std::vector<bool>)) {
     return "[bool]";
-  } if (type == typeid(std::vector<int32_t>)) {
+  }
+  if (type == typeid(std::vector<int32_t>)) {
     return "[int]";
-  } if (type == typeid(std::vector<int64_t>)) {
+  }
+  if (type == typeid(std::vector<int64_t>)) {
     return "[long]";
-  } if (type == typeid(std::vector<float>)) {
+  }
+  if (type == typeid(std::vector<float>)) {
     return "[float]";
-  } if (type == typeid(std::vector<double>)) {
+  }
+  if (type == typeid(std::vector<double>)) {
     return "[double]";
-  } if (type == typeid(NdArray<int32_t>)) {
+  }
+  if (type == typeid(NdArray<int32_t>)) {
     return "[int+]";
-  } if (type == typeid(NdArray<int64_t>)) {
+  }
+  if (type == typeid(NdArray<int64_t>)) {
     return "[long+]";
-  } if (type == typeid(NdArray<float>)) {
+  }
+  if (type == typeid(NdArray<float>)) {
     return "[float+]";
-  } if (type == typeid(NdArray<double>)) {
+  }
+  if (type == typeid(NdArray<double>)) {
     return "[double+]";
   }
-  throw Elements::Exception() << "Conversion to string for type " << type.name()
-                            << " is not supported";
+  throw Elements::Exception() << "Conversion to string for type " << type.name() << " is not supported";
 }
 
 std::vector<size_t> calculateColumnLengths(const Table& table) {
-  std::vector<size_t> sizes {};
+  std::vector<size_t> sizes{};
   // We initialize the values to the required size for the column name
   auto column_info = table.getColumnInfo();
-  for (size_t i=0; i<column_info->size(); ++i) {
+  for (size_t i = 0; i < column_info->size(); ++i) {
     sizes.push_back(quoted(column_info->getDescription(i).name).size());
   }
   for (auto row : table) {
-    for (size_t i=0; i<sizes.size(); ++i) {
+    for (size_t i = 0; i < sizes.size(); ++i) {
       sizes[i] = std::max(sizes[i], boost::apply_visitor(ToStringVisitor{}, row[i]).size());
     }
   }
@@ -99,5 +112,5 @@ std::string quoted(const std::string& str) {
   return q.str();
 }
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid

--- a/Table/src/lib/AsciiWriterHelper.h
+++ b/Table/src/lib/AsciiWriterHelper.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/AsciiWriterHelper.h
  * @date April 16, 2014
  * @author Nikolaos Apostolakos
@@ -25,12 +25,12 @@
 #ifndef TABLE_ASCIIWRITERHELPER_H
 #define TABLE_ASCIIWRITERHELPER_H
 
-#include <vector>
-#include <typeindex>
 #include <boost/io/detail/quoted_manip.hpp>
+#include <sstream>
+#include <typeindex>
+#include <vector>
 
 #include "ElementsKernel/Export.h"
-
 
 #include "Table/Table.h"
 
@@ -70,7 +70,7 @@ ELEMENTS_API std::vector<size_t> calculateColumnLengths(const Table& table);
  * @param str
  * @return
  */
-std::string quoted(const std::string &str);
+std::string quoted(const std::string& str);
 
 /**
  * This visitor will wrap strings between quotes so spaces (and quotes) can be
@@ -83,7 +83,7 @@ struct ToStringVisitor : public boost::static_visitor<std::string> {
     return q.str();
   }
 
-  template<typename T>
+  template <typename T>
   std::string operator()(const T& from) const {
     std::stringstream q;
     q << from;
@@ -91,7 +91,7 @@ struct ToStringVisitor : public boost::static_visitor<std::string> {
   }
 };
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid
 
 #endif /* TABLE_ASCIIWRITERHELPER_H */

--- a/Table/src/lib/ColumnDescription.cpp
+++ b/Table/src/lib/ColumnDescription.cpp
@@ -36,17 +36,17 @@ using boost::regex_match;
 namespace Euclid {
 namespace Table {
 
-ColumnDescription::ColumnDescription(std::string input_name, std::type_index input_type,
-                                     std::string input_unit, std::string input_description)
-        : name(input_name), type(input_type), unit(input_unit), description(input_description) {
-    if (input_name.empty()) {
-      throw Elements::Exception() << "Empty string name is not allowed";
-    }
-    if (regex_match(input_name, regex{".*\\v.*"})) {
-      throw Elements::Exception() << "Column name '" << input_name << "' contains "
+ColumnDescription::ColumnDescription(std::string input_name, std::type_index input_type, std::string input_unit,
+                                     std::string input_description)
+    : name(input_name), type(input_type), unit(input_unit), description(input_description) {
+  if (input_name.empty()) {
+    throw Elements::Exception() << "Empty string name is not allowed";
+  }
+  if (regex_match(input_name, regex{".*\\v.*"})) {
+    throw Elements::Exception() << "Column name '" << input_name << "' contains "
                                 << "vertical whitespace characters";
-    }
+  }
 }
 
-} // Table namespace
-} // Euclid namespace
+}  // namespace Table
+}  // namespace Euclid

--- a/Table/src/lib/ColumnInfo.cpp
+++ b/Table/src/lib/ColumnInfo.cpp
@@ -16,26 +16,25 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/ColumnInfo.cpp
  * @date April 7, 2014
  * @author Nikolaos Apostolakos
  */
 
+#include "Table/ColumnInfo.h"
+#include "ElementsKernel/Exception.h"
 #include <algorithm>
 #include <set>
-#include "ElementsKernel/Exception.h"
-#include "Table/ColumnInfo.h"
 
 namespace Euclid {
 namespace Table {
 
-ColumnInfo::ColumnInfo(std::vector<info_type> info_list)
-        : m_info_list{std::move(info_list)} {
+ColumnInfo::ColumnInfo(std::vector<info_type> info_list) : m_info_list{std::move(info_list)} {
   if (m_info_list.empty()) {
     throw Elements::Exception() << "Empty info_list is not allowed";
   }
-  std::set<std::string> set {};
+  std::set<std::string> set{};
   for (const auto& info : m_info_list) {
     const auto& name = info.name;
     if (!set.insert(name).second) {  // Check for duplicate names
@@ -51,7 +50,7 @@ bool ColumnInfo::operator==(const ColumnInfo& other) const {
   return std::equal(this->m_info_list.cbegin(), this->m_info_list.cend(), other.m_info_list.cbegin());
 }
 
-bool ColumnInfo::operator !=(const ColumnInfo& other) const {
+bool ColumnInfo::operator!=(const ColumnInfo& other) const {
   return !(*this == other);
 }
 
@@ -67,8 +66,7 @@ const ColumnDescription& ColumnInfo::getDescription(std::size_t index) const {
 }
 
 const ColumnDescription& ColumnInfo::getDescription(const std::string& name) const {
-  auto iter = std::find_if(m_info_list.begin(), m_info_list.end(),
-                           [&name](const info_type& info) { return info.name == name; });
+  auto iter = std::find_if(m_info_list.begin(), m_info_list.end(), [&name](const info_type& info) { return info.name == name; });
   if (iter == m_info_list.end()) {
     throw Elements::Exception() << "Column " << name << " does not exist";
   }
@@ -77,14 +75,14 @@ const ColumnDescription& ColumnInfo::getDescription(const std::string& name) con
 
 std::unique_ptr<size_t> ColumnInfo::find(const std::string& name) const {
   auto begin = m_info_list.begin();
-  auto end = m_info_list.end();
-  auto iter = std::find_if(begin, end, [&name](const info_type& info){return info.name == name;});
+  auto end   = m_info_list.end();
+  auto iter  = std::find_if(begin, end, [&name](const info_type& info) { return info.name == name; });
   if (iter != end) {
-    size_t index {static_cast<size_t>(std::distance(begin, iter))};
-    return std::unique_ptr<size_t> {new size_t {index}};
+    size_t index{static_cast<size_t>(std::distance(begin, iter))};
+    return std::unique_ptr<size_t>{new size_t{index}};
   }
-  return std::unique_ptr<size_t> {};
+  return std::unique_ptr<size_t>{};
 }
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid

--- a/Table/src/lib/FitsReader.cpp
+++ b/Table/src/lib/FitsReader.cpp
@@ -31,50 +31,47 @@
 using boost::regex;
 using boost::regex_match;
 
+#include "AlexandriaKernel/memory_tools.h"
 #include "ElementsKernel/Exception.h"
 #include "ElementsKernel/Unused.h"
-#include "AlexandriaKernel/memory_tools.h"
 #include "Table/FitsReader.h"
 
-#include "ReaderHelper.h"
 #include "FitsReaderHelper.h"
+#include "ReaderHelper.h"
 
 namespace Euclid {
 namespace Table {
 
-static CCfits::HDU& _readKeys(CCfits::HDU &hdu) {
+static CCfits::HDU& _readKeys(CCfits::HDU& hdu) {
   hdu.readAllKeys();
   return hdu;
 }
 
-FitsReader::FitsReader(const CCfits::HDU& hdu) : m_hdu(hdu) {
-}
+FitsReader::FitsReader(const CCfits::HDU& hdu) : m_hdu(hdu) {}
 
 FitsReader::FitsReader(const std::string& filename, int hduIndex)
-        : m_fits(Euclid::make_unique<CCfits::FITS>(filename)), m_hdu(_readKeys(m_fits->extension(hduIndex))) {
-}
+    : m_fits(Euclid::make_unique<CCfits::FITS>(filename)), m_hdu(_readKeys(m_fits->extension(hduIndex))) {}
 
 FitsReader::FitsReader(const std::string& filename, const std::string& hduName)
-        : m_fits(Euclid::make_unique<CCfits::FITS>(filename)), m_hdu(_readKeys(m_fits->extension(hduName))) {
-}
+    : m_fits(Euclid::make_unique<CCfits::FITS>(filename)), m_hdu(_readKeys(m_fits->extension(hduName))) {}
 
 FitsReader& FitsReader::fixColumnNames(std::vector<std::string> column_names) {
   if (m_reading_started) {
     throw Elements::Exception() << "Fixing the column names after reading "
-            << "has started is not allowed";
+                                << "has started is not allowed";
   }
 
   m_column_names = std::move(column_names);
 
-  std::set<std::string> set {};
-  regex whitespace {".*\\s.*"}; // Checks if input contains any whitespace characters
+  std::set<std::string> set{};
+  regex                 whitespace{".*\\s.*"};  // Checks if input contains any whitespace characters
   for (const auto& name : m_column_names) {
     if (name.empty()) {
       throw Elements::Exception() << "Empty string column names are not allowed";
     }
     if (regex_match(name, whitespace)) {
       throw Elements::Exception() << "Column name '" << name << "' contains "
-                                << "whitespace characters";
+                                  << "whitespace characters";
     }
     if (!set.insert(name).second) {  // Check for duplicate names
       throw Elements::Exception() << "Duplicate column name " << name;
@@ -99,18 +96,17 @@ void FitsReader::readColumnInfo() {
 
   m_total_rows = table_hdu.rows();
 
-  std::vector<std::string> names {};
+  std::vector<std::string> names{};
   if (m_column_names.empty()) {
     names = autoDetectColumnNames(table_hdu);
   } else if (m_column_names.size() != static_cast<size_t>(table_hdu.numCols())) {
-    throw Elements::Exception() << "Columns number in HDU (" << table_hdu.numCols()
-                              << ") does not match the column names number ("
-                              << m_column_names.size() << ")";
+    throw Elements::Exception() << "Columns number in HDU (" << table_hdu.numCols() << ") does not match the column names number ("
+                                << m_column_names.size() << ")";
   } else {
     names = m_column_names;
   }
-  m_column_info = createColumnInfo(names, autoDetectColumnTypes(table_hdu),
-          autoDetectColumnUnits(table_hdu), autoDetectColumnDescriptions(table_hdu));
+  m_column_info = createColumnInfo(names, autoDetectColumnTypes(table_hdu), autoDetectColumnUnits(table_hdu),
+                                   autoDetectColumnDescriptions(table_hdu));
 }
 
 const ColumnInfo& FitsReader::getInfo() {
@@ -133,24 +129,24 @@ Table FitsReader::readImpl(long rows) {
   if (rows == -1) {
     rows = m_total_rows - m_current_row + 1;
   }
-  rows = std::min(rows, m_total_rows-m_current_row+1);
+  rows = std::min(rows, m_total_rows - m_current_row + 1);
 
   const CCfits::Table& table_hdu = dynamic_cast<const CCfits::Table&>(m_hdu.get());
 
   // CCfits reads per column, so we first read all the columns and then we
   // create all the rows
   std::vector<std::vector<Row::cell_type>> data;
-  for (int i=1; i<=table_hdu.numCols(); ++i) {
+  for (int i = 1; i <= table_hdu.numCols(); ++i) {
     // The i-1 is because CCfits starts from 1 and ColumnInfo from 0
-    data.push_back(translateColumn(table_hdu.column(i), m_column_info->getDescription(i - 1).type, m_current_row,
-                                   m_current_row + rows - 1));
+    data.push_back(
+        translateColumn(table_hdu.column(i), m_column_info->getDescription(i - 1).type, m_current_row, m_current_row + rows - 1));
   }
 
   m_current_row += rows;
 
   std::vector<Row> row_list;
-  for (int i=0; i<rows; ++i) {
-    std::vector<Row::cell_type> cells {};
+  for (int i = 0; i < rows; ++i) {
+    std::vector<Row::cell_type> cells{};
     for (const auto& column_data : data) {
       cells.push_back(column_data[i]);
     }
@@ -175,6 +171,5 @@ std::size_t FitsReader::rowsLeft() {
   return m_total_rows - m_current_row + 1;
 }
 
-
-} // Table namespace
-} // Euclid namespace
+}  // namespace Table
+}  // namespace Euclid

--- a/Table/src/lib/FitsReaderHelper.cpp
+++ b/Table/src/lib/FitsReaderHelper.cpp
@@ -16,17 +16,17 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/FitsReaderHelper.cpp
  * @date April 17, 2014
  * @author Nikolaos Apostolakos
  */
 
+#include "FitsReaderHelper.h"
+#include "ElementsKernel/Exception.h"
 #include <CCfits/CCfits>
 #include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
-#include "ElementsKernel/Exception.h"
-#include "FitsReaderHelper.h"
 
 namespace Euclid {
 namespace Table {
@@ -34,8 +34,8 @@ namespace Table {
 using NdArray::NdArray;
 
 std::vector<std::string> autoDetectColumnNames(const CCfits::Table& table_hdu) {
-  std::vector<std::string> names {};
-  for (int i=1; i<=table_hdu.numCols(); ++i) {
+  std::vector<std::string> names{};
+  for (int i = 1; i <= table_hdu.numCols(); ++i) {
     std::string name = table_hdu.column(i).name();
     if (name.empty()) {
       name = "Col" + std::to_string(i);
@@ -58,16 +58,16 @@ std::type_index asciiFormatToType(const std::string& format) {
     return typeid(double);
   }
   throw Elements::Exception() << "FITS ASCII table format " << format << " is not "
-                            << "yet supported";
+                              << "yet supported";
 }
 
 std::type_index binaryFormatToType(const std::string& format, const std::vector<size_t>& shape) {
   // Get the size out of the format string
-  char ft = format.front();
-  int size = 1;
+  char ft   = format.front();
+  int  size = 1;
   if (std::isdigit(format.front())) {
     size = std::stoi(format.substr(0, format.size() - 1));
-    ft = format.back();
+    ft   = format.back();
   }
 
   // If shape is set, it is an NdArray
@@ -90,23 +90,17 @@ std::type_index binaryFormatToType(const std::string& format, const std::vector<
   else if (size == 1) {
     if (ft == 'L') {
       return typeid(bool);
-    }
-    else if (ft == 'B') {
+    } else if (ft == 'B') {
       return typeid(int32_t);
-    }
-    else if (ft == 'I') {
+    } else if (ft == 'I') {
       return typeid(int32_t);
-    }
-    else if (ft == 'J') {
+    } else if (ft == 'J') {
       return typeid(int32_t);
-    }
-    else if (ft == 'K') {
+    } else if (ft == 'K') {
       return typeid(int64_t);
-    }
-    else if (ft == 'E') {
+    } else if (ft == 'E') {
       return typeid(float);
-    }
-    else if (ft == 'D') {
+    } else if (ft == 'D') {
       return typeid(double);
     }
   }
@@ -129,14 +123,14 @@ std::type_index binaryFormatToType(const std::string& format, const std::vector<
     }
   }
   throw Elements::Exception() << "FITS binary table format " << format << " is not "
-                            << "yet supported";
+                              << "yet supported";
 }
 
-std::vector<size_t> parseTDIM(const std::string &tdim) {
-  std::vector<size_t> result {};
+std::vector<size_t> parseTDIM(const std::string& tdim) {
+  std::vector<size_t> result{};
   if (!tdim.empty() && tdim.front() == '(' && tdim.back() == ')') {
-    auto subtdim = tdim.substr(1, tdim.size() - 2);
-    boost::char_separator<char> sep{","};
+    auto                                          subtdim = tdim.substr(1, tdim.size() - 2);
+    boost::char_separator<char>                   sep{","};
     boost::tokenizer<boost::char_separator<char>> tok{subtdim, sep};
     for (auto& s : tok) {
       result.push_back(boost::lexical_cast<size_t>(s));
@@ -148,8 +142,8 @@ std::vector<size_t> parseTDIM(const std::string &tdim) {
 }
 
 std::vector<std::type_index> autoDetectColumnTypes(const CCfits::Table& table_hdu) {
-  std::vector<std::type_index> types {};
-  for (int i=1; i<=table_hdu.numCols(); i++) {
+  std::vector<std::type_index> types{};
+  for (int i = 1; i <= table_hdu.numCols(); i++) {
     auto& column = table_hdu.column(i);
 
     if (typeid(table_hdu) == typeid(CCfits::BinTable)) {
@@ -163,18 +157,18 @@ std::vector<std::type_index> autoDetectColumnTypes(const CCfits::Table& table_hd
 }
 
 std::vector<std::string> autoDetectColumnUnits(const CCfits::Table& table_hdu) {
-  std::vector<std::string> units {};
-  for (int i=1; i<=table_hdu.numCols(); ++i) {
+  std::vector<std::string> units{};
+  for (int i = 1; i <= table_hdu.numCols(); ++i) {
     units.push_back(table_hdu.column(i).unit());
   }
   return units;
 }
 
 std::vector<std::string> autoDetectColumnDescriptions(const CCfits::Table& table_hdu) {
-  std::vector<std::string> descriptions {};
-  for (int i=1; i<=table_hdu.numCols(); ++i) {
+  std::vector<std::string> descriptions{};
+  for (int i = 1; i <= table_hdu.numCols(); ++i) {
     std::string desc;
-    auto key = table_hdu.keyWord().find("TDESC" + std::to_string(i));
+    auto        key = table_hdu.keyWord().find("TDESC" + std::to_string(i));
     if (key != table_hdu.keyWord().end()) {
       key->second->value(desc);
     }
@@ -183,7 +177,7 @@ std::vector<std::string> autoDetectColumnDescriptions(const CCfits::Table& table
   return descriptions;
 }
 
-template<typename T>
+template <typename T>
 std::vector<Row::cell_type> convertScalarColumn(CCfits::Column& column, long first, long last) {
   std::vector<T> data;
   column.read(data, first, last);
@@ -194,18 +188,18 @@ std::vector<Row::cell_type> convertScalarColumn(CCfits::Column& column, long fir
   return result;
 }
 
-template<typename T>
+template <typename T>
 std::vector<Row::cell_type> convertVectorColumn(CCfits::Column& column, long first, long last) {
   std::vector<std::valarray<T>> data;
   column.readArrays(data, first, last);
   std::vector<Row::cell_type> result;
   for (auto& valar : data) {
-    result.push_back(std::vector<T>(std::begin(valar),std::end(valar)));
+    result.push_back(std::vector<T>(std::begin(valar), std::end(valar)));
   }
   return result;
 }
 
-template<typename T>
+template <typename T>
 std::vector<Row::cell_type> convertNdArrayColumn(CCfits::Column& column, long first, long last) {
   std::vector<std::valarray<T>> data;
   column.readArrays(data, first, last);
@@ -255,5 +249,5 @@ std::vector<Row::cell_type> translateColumn(CCfits::Column& column, std::type_in
   throw Elements::Exception() << "Unsupported column type " << type.name();
 }
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid

--- a/Table/src/lib/FitsReaderHelper.h
+++ b/Table/src/lib/FitsReaderHelper.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/FitsReaderHelper.h
  * @date April 17, 2014
  * @author Nikolaos Apostolakos
@@ -25,10 +25,10 @@
 #ifndef FITSREADERHELPER_H
 #define FITSREADERHELPER_H
 
-#include <vector>
+#include <CCfits/CCfits>
 #include <string>
 #include <typeindex>
-#include <CCfits/CCfits>
+#include <vector>
 
 #include "ElementsKernel/Export.h"
 
@@ -82,10 +82,9 @@ ELEMENTS_API std::vector<std::string> autoDetectColumnDescriptions(const CCfits:
  */
 ELEMENTS_API std::vector<Row::cell_type> translateColumn(CCfits::Column& column, std::type_index type);
 
-ELEMENTS_API std::vector<Row::cell_type> translateColumn(CCfits::Column& column, std::type_index type,
-                                                         long first, long last);
+ELEMENTS_API std::vector<Row::cell_type> translateColumn(CCfits::Column& column, std::type_index type, long first, long last);
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid
 
 #endif /* FITSREADERHELPER_H */

--- a/Table/src/lib/FitsWriter.cpp
+++ b/Table/src/lib/FitsWriter.cpp
@@ -22,26 +22,22 @@
  * @author nikoapos
  */
 
-#include <CCfits/CCfits>
-#include "ElementsKernel/Exception.h"
 #include "Table/FitsWriter.h"
+#include "ElementsKernel/Exception.h"
 #include "FitsWriterHelper.h"
+#include <CCfits/CCfits>
 
 namespace Euclid {
 namespace Table {
 
+FitsWriter::FitsWriter(const std::string& filename, bool override_flag) : m_filename(filename), m_override_file(override_flag) {}
 
-FitsWriter::FitsWriter(const std::string& filename, bool override_flag)
-        : m_filename(filename), m_override_file(override_flag) {
-}
-
-FitsWriter::FitsWriter(std::shared_ptr<CCfits::FITS> fits) : m_fits(fits) {
-}
+FitsWriter::FitsWriter(std::shared_ptr<CCfits::FITS> fits) : m_fits(fits) {}
 
 FitsWriter& FitsWriter::setFormat(Format format) {
   if (m_initialized) {
     throw Elements::Exception() << "Changing the format after writing "
-            << "has started is not allowed";
+                                << "has started is not allowed";
   }
   m_format = format;
   return *this;
@@ -50,7 +46,7 @@ FitsWriter& FitsWriter::setFormat(Format format) {
 FitsWriter& FitsWriter::setHduName(const std::string& name) {
   if (m_initialized) {
     throw Elements::Exception() << "Changing the HDU name after writing "
-            << "has started is not allowed";
+                                << "has started is not allowed";
   }
   m_hdu_name = name;
   return *this;
@@ -59,7 +55,7 @@ FitsWriter& FitsWriter::setHduName(const std::string& name) {
 void FitsWriter::addComment(const std::string& message) {
   if (m_initialized) {
     throw Elements::Exception() << "Adding comments after writing "
-            << "has started is not allowed";
+                                << "has started is not allowed";
   }
   m_comments.push_back(message);
 }
@@ -72,45 +68,40 @@ void FitsWriter::init(const Table& table) {
   } else {
     // CCfits overrides the file if the name starts with !, otherwise it opens it
     std::string filename = (m_override_file ? "!" : "") + m_filename;
-    fits = std::make_shared<CCfits::FITS>(filename, CCfits::RWmode::Write);
+    fits                 = std::make_shared<CCfits::FITS>(filename, CCfits::RWmode::Write);
   }
 
   // Create the column info arrays to feed the CCfits based on the ColumnInfo object
-  auto& info = *table.getColumnInfo();
-  std::vector<std::string> column_name_list {};
-  std::vector<std::string> column_unit_list {};
-  for (size_t column_index=0; column_index<info.size(); ++column_index) {
+  auto&                    info = *table.getColumnInfo();
+  std::vector<std::string> column_name_list{};
+  std::vector<std::string> column_unit_list{};
+  for (size_t column_index = 0; column_index < info.size(); ++column_index) {
     column_name_list.push_back(info.getDescription(column_index).name);
     column_unit_list.push_back(info.getDescription(column_index).unit);
   }
-  std::vector<std::string> column_format_list = (m_format == Format::BINARY)
-                                              ? getBinaryFormatList(table)
-                                              : getAsciiFormatList(table);
+  std::vector<std::string> column_format_list =
+      (m_format == Format::BINARY) ? getBinaryFormatList(table) : getAsciiFormatList(table);
 
-  CCfits::HduType hdu_type = (m_format == Format::BINARY)
-                           ? CCfits::HduType::BinaryTbl
-                           : CCfits::HduType::AsciiTbl;
+  CCfits::HduType hdu_type = (m_format == Format::BINARY) ? CCfits::HduType::BinaryTbl : CCfits::HduType::AsciiTbl;
 
   auto extension_map = fits->extension();
-  auto extension_i = extension_map.find(m_hdu_name);
-  bool new_hdu = (extension_i == extension_map.end() || extension_i->second->version() != 1);
+  auto extension_i   = extension_map.find(m_hdu_name);
+  bool new_hdu       = (extension_i == extension_map.end() || extension_i->second->version() != 1);
 
   CCfits::Table* table_hdu;
   if (!new_hdu) {
     table_hdu = dynamic_cast<CCfits::Table*>(extension_i->second);
-  }
-  else {
-    table_hdu = fits->addTable(m_hdu_name, 0, column_name_list,
-                               column_format_list, column_unit_list, hdu_type);
+  } else {
+    table_hdu = fits->addTable(m_hdu_name, 0, column_name_list, column_format_list, column_unit_list, hdu_type);
 
     // Write the customized description header keywords, and also dimensions for multidimensional arrays
-    for (size_t column_index=0; column_index<info.size(); ++column_index) {
+    for (size_t column_index = 0; column_index < info.size(); ++column_index) {
       auto& desc = info.getDescription(column_index).description;
-      table_hdu->addKey("TDESC" + std::to_string(column_index+1), desc, "");
+      table_hdu->addKey("TDESC" + std::to_string(column_index + 1), desc, "");
 
       auto shape_str = getTDIM(table, column_index);
       if (!shape_str.empty()) {
-        table_hdu->addKey(CCfits::Column::TDIM() + std::to_string(column_index+1), shape_str, "");
+        table_hdu->addKey(CCfits::Column::TDIM() + std::to_string(column_index + 1), shape_str, "");
       }
     }
 
@@ -119,9 +110,9 @@ void FitsWriter::init(const Table& table) {
     }
   }
 
-  m_hdu_index = table_hdu->index();
+  m_hdu_index    = table_hdu->index();
   m_current_line = table_hdu->rows() + 1;
-  m_initialized = true;
+  m_initialized  = true;
 }
 
 void FitsWriter::append(const Table& table) {
@@ -134,11 +125,11 @@ void FitsWriter::append(const Table& table) {
   auto& table_hdu = fits->extension(m_hdu_index);
 
   auto& info = *table.getColumnInfo();
-  for (size_t column_index=0; column_index<info.size(); ++column_index) {
+  for (size_t column_index = 0; column_index < info.size(); ++column_index) {
     populateColumn(table, column_index, table_hdu, m_current_line);
   }
   m_current_line += table.size();
 }
 
-} // Table namespace
-} // Euclid namespace
+}  // namespace Table
+}  // namespace Euclid

--- a/Table/src/lib/FitsWriterHelper.cpp
+++ b/Table/src/lib/FitsWriterHelper.cpp
@@ -16,28 +16,28 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/FitsWriterHelper.cpp
  * @date April 23, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <algorithm>
-#include <sstream>
-#include <iomanip>
-#include <valarray>
-#include <boost/lexical_cast.hpp>
-#include <CCfits/CCfits>
 #include "FitsWriterHelper.h"
-#include "Table/Table.h"
 #include "ElementsKernel/Exception.h"
+#include "Table/Table.h"
+#include <CCfits/CCfits>
+#include <algorithm>
+#include <boost/lexical_cast.hpp>
+#include <iomanip>
+#include <sstream>
+#include <valarray>
 
 namespace Euclid {
 namespace Table {
 
 using NdArray::NdArray;
 
-template<typename T>
+template <typename T>
 std::string scientificFormat(T value) {
   std::ostringstream stream;
   stream << std::scientific << value;
@@ -61,9 +61,9 @@ size_t maxWidthScientific(const Table& table, size_t column_index) {
 }
 
 std::vector<std::string> getAsciiFormatList(const Table& table) {
-  auto column_info = table.getColumnInfo();
-  std::vector<std::string> format_list {};
-  for (size_t column_index=0; column_index<column_info->size(); ++column_index) {
+  auto                     column_info = table.getColumnInfo();
+  std::vector<std::string> format_list{};
+  for (size_t column_index = 0; column_index < column_info->size(); ++column_index) {
     auto type = column_info->getDescription(column_index).type;
     if (type == typeid(bool)) {
       format_list.push_back("I1");
@@ -96,9 +96,9 @@ size_t vectorSize(const Table& table, size_t column_index) {
 
 template <typename T>
 size_t ndArraySize(const Table& table, size_t column_index) {
-  const auto &ndarray = boost::get<NdArray<T>>(table[0][column_index]);
-  size_t size = ndarray.size();
-  auto shape = ndarray.shape();
+  const auto& ndarray = boost::get<NdArray<T>>(table[0][column_index]);
+  size_t      size    = ndarray.size();
+  auto        shape   = ndarray.shape();
   for (const auto& row : table) {
     if (boost::get<NdArray<T>>(row[column_index]).shape() != shape) {
       throw Elements::Exception() << "Binary FITS table variable shape array columns are not supported";
@@ -108,9 +108,9 @@ size_t ndArraySize(const Table& table, size_t column_index) {
 }
 
 std::vector<std::string> getBinaryFormatList(const Table& table) {
-  auto column_info = table.getColumnInfo();
-  std::vector<std::string> format_list {};
-  for (size_t column_index=0; column_index<column_info->size(); ++column_index) {
+  auto                     column_info = table.getColumnInfo();
+  std::vector<std::string> format_list{};
+  for (size_t column_index = 0; column_index < column_info->size(); ++column_index) {
     auto type = column_info->getDescription(column_index).type;
     if (type == typeid(bool)) {
       format_list.push_back("L");
@@ -159,9 +159,9 @@ std::vector<std::string> getBinaryFormatList(const Table& table) {
   return format_list;
 }
 
-template<typename T>
+template <typename T>
 std::vector<T> createColumnData(const Euclid::Table::Table& table, size_t column_index) {
-  std::vector<T> data {};
+  std::vector<T> data{};
   for (const auto& row : table) {
     data.push_back(boost::get<T>(row[column_index]));
   }
@@ -170,7 +170,7 @@ std::vector<T> createColumnData(const Euclid::Table::Table& table, size_t column
 
 template <typename T>
 std::vector<std::valarray<T>> createVectorColumnData(const Euclid::Table::Table& table, size_t column_index) {
-  std::vector<std::valarray<T>> result {};
+  std::vector<std::valarray<T>> result{};
   for (auto& row : table) {
     const auto& vec = boost::get<std::vector<T>>(row[column_index]);
     result.emplace_back(vec.data(), vec.size());
@@ -180,7 +180,7 @@ std::vector<std::valarray<T>> createVectorColumnData(const Euclid::Table::Table&
 
 template <typename T>
 std::vector<T> createSingleValueVectorColumnData(const Euclid::Table::Table& table, size_t column_index) {
-  std::vector<T> result {};
+  std::vector<T> result{};
   for (auto& row : table) {
     const auto& vec = boost::get<std::vector<T>>(row[column_index]);
     result.push_back(vec.front());
@@ -192,7 +192,7 @@ template <typename T>
 std::vector<std::valarray<T>> createNdArrayColumnData(const Euclid::Table::Table& table, size_t column_index) {
   std::vector<std::valarray<T>> result{};
   for (auto& row : table) {
-    const auto& ndarray = boost::get<NdArray<T>>(row[column_index]);
+    const auto&      ndarray = boost::get<NdArray<T>>(row[column_index]);
     std::valarray<T> data(ndarray.size());
     std::copy(std::begin(ndarray), std::end(ndarray), std::begin(data));
     result.emplace_back(std::move(data));
@@ -202,7 +202,7 @@ std::vector<std::valarray<T>> createNdArrayColumnData(const Euclid::Table::Table
 
 template <typename T>
 std::vector<T> createSingleNdArrayVectorColumnData(const Euclid::Table::Table& table, size_t column_index) {
-  std::vector<T> result {};
+  std::vector<T> result{};
   for (auto& row : table) {
     const auto& nd = boost::get<NdArray<T>>(row[column_index]);
     if (nd.size() > 0)
@@ -217,9 +217,9 @@ template <typename T>
 void populateVectorColumn(const Table& table, size_t column_index, CCfits::ExtHDU& table_hdu, long first_row) {
   const auto& vec = boost::get<std::vector<T>>(table[0][column_index]);
   if (vec.size() > 1) {
-    table_hdu.column(column_index+1).writeArrays(createVectorColumnData<T>(table, column_index), first_row);
+    table_hdu.column(column_index + 1).writeArrays(createVectorColumnData<T>(table, column_index), first_row);
   } else {
-    table_hdu.column(column_index+1).write(createSingleValueVectorColumnData<T>(table, column_index), first_row);
+    table_hdu.column(column_index + 1).write(createSingleValueVectorColumnData<T>(table, column_index), first_row);
   }
 }
 
@@ -228,16 +228,15 @@ void populateNdArrayColumn(const Table& table, size_t column_index, CCfits::ExtH
   const auto& nd = boost::get<NdArray<T>>(table[0][column_index]);
   if (nd.size() > 1) {
     table_hdu.column(column_index + 1).writeArrays(createNdArrayColumnData<T>(table, column_index), first_row);
-  }
-  else {
-    table_hdu.column(column_index+1).write(createSingleNdArrayVectorColumnData<T>(table, column_index), first_row);
+  } else {
+    table_hdu.column(column_index + 1).write(createSingleNdArrayVectorColumnData<T>(table, column_index), first_row);
   }
 }
 
 std::string getTDIM(const Table& table, size_t column_index) {
-  auto& first_row = table[0];
-  auto& cell = first_row[column_index];
-  auto type = table.getColumnInfo()->getDescription(column_index).type;
+  auto&               first_row = table[0];
+  auto&               cell      = first_row[column_index];
+  auto                type      = table.getColumnInfo()->getDescription(column_index).type;
   std::vector<size_t> shape;
 
   if (type == typeid(NdArray<int32_t>)) {
@@ -253,7 +252,7 @@ std::string getTDIM(const Table& table, size_t column_index) {
   }
 
   int64_t ncells = 1;
-  for (auto &axis : shape) {
+  for (auto& axis : shape) {
     ncells *= axis;
   }
   if (ncells == 1) {
@@ -276,17 +275,17 @@ void populateColumn(const Table& table, size_t column_index, CCfits::ExtHDU& tab
   auto type = table.getColumnInfo()->getDescription(column_index).type;
   // CCfits indices start from 1
   if (type == typeid(bool)) {
-    table_hdu.column(column_index+1).write(createColumnData<bool>(table, column_index), first_row);
+    table_hdu.column(column_index + 1).write(createColumnData<bool>(table, column_index), first_row);
   } else if (type == typeid(int32_t)) {
-    table_hdu.column(column_index+1).write(createColumnData<int32_t>(table, column_index), first_row);
+    table_hdu.column(column_index + 1).write(createColumnData<int32_t>(table, column_index), first_row);
   } else if (type == typeid(int64_t)) {
-    table_hdu.column(column_index+1).write(createColumnData<int64_t>(table, column_index), first_row);
+    table_hdu.column(column_index + 1).write(createColumnData<int64_t>(table, column_index), first_row);
   } else if (type == typeid(float)) {
-    table_hdu.column(column_index+1).write(createColumnData<float>(table, column_index), first_row);
+    table_hdu.column(column_index + 1).write(createColumnData<float>(table, column_index), first_row);
   } else if (type == typeid(double)) {
-    table_hdu.column(column_index+1).write(createColumnData<double>(table, column_index), first_row);
+    table_hdu.column(column_index + 1).write(createColumnData<double>(table, column_index), first_row);
   } else if (type == typeid(std::string)) {
-    table_hdu.column(column_index+1).write(createColumnData<std::string>(table, column_index), first_row);
+    table_hdu.column(column_index + 1).write(createColumnData<std::string>(table, column_index), first_row);
   } else if (type == typeid(std::vector<int32_t>)) {
     populateVectorColumn<int32_t>(table, column_index, table_hdu, first_row);
   } else if (type == typeid(std::vector<int64_t>)) {
@@ -308,5 +307,5 @@ void populateColumn(const Table& table, size_t column_index, CCfits::ExtHDU& tab
   }
 }
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid

--- a/Table/src/lib/FitsWriterHelper.h
+++ b/Table/src/lib/FitsWriterHelper.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file src/lib/FitsWriterHelper.h
  * @date April 23, 2014
  * @author Nikolaos Apostolakos
@@ -25,10 +25,10 @@
 #ifndef TABLE_FITSWRITERHELPER_H
 #define TABLE_FITSWRITERHELPER_H
 
-#include <string>
-#include <vector>
-#include <typeindex>
 #include <CCfits/CCfits>
+#include <string>
+#include <typeindex>
+#include <vector>
 
 #include "ElementsKernel/Export.h"
 
@@ -72,9 +72,9 @@ ELEMENTS_API std::vector<std::string> getBinaryFormatList(const Table& table);
  */
 ELEMENTS_API std::string getTDIM(const Table& table, size_t column_index);
 
-void populateColumn(const Table& table, size_t column_index, CCfits::ExtHDU& table_hdu, long first_row=1);
+void populateColumn(const Table& table, size_t column_index, CCfits::ExtHDU& table_hdu, long first_row = 1);
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid
 
 #endif /* TABLE_FITSWRITERHELPER_H */

--- a/Table/src/lib/ReaderHelper.cpp
+++ b/Table/src/lib/ReaderHelper.cpp
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/ReaderHelper.cpp
  * @date April 21, 2014
  * @author Nikolaos Apostolakos
@@ -27,16 +27,14 @@
 namespace Euclid {
 namespace Table {
 
-std::shared_ptr<ColumnInfo> createColumnInfo(const std::vector<std::string>& names,
-                                             const std::vector<std::type_index>& types,
-                                             const std::vector<std::string>& units,
-                                             const std::vector<std::string>& descriptions) {
-  std::vector<ColumnInfo::info_type> info_list {};
-  for (size_t i=0; i< names.size(); ++i) {
+std::shared_ptr<ColumnInfo> createColumnInfo(const std::vector<std::string>& names, const std::vector<std::type_index>& types,
+                                             const std::vector<std::string>& units, const std::vector<std::string>& descriptions) {
+  std::vector<ColumnInfo::info_type> info_list{};
+  for (size_t i = 0; i < names.size(); ++i) {
     info_list.push_back({names[i], types[i], units[i], descriptions[i]});
   }
   return std::shared_ptr<ColumnInfo>(new ColumnInfo{std::move(info_list)});
 }
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid

--- a/Table/src/lib/ReaderHelper.h
+++ b/Table/src/lib/ReaderHelper.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file src/lib/ReaderHelper.h
  * @date April 21, 2014
  * @author Nikolaos Apostolakos
@@ -25,22 +25,20 @@
 #ifndef TABLE_READERHELPER_H
 #define TABLE_READERHELPER_H
 
+#include "Table/ColumnInfo.h"
 #include <memory>
 #include <string>
-#include <vector>
 #include <typeindex>
-#include "Table/ColumnInfo.h"
+#include <vector>
 
 namespace Euclid {
 namespace Table {
 
 /// Creates a ColumnInfo object from the given names and types
-std::shared_ptr<ColumnInfo> createColumnInfo(const std::vector<std::string>& names,
-                                             const std::vector<std::type_index>& types,
-                                             const std::vector<std::string>& units,
-                                             const std::vector<std::string>& descriptions);
+std::shared_ptr<ColumnInfo> createColumnInfo(const std::vector<std::string>& names, const std::vector<std::type_index>& types,
+                                             const std::vector<std::string>& units, const std::vector<std::string>& descriptions);
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid
 
 #endif /* TABLE_READERHELPER_H */

--- a/Table/src/lib/Row.cpp
+++ b/Table/src/lib/Row.cpp
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/Row.cpp
  * @date April 8, 2014
  * @author Nikolaos Apostolakos
@@ -30,9 +30,9 @@
 #include <boost/regex.hpp>
 using boost::regex;
 using boost::regex_match;
-#include <boost/algorithm/string/join.hpp>
 #include "ElementsKernel/Exception.h"
 #include "Table/Row.h"
+#include <boost/algorithm/string/join.hpp>
 
 #if BOOST_VERSION < 105600
 #include <boost/units/detail/utility.hpp>
@@ -44,7 +44,7 @@ using boost::core::demangle;
 namespace std {
 
 template <typename T>
-std::ostream& operator<< (std::ostream& s, const std::vector<T>& v) {
+std::ostream& operator<<(std::ostream& s, const std::vector<T>& v) {
   auto it = v.begin();
   if (it != v.end()) {
     s << *it;
@@ -55,37 +55,35 @@ std::ostream& operator<< (std::ostream& s, const std::vector<T>& v) {
   return s;
 }
 
-template std::ostream& operator<< <double> (std::ostream& s, const std::vector<double>& v);
-template std::ostream& operator<< <float> (std::ostream& s, const std::vector<float>& v);
-template std::ostream& operator<< <std::int64_t> (std::ostream& s, const std::vector<std::int64_t>& v);
-template std::ostream& operator<< <std::int32_t> (std::ostream& s, const std::vector<std::int32_t>& v);
-template std::ostream& operator<< <bool> (std::ostream& s, const std::vector<bool>& v);
+template std::ostream& operator<<<double>(std::ostream& s, const std::vector<double>& v);
+template std::ostream& operator<<<float>(std::ostream& s, const std::vector<float>& v);
+template std::ostream& operator<<<std::int64_t>(std::ostream& s, const std::vector<std::int64_t>& v);
+template std::ostream& operator<<<std::int32_t>(std::ostream& s, const std::vector<std::int32_t>& v);
+template std::ostream& operator<<<bool>(std::ostream& s, const std::vector<bool>& v);
 
-}
+}  // namespace std
 
 namespace Euclid {
 namespace Table {
 
 Row::Row(std::vector<cell_type> values, std::shared_ptr<ColumnInfo> column_info)
-        : m_values(std::move(values)), m_column_info{column_info} {
+    : m_values(std::move(values)), m_column_info{column_info} {
   if (!m_column_info) {
     throw Elements::Exception() << "Row construction with nullptr column_info";
   }
   if (m_values.size() != m_column_info->size()) {
-    throw Elements::Exception() << "Wrong number of row values (" << m_values.size()
-                              << " instead of " << m_column_info->size();
+    throw Elements::Exception() << "Wrong number of row values (" << m_values.size() << " instead of " << m_column_info->size();
   }
-  for (std::size_t i=0; i<m_values.size(); ++i) {
-    auto& value_type = m_values[i].type();
+  for (std::size_t i = 0; i < m_values.size(); ++i) {
+    auto& value_type  = m_values[i].type();
     auto& column_type = column_info->getDescription(i).type;
     auto& column_name = column_info->getDescription(i).name;
     if (std::type_index{value_type} != column_type) {
-      throw Elements::Exception() << "Incompatible cell type for " << column_name << ": expected "
-                                  << demangle(column_type.name())
+      throw Elements::Exception() << "Incompatible cell type for " << column_name << ": expected " << demangle(column_type.name())
                                   << ", got " << demangle(value_type.name());
     }
   }
-  regex vertical_whitespace {".*\\v.*"}; // Checks if input contains any vertical whitespace characters
+  regex vertical_whitespace{".*\\v.*"};  // Checks if input contains any vertical whitespace characters
   for (auto cell : m_values) {
     if (cell.type() == typeid(std::string)) {
       std::string value = boost::get<std::string>(cell);
@@ -94,7 +92,7 @@ Row::Row(std::vector<cell_type> values, std::shared_ptr<ColumnInfo> column_info)
       }
       if (regex_match(value, vertical_whitespace)) {
         throw Elements::Exception() << "Cell value '" << value << "' contains "
-                                  << "vertical whitespace characters";
+                                    << "vertical whitespace characters";
       }
     }
   }
@@ -108,14 +106,14 @@ size_t Row::size() const {
   return m_values.size();
 }
 
-const Row::cell_type& Row::operator [](const size_t index) const {
+const Row::cell_type& Row::operator[](const size_t index) const {
   if (index >= m_values.size()) {
     throw Elements::Exception("Index out of bounds");
   }
   return m_values[index];
 }
 
-const Row::cell_type& Row::operator [](const std::string& column) const {
+const Row::cell_type& Row::operator[](const std::string& column) const {
   auto index = m_column_info->find(column);
   if (!index) {
     throw Elements::Exception() << "Row does not contain column with name " << column;
@@ -131,5 +129,5 @@ Row::const_iterator Row::end() const {
   return m_values.cend();
 }
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid

--- a/Table/src/lib/Table.cpp
+++ b/Table/src/lib/Table.cpp
@@ -16,20 +16,19 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/Table.cpp
  * @date April 9, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include "ElementsKernel/Exception.h"
 #include "Table/Table.h"
+#include "ElementsKernel/Exception.h"
 
 namespace Euclid {
 namespace Table {
 
-Table::Table(std::vector<Row> row_list) : m_row_list {std::move(row_list)} ,
-                                          m_column_info {} {
+Table::Table(std::vector<Row> row_list) : m_row_list{std::move(row_list)}, m_column_info{} {
   // Check we have some rows
   if (m_row_list.empty()) {
     throw Elements::Exception() << "Construction of empty tables is not allowed";
@@ -41,7 +40,7 @@ Table::Table(std::vector<Row> row_list) : m_row_list {std::move(row_list)} ,
   for (auto row : m_row_list) {
     if (*row.getColumnInfo() != *m_column_info) {
       throw Elements::Exception() << "Construction of table from rows with different "
-                                << "columns is not allowed";
+                                  << "columns is not allowed";
     }
   }
 }
@@ -54,7 +53,7 @@ std::size_t Table::size() const {
   return m_row_list.size();
 }
 
-const Row& Table::operator [](std::size_t index) const {
+const Row& Table::operator[](std::size_t index) const {
   if (index >= m_row_list.size()) {
     throw Elements::Exception("Index out of bounds");
   }
@@ -69,5 +68,5 @@ Table::const_iterator Table::end() const {
   return m_row_list.cend();
 }
 
-}
-} // end of namespace Euclid
+}  // namespace Table
+}  // end of namespace Euclid

--- a/Table/src/lib/TableWriter.cpp
+++ b/Table/src/lib/TableWriter.cpp
@@ -39,6 +39,5 @@ void TableWriter::addData(const Table& table) {
   append(table);
 }
 
-
-} // Table namespace
-} // Euclid namespace
+}  // namespace Table
+}  // namespace Euclid

--- a/Table/tests/src/AsciiReaderHelper_test.cpp
+++ b/Table/tests/src/AsciiReaderHelper_test.cpp
@@ -1,127 +1,110 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file tests/src/AsciiReaderHelper_test.cpp
  * @date April 15, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
 #include "ElementsKernel/Exception.h"
 #include "src/lib/AsciiReaderHelper.h"
+#include <boost/test/unit_test.hpp>
 
 struct AsciiReaderHelper_Fixture {
-  std::string only_comments {
-    "# First comment line\n"
-    "# Second comment line\n"
-    "# Third comment line"
-  };
-  
-  std::string two_columns {
-    "   # First Second\n"
-    " \n"
-    "  1.1E-12   Test  # Comment"
-  };
-  
-  std::string no_names {
-    "# This is a comment but with wrong number of words\n"
-    "1 2 3 4 5"
-  };
-  
-  std::string five_names {
-    "# This is not a comment with the names\n"
-    "# First Second# #Third #Fourth# Fifth\n"
-    "#\n"
-    "\n"
-    "1 2 3 4 5"
-  };
-  
-  std::string duplicate_names {
-    "# This is not a comment with the names\n"
-    "# First Second# #Third #Second# Fifth\n"
-    "#\n"
-    "\n"
-    "1 2 3 4 5"
-  };
-  
-  std::string column_descriptions {
-    "# Column: First bool (unit1) - This is the first description\n"
-    "# Column: Second boolean\n"
-    "# Column: Third int (unit3)\n"
-    "# Column: Fourth int32 - This is the fourth description\n"
-  };
-  
-  std::string all_types {
-    "# Column: Bool1 bool (unit1) - This is the first description\n"
-    "# Column: Bool2 boolean\n"
-    "# Column: Int1 int (unit3)\n"
-    "# Column: Int2 int32 - This is the fourth description\n"
-    "# Column: Long1 long\n"
-    "# Column: Long2 int64\n"
-    "# Column: Float float\n"
-    "# Column: Double double\n"
-    "# Column: String string\n"
-    "# Column: DoubleVector [double]\n"
-    "\n"
-    "# Bool1 Bool2   Int1 Int2  Long1 Long2 Float Double String DoubleVector\n"
-    "\n"
-    "  true  t       1    2     3     4     5.    6.     7      1.1,1.2,1.3\n"
-    "  yes   y       8    9     10    11    1.2   1.3    14     2.1,2.2,2.3,2.4\n"
-    "  1     false   15   16    17    18    1.9   2.0    21     3.1,3.2,3.3\n"
-    "  f     no      22   23    24    25    2.6   2.7    28     4.1,4.2\n"
-    "  n     0       29   30    31    32    3.3   3.4    35     5.1,5.2\n"
-  };
-  
-  std::string invalid_type {
-    "# Column: First Wrong\n"
-    "# Column: Second boolean\n"
-    "# Column: Third int\n"
-  };
+  std::string only_comments{"# First comment line\n"
+                            "# Second comment line\n"
+                            "# Third comment line"};
+
+  std::string two_columns{"   # First Second\n"
+                          " \n"
+                          "  1.1E-12   Test  # Comment"};
+
+  std::string no_names{"# This is a comment but with wrong number of words\n"
+                       "1 2 3 4 5"};
+
+  std::string five_names{"# This is not a comment with the names\n"
+                         "# First Second# #Third #Fourth# Fifth\n"
+                         "#\n"
+                         "\n"
+                         "1 2 3 4 5"};
+
+  std::string duplicate_names{"# This is not a comment with the names\n"
+                              "# First Second# #Third #Second# Fifth\n"
+                              "#\n"
+                              "\n"
+                              "1 2 3 4 5"};
+
+  std::string column_descriptions{"# Column: First bool (unit1) - This is the first description\n"
+                                  "# Column: Second boolean\n"
+                                  "# Column: Third int (unit3)\n"
+                                  "# Column: Fourth int32 - This is the fourth description\n"};
+
+  std::string all_types{"# Column: Bool1 bool (unit1) - This is the first description\n"
+                        "# Column: Bool2 boolean\n"
+                        "# Column: Int1 int (unit3)\n"
+                        "# Column: Int2 int32 - This is the fourth description\n"
+                        "# Column: Long1 long\n"
+                        "# Column: Long2 int64\n"
+                        "# Column: Float float\n"
+                        "# Column: Double double\n"
+                        "# Column: String string\n"
+                        "# Column: DoubleVector [double]\n"
+                        "\n"
+                        "# Bool1 Bool2   Int1 Int2  Long1 Long2 Float Double String DoubleVector\n"
+                        "\n"
+                        "  true  t       1    2     3     4     5.    6.     7      1.1,1.2,1.3\n"
+                        "  yes   y       8    9     10    11    1.2   1.3    14     2.1,2.2,2.3,2.4\n"
+                        "  1     false   15   16    17    18    1.9   2.0    21     3.1,3.2,3.3\n"
+                        "  f     no      22   23    24    25    2.6   2.7    28     4.1,4.2\n"
+                        "  n     0       29   30    31    32    3.3   3.4    35     5.1,5.2\n"};
+
+  std::string invalid_type{"# Column: First Wrong\n"
+                           "# Column: Second boolean\n"
+                           "# Column: Third int\n"};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (AsciiReaderHelper_test)
+BOOST_AUTO_TEST_SUITE(AsciiReaderHelper_test)
 
 //-----------------------------------------------------------------------------
 // Test the StreamRewinder
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(StreamRewinder, AsciiReaderHelper_Fixture) {
-  
+
   // Given
-  std::stringstream stream {only_comments};
-  
+  std::stringstream stream{only_comments};
+
   // When
   std::string line;
   {
     getline(stream, line);
-    Euclid::Table::StreamRewinder rewinder {stream};
+    Euclid::Table::StreamRewinder rewinder{stream};
     getline(stream, line);
     getline(stream, line);
   }
-  
+
   // Then
   BOOST_CHECK_EQUAL(line, "# Third comment line");
   getline(stream, line);
   BOOST_CHECK_EQUAL(line, "# Second comment line");
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -129,13 +112,12 @@ BOOST_FIXTURE_TEST_CASE(StreamRewinder, AsciiReaderHelper_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(countColumnsNoDataLines, AsciiReaderHelper_Fixture) {
-  
+
   // Given
-  std::stringstream stream {only_comments};
-  
+  std::stringstream stream{only_comments};
+
   // Then
   BOOST_CHECK_THROW(Euclid::Table::countColumns(stream, "#"), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -143,16 +125,15 @@ BOOST_FIXTURE_TEST_CASE(countColumnsNoDataLines, AsciiReaderHelper_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(countColumns, AsciiReaderHelper_Fixture) {
-  
+
   // Given
-  std::stringstream stream {two_columns};
-  
+  std::stringstream stream{two_columns};
+
   // When
   size_t size = Euclid::Table::countColumns(stream, "#");
-  
+
   // Then
   BOOST_CHECK_EQUAL(size, 2u);
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -160,18 +141,17 @@ BOOST_FIXTURE_TEST_CASE(countColumns, AsciiReaderHelper_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(countColumnsRewinds, AsciiReaderHelper_Fixture) {
-  
+
   // Given
-  std::stringstream stream {two_columns};
-  
+  std::stringstream stream{two_columns};
+
   // When
   Euclid::Table::countColumns(stream, "#");
-  std::string line {};
+  std::string line{};
   getline(stream, line);
-  
+
   // Then
   BOOST_CHECK_EQUAL(line, "   # First Second");
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -179,41 +159,40 @@ BOOST_FIXTURE_TEST_CASE(countColumnsRewinds, AsciiReaderHelper_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnDescriptions, AsciiReaderHelper_Fixture) {
-  
+
   // Given
-  std::stringstream stream {column_descriptions};
-  
+  std::stringstream stream{column_descriptions};
+
   // When
   auto result = Euclid::Table::autoDetectColumnDescriptions(stream, "#");
-  
+
   // Then
   BOOST_CHECK_EQUAL(result.size(), 4);
-  
+
   BOOST_CHECK_EQUAL(result.count("First"), 1);
   BOOST_CHECK_EQUAL(result.count("Second"), 1);
   BOOST_CHECK_EQUAL(result.count("Third"), 1);
   BOOST_CHECK_EQUAL(result.count("Fourth"), 1);
-  
+
   BOOST_CHECK_EQUAL(result.at("First").name, "First");
   BOOST_CHECK_EQUAL(result.at("Second").name, "Second");
   BOOST_CHECK_EQUAL(result.at("Third").name, "Third");
   BOOST_CHECK_EQUAL(result.at("Fourth").name, "Fourth");
-  
+
   BOOST_CHECK_EQUAL(result.at("First").type.name(), typeid(bool).name());
   BOOST_CHECK_EQUAL(result.at("Second").type.name(), typeid(bool).name());
   BOOST_CHECK_EQUAL(result.at("Third").type.name(), typeid(int).name());
   BOOST_CHECK_EQUAL(result.at("Fourth").type.name(), typeid(int).name());
-  
+
   BOOST_CHECK_EQUAL(result.at("First").unit, "unit1");
   BOOST_CHECK_EQUAL(result.at("Second").unit, "");
   BOOST_CHECK_EQUAL(result.at("Third").unit, "unit3");
   BOOST_CHECK_EQUAL(result.at("Fourth").unit, "");
-  
+
   BOOST_CHECK_EQUAL(result.at("First").description, "This is the first description");
   BOOST_CHECK_EQUAL(result.at("Second").description, "");
   BOOST_CHECK_EQUAL(result.at("Third").description, "");
   BOOST_CHECK_EQUAL(result.at("Fourth").description, "This is the fourth description");
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -221,18 +200,15 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnDescriptions, AsciiReaderHelper_Fixture)
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(autoDetectColumnDescriptions_duplicateName) {
-  
+
   // Given
-  std::stringstream stream {
-    "# Column: First bool (unit1) - This is the first description\n"
-    "# Column: Second boolean\n"
-    "# Column: Third int (unit3)\n"
-    "# Column: Second int32 - This is the fourth description\n"
-  };
-  
+  std::stringstream stream{"# Column: First bool (unit1) - This is the first description\n"
+                           "# Column: Second boolean\n"
+                           "# Column: Third int (unit3)\n"
+                           "# Column: Second int32 - This is the fourth description\n"};
+
   // Then
   BOOST_CHECK_THROW(Euclid::Table::autoDetectColumnDescriptions(stream, "#"), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -240,18 +216,15 @@ BOOST_AUTO_TEST_CASE(autoDetectColumnDescriptions_duplicateName) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(autoDetectColumnDescriptions_invalidType) {
-  
+
   // Given
-  std::stringstream stream {
-    "# Column: First bool (unit1) - This is the first description\n"
-    "# Column: Second boolean\n"
-    "# Column: Third inta (unit3)\n"
-    "# Column: Fourth int32 - This is the fourth description\n"
-  };
-  
+  std::stringstream stream{"# Column: First bool (unit1) - This is the first description\n"
+                           "# Column: Second boolean\n"
+                           "# Column: Third inta (unit3)\n"
+                           "# Column: Fourth int32 - This is the fourth description\n"};
+
   // Then
   BOOST_CHECK_THROW(Euclid::Table::autoDetectColumnDescriptions(stream, "#"), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -259,13 +232,13 @@ BOOST_AUTO_TEST_CASE(autoDetectColumnDescriptions_invalidType) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnNamesNoNames, AsciiReaderHelper_Fixture) {
-  
+
   // Given
-  std::stringstream stream {no_names};
-  
+  std::stringstream stream{no_names};
+
   // When
   auto names = Euclid::Table::autoDetectColumnNames(stream, "#", 5);
-  
+
   // Then
   BOOST_CHECK_EQUAL(names.size(), 5u);
   BOOST_CHECK_EQUAL(names[0], "col1");
@@ -273,7 +246,6 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnNamesNoNames, AsciiReaderHelper_Fixture)
   BOOST_CHECK_EQUAL(names[2], "col3");
   BOOST_CHECK_EQUAL(names[3], "col4");
   BOOST_CHECK_EQUAL(names[4], "col5");
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -281,13 +253,13 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnNamesNoNames, AsciiReaderHelper_Fixture)
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnNamesSuccess, AsciiReaderHelper_Fixture) {
-  
+
   // Given
-  std::stringstream stream {five_names};
-  
+  std::stringstream stream{five_names};
+
   // When
   auto names = Euclid::Table::autoDetectColumnNames(stream, "#", 5);
-  
+
   // Then
   BOOST_CHECK_EQUAL(names.size(), 5u);
   BOOST_CHECK_EQUAL(names[0], "First");
@@ -295,7 +267,6 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnNamesSuccess, AsciiReaderHelper_Fixture)
   BOOST_CHECK_EQUAL(names[2], "Third");
   BOOST_CHECK_EQUAL(names[3], "Fourth");
   BOOST_CHECK_EQUAL(names[4], "Fifth");
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -303,23 +274,22 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnNamesSuccess, AsciiReaderHelper_Fixture)
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(autoDetectColumnNamesSuccess_fromDescription) {
-  
+
   // Given
-  std::stringstream stream {
-    "# This is not a comment with the names\n"
-    "# Column: First\n"
-    "# Column: Second double\n"
-    "# Column: Third (unit)\n"
-    "# Comment in between\n"
-    "# Column: Fourth\n"
-    "# Column: Fifth - Description\n"
-    "# Some more comments here\n"
-    "\n"
-    "1 2 3 4 5"};
-  
+  std::stringstream stream{"# This is not a comment with the names\n"
+                           "# Column: First\n"
+                           "# Column: Second double\n"
+                           "# Column: Third (unit)\n"
+                           "# Comment in between\n"
+                           "# Column: Fourth\n"
+                           "# Column: Fifth - Description\n"
+                           "# Some more comments here\n"
+                           "\n"
+                           "1 2 3 4 5"};
+
   // When
   auto names = Euclid::Table::autoDetectColumnNames(stream, "#", 5);
-  
+
   // Then
   BOOST_CHECK_EQUAL(names.size(), 5u);
   BOOST_CHECK_EQUAL(names[0], "First");
@@ -327,29 +297,27 @@ BOOST_AUTO_TEST_CASE(autoDetectColumnNamesSuccess_fromDescription) {
   BOOST_CHECK_EQUAL(names[2], "Third");
   BOOST_CHECK_EQUAL(names[3], "Fourth");
   BOOST_CHECK_EQUAL(names[4], "Fifth");
-  
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(autoDetectColumnNames_descriptionsUnordered) {
-  
+
   // Given
-  std::stringstream stream {
-    "# This is not a comment with the names\n"
-    "# Column: First\n"
-    "# Column: Fourth\n"
-    "# Column: Second double\n"
-    "# Column: Third (unit)\n"
-    "# Column: Fifth - Description\n"
-    "# Some more comments here\n"
-    "\n"
-    "# First Second Third Fourth Fifth\n"
-    "1 2 3 4 5"};
-  
+  std::stringstream stream{"# This is not a comment with the names\n"
+                           "# Column: First\n"
+                           "# Column: Fourth\n"
+                           "# Column: Second double\n"
+                           "# Column: Third (unit)\n"
+                           "# Column: Fifth - Description\n"
+                           "# Some more comments here\n"
+                           "\n"
+                           "# First Second Third Fourth Fifth\n"
+                           "1 2 3 4 5"};
+
   // When
   auto names = Euclid::Table::autoDetectColumnNames(stream, "#", 5);
-  
+
   // Then
   BOOST_CHECK_EQUAL(names.size(), 5u);
   BOOST_CHECK_EQUAL(names[0], "First");
@@ -357,28 +325,26 @@ BOOST_AUTO_TEST_CASE(autoDetectColumnNames_descriptionsUnordered) {
   BOOST_CHECK_EQUAL(names[2], "Third");
   BOOST_CHECK_EQUAL(names[3], "Fourth");
   BOOST_CHECK_EQUAL(names[4], "Fifth");
-  
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(autoDetectColumnNames_descriptionsMissing) {
-  
+
   // Given
-  std::stringstream stream {
-    "# This is not a comment with the names\n"
-    "# Column: First\n"
-    "# Column: Second double\n"
-    "# Column: Third (unit)\n"
-    "# Column: Fifth - Description\n"
-    "# Some more comments here\n"
-    "\n"
-    "# First Second Third Fourth Fifth\n"
-    "1 2 3 4 5"};
-  
+  std::stringstream stream{"# This is not a comment with the names\n"
+                           "# Column: First\n"
+                           "# Column: Second double\n"
+                           "# Column: Third (unit)\n"
+                           "# Column: Fifth - Description\n"
+                           "# Some more comments here\n"
+                           "\n"
+                           "# First Second Third Fourth Fifth\n"
+                           "1 2 3 4 5"};
+
   // When
   auto names = Euclid::Table::autoDetectColumnNames(stream, "#", 5);
-  
+
   // Then
   BOOST_CHECK_EQUAL(names.size(), 5u);
   BOOST_CHECK_EQUAL(names[0], "First");
@@ -386,24 +352,22 @@ BOOST_AUTO_TEST_CASE(autoDetectColumnNames_descriptionsMissing) {
   BOOST_CHECK_EQUAL(names[2], "Third");
   BOOST_CHECK_EQUAL(names[3], "Fourth");
   BOOST_CHECK_EQUAL(names[4], "Fifth");
-  
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(autoDetectColumnNames_lessDescriptions) {
-  
+
   // Given
-  std::stringstream stream {
-    "# This is not a comment with the names\n"
-    "# Column: First\n"
-    "# Column: Second double\n"
-    "\n"
-    "1 2 3 4 5"};
-  
+  std::stringstream stream{"# This is not a comment with the names\n"
+                           "# Column: First\n"
+                           "# Column: Second double\n"
+                           "\n"
+                           "1 2 3 4 5"};
+
   // When
   auto names = Euclid::Table::autoDetectColumnNames(stream, "#", 5);
-  
+
   // Then
   BOOST_CHECK_EQUAL(names.size(), 5u);
   BOOST_CHECK_EQUAL(names[0], "First");
@@ -411,7 +375,6 @@ BOOST_AUTO_TEST_CASE(autoDetectColumnNames_lessDescriptions) {
   BOOST_CHECK_EQUAL(names[2], "col3");
   BOOST_CHECK_EQUAL(names[3], "col4");
   BOOST_CHECK_EQUAL(names[4], "col5");
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -419,15 +382,14 @@ BOOST_AUTO_TEST_CASE(autoDetectColumnNames_lessDescriptions) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnNamesDuplicate, AsciiReaderHelper_Fixture) {
-  
+
   // Given
-  std::stringstream stream {duplicate_names};
-  
+  std::stringstream stream{duplicate_names};
+
   // Then
   BOOST_CHECK_THROW(Euclid::Table::autoDetectColumnNames(stream, "#", 5), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Table/tests/src/AsciiReader_test.cpp
+++ b/Table/tests/src/AsciiReader_test.cpp
@@ -32,92 +32,68 @@ using namespace Euclid::Table;
 using namespace Euclid::NdArray;
 
 struct AsciiReader_Fixture {
-  std::string only_hash_comments {
-    "# This string contains no data\n"
-    "# only hash comments\n"
-  };
-  std::string only_double_slash_comments {
-    "// This string contains no data\n"
-    "// only double slash comments\n"
-  };
-  std::string different_number_of_columns {
-    "1 2 3 4 5\n"
-    "1 2 3 4 5 6\n"
-  };
-  std::string duplicate_column_names {
-    "# First Second Third Second Fifth\n"
-    "  1     2      3     4      5"
-  };
-  std::string multiple_comments {
-    "# This is a comment line before the column names\n"
-    "\n"
-    "# First Second Third Fourth Fifth\n"
-    "\n"
-    "  1     2      3     4      5"
-  };
+  std::string only_hash_comments{"# This string contains no data\n"
+                                 "# only hash comments\n"};
+  std::string only_double_slash_comments{"// This string contains no data\n"
+                                         "// only double slash comments\n"};
+  std::string different_number_of_columns{"1 2 3 4 5\n"
+                                          "1 2 3 4 5 6\n"};
+  std::string duplicate_column_names{"# First Second Third Second Fifth\n"
+                                     "  1     2      3     4      5"};
+  std::string multiple_comments{"# This is a comment line before the column names\n"
+                                "\n"
+                                "# First Second Third Fourth Fifth\n"
+                                "\n"
+                                "  1     2      3     4      5"};
 
-  std::string all_types {
-    "# Column: Bool1 bool\n"
-    "# Column: Bool2 boolean\n"
-    "# Column: Int1 int\n"
-    "# Column: Int2 int32\n"
-    "# Column: Long1 long\n"
-    "# Column: Long2 int64\n"
-    "# Column: Float float\n"
-    "# Column: Double double\n"
-    "# Column: String string\n"
-    "# Column: DoubleVector [double]\n"
-    "# Column: NdArray [double+]\n"
-    "\n"
-    "# Bool1 Bool2   Int1 Int2  Long1 Long2 Float Double String DoubleVector NdArray\n"
-    "\n"
-    "  true  t       1    2     3     4     5.    6.     7      1.1,1.2      <2,3>1,2,3,4,5,6\n"
-    "  yes   y       8    9     10    11    1.2   1.3    14     2.1,2.2,2.3  <2,3>6,5,4,3,2,1\n"
-    "  1     false   15   16    17    18    1.9   2.0    21     3.1,3.2      <2,3>1,3,5,7,9,0\n"
-    "  f     no      22   23    24    25    2.6   2.7    28     4.1,4.2,4.3  <2,3>0,2,4,6,8,0\n"
-    "  n     0       29   30    31    32    3.3   3.4    35     5.1          <2,3>3,3,3,3,3,3\n"
-  };
+  std::string all_types{"# Column: Bool1 bool\n"
+                        "# Column: Bool2 boolean\n"
+                        "# Column: Int1 int\n"
+                        "# Column: Int2 int32\n"
+                        "# Column: Long1 long\n"
+                        "# Column: Long2 int64\n"
+                        "# Column: Float float\n"
+                        "# Column: Double double\n"
+                        "# Column: String string\n"
+                        "# Column: DoubleVector [double]\n"
+                        "# Column: NdArray [double+]\n"
+                        "\n"
+                        "# Bool1 Bool2   Int1 Int2  Long1 Long2 Float Double String DoubleVector NdArray\n"
+                        "\n"
+                        "  true  t       1    2     3     4     5.    6.     7      1.1,1.2      <2,3>1,2,3,4,5,6\n"
+                        "  yes   y       8    9     10    11    1.2   1.3    14     2.1,2.2,2.3  <2,3>6,5,4,3,2,1\n"
+                        "  1     false   15   16    17    18    1.9   2.0    21     3.1,3.2      <2,3>1,3,5,7,9,0\n"
+                        "  f     no      22   23    24    25    2.6   2.7    28     4.1,4.2,4.3  <2,3>0,2,4,6,8,0\n"
+                        "  n     0       29   30    31    32    3.3   3.4    35     5.1          <2,3>3,3,3,3,3,3\n"};
 
   std::vector<size_t> nd_expected_shape{2, 3};
 
-  std::string wrong_bool {
-    "# Column: Bool bool\n"
-    "  7"
-  };
+  std::string wrong_bool{"# Column: Bool bool\n"
+                         "  7"};
 
-  std::string wrong_int32 {
-    "# Column: Int int\n"
-    "  7.2"
-  };
+  std::string wrong_int32{"# Column: Int int\n"
+                          "  7.2"};
 
-  std::string wrong_int64 {
-    "# Column: Int long\n"
-    "  7.2"
-  };
+  std::string wrong_int64{"# Column: Int long\n"
+                          "  7.2"};
 
-  std::string wrong_float {
-    "# Column: Float float\n"
-    "  true"
-  };
+  std::string wrong_float{"# Column: Float float\n"
+                          "  true"};
 
-  std::string wrong_double {
-    "# Column: Double double\n"
-    "  Something"
-  };
+  std::string wrong_double{"# Column: Double double\n"
+                           "  Something"};
 
-  std::string with_quotes {
-    "# Column: Flag bool\n"
-    "# Column: \"With Spaces\"\n"
-    "\n"
-    "# Flag \"With Spaces\"\n"
-    "     0       regular\n"
-    "     1  \"spaces here too\"\n"
-  };
+  std::string with_quotes{"# Column: Flag bool\n"
+                          "# Column: \"With Spaces\"\n"
+                          "\n"
+                          "# Flag \"With Spaces\"\n"
+                          "     0       regular\n"
+                          "     1  \"spaces here too\"\n"};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (AsciiReader_test)
+BOOST_AUTO_TEST_SUITE(AsciiReader_test)
 
 //-----------------------------------------------------------------------------
 // Test that setting empty comment indicator throws exception
@@ -126,15 +102,14 @@ BOOST_AUTO_TEST_SUITE (AsciiReader_test)
 BOOST_FIXTURE_TEST_CASE(EmptyCommentIndicator, AsciiReader_Fixture) {
 
   // Given
-  std::string comment = "";
-  std::stringstream in {all_types};
+  std::string       comment = "";
+  std::stringstream in{all_types};
 
   // When
-  AsciiReader reader {in};
+  AsciiReader reader{in};
 
   // Then
   BOOST_CHECK_THROW(reader.setCommentIndicator(comment), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -144,15 +119,14 @@ BOOST_FIXTURE_TEST_CASE(EmptyCommentIndicator, AsciiReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(DuplicateColumnNames, AsciiReader_Fixture) {
 
   // Given
-  std::vector<std::string> names {"First", "Second", "Third", "Second"};
-  std::stringstream in {all_types};
+  std::vector<std::string> names{"First", "Second", "Third", "Second"};
+  std::stringstream        in{all_types};
 
   // When
-  AsciiReader reader {in};
+  AsciiReader reader{in};
 
   // Then
   BOOST_CHECK_THROW(reader.fixColumnNames(names), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -162,15 +136,14 @@ BOOST_FIXTURE_TEST_CASE(DuplicateColumnNames, AsciiReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(EmptyColumnNames, AsciiReader_Fixture) {
 
   // Given
-  std::vector<std::string> names {"First", "Second", "", "Forth"};
-  std::stringstream in {all_types};
+  std::vector<std::string> names{"First", "Second", "", "Forth"};
+  std::stringstream        in{all_types};
 
   // When
-  AsciiReader reader {in};
+  AsciiReader reader{in};
 
   // Then
   BOOST_CHECK_THROW(reader.fixColumnNames(names), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -180,12 +153,12 @@ BOOST_FIXTURE_TEST_CASE(EmptyColumnNames, AsciiReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ColumnNamesWithWhitespaces, AsciiReader_Fixture) {
 
   // Given
-  std::vector<std::string> space {"Sp ace"};
-  std::vector<std::string> tab {"T\tab"};
-  std::vector<std::string> carriage_return {"Carriage\rReturn"};
-  std::vector<std::string> new_line {"New\nLine"};
-  std::vector<std::string> new_page {"New\fPage"};
-  std::stringstream in {all_types};
+  std::vector<std::string> space{"Sp ace"};
+  std::vector<std::string> tab{"T\tab"};
+  std::vector<std::string> carriage_return{"Carriage\rReturn"};
+  std::vector<std::string> new_line{"New\nLine"};
+  std::vector<std::string> new_page{"New\fPage"};
+  std::stringstream        in{all_types};
 
   // Then
   AsciiReader{in}.fixColumnNames(space);
@@ -193,7 +166,6 @@ BOOST_FIXTURE_TEST_CASE(ColumnNamesWithWhitespaces, AsciiReader_Fixture) {
   BOOST_CHECK_THROW(AsciiReader{in}.fixColumnNames(carriage_return), Elements::Exception);
   BOOST_CHECK_THROW(AsciiReader{in}.fixColumnNames(new_line), Elements::Exception);
   BOOST_CHECK_THROW(AsciiReader{in}.fixColumnNames(new_page), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -203,14 +175,13 @@ BOOST_FIXTURE_TEST_CASE(ColumnNamesWithWhitespaces, AsciiReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ColumnNameTypeDifferentSize, AsciiReader_Fixture) {
 
   // Given
-  std::vector<std::string> names {"First", "Second"};
-  std::vector<std::type_index> types {typeid(int)};
-  std::stringstream in {all_types};
+  std::vector<std::string>     names{"First", "Second"};
+  std::vector<std::type_index> types{typeid(int)};
+  std::stringstream            in{all_types};
 
   // Then
   BOOST_CHECK_THROW(AsciiReader{in}.fixColumnNames(names).fixColumnTypes(types), Elements::Exception);
   BOOST_CHECK_THROW(AsciiReader{in}.fixColumnTypes(types).fixColumnNames(names), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -220,12 +191,12 @@ BOOST_FIXTURE_TEST_CASE(ColumnNameTypeDifferentSize, AsciiReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ReadSuccess, AsciiReader_Fixture) {
 
   // Given
-  std::stringstream in {all_types};
+  std::stringstream in{all_types};
 
   // When
-  AsciiReader reader {in};
-  Euclid::Table::Table table = reader.read();
-  auto column_info = table.getColumnInfo();
+  AsciiReader          reader{in};
+  Euclid::Table::Table table       = reader.read();
+  auto                 column_info = table.getColumnInfo();
 
   // Then
   BOOST_CHECK_EQUAL(column_info->getDescription(0).name, "Bool1");
@@ -275,10 +246,9 @@ BOOST_FIXTURE_TEST_CASE(ReadSuccess, AsciiReader_Fixture) {
   BOOST_CHECK_EQUAL(boost::get<std::vector<double>>(table[3][9])[0], 4.1);
   BOOST_CHECK_EQUAL(boost::get<std::vector<double>>(table[3][9])[1], 4.2);
   BOOST_CHECK_EQUAL(boost::get<std::vector<double>>(table[3][9])[2], 4.3);
-  auto ndarray = boost::get<NdArray<double>>(table[3][10]);
+  auto ndarray       = boost::get<NdArray<double>>(table[3][10]);
   auto ndarray_shape = ndarray.shape();
   BOOST_CHECK_EQUAL_COLLECTIONS(ndarray_shape.begin(), ndarray_shape.end(), nd_expected_shape.begin(), nd_expected_shape.end());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -288,14 +258,14 @@ BOOST_FIXTURE_TEST_CASE(ReadSuccess, AsciiReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ReadOverrideTypes, AsciiReader_Fixture) {
 
   // Given
-  std::vector<std::type_index> types {typeid(bool), typeid(std::string), typeid(int32_t), typeid(int32_t), typeid(int32_t)};
-  std::stringstream in {multiple_comments};
+  std::vector<std::type_index> types{typeid(bool), typeid(std::string), typeid(int32_t), typeid(int32_t), typeid(int32_t)};
+  std::stringstream            in{multiple_comments};
 
   // When
-  AsciiReader reader {in};
+  AsciiReader reader{in};
   reader.fixColumnTypes(types);
-  Table table = reader.read();
-  auto column_info = table.getColumnInfo();
+  Table table       = reader.read();
+  auto  column_info = table.getColumnInfo();
 
   // Then
   BOOST_CHECK(column_info->getDescription(0).type == typeid(bool));
@@ -303,7 +273,6 @@ BOOST_FIXTURE_TEST_CASE(ReadOverrideTypes, AsciiReader_Fixture) {
   BOOST_CHECK(column_info->getDescription(2).type == typeid(int32_t));
   BOOST_CHECK(column_info->getDescription(3).type == typeid(int32_t));
   BOOST_CHECK(column_info->getDescription(4).type == typeid(int32_t));
-
 }
 
 //-----------------------------------------------------------------------------
@@ -313,14 +282,14 @@ BOOST_FIXTURE_TEST_CASE(ReadOverrideTypes, AsciiReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ReadOverrideNames, AsciiReader_Fixture) {
 
   // Given
-  std::vector<std::string> names {"A","B","C","D","E"};
-  std::stringstream in {multiple_comments};
+  std::vector<std::string> names{"A", "B", "C", "D", "E"};
+  std::stringstream        in{multiple_comments};
 
   // When
-  AsciiReader reader {in};
+  AsciiReader reader{in};
   reader.fixColumnNames(names);
-  Table table = reader.read();
-  auto column_info = table.getColumnInfo();
+  Table table       = reader.read();
+  auto  column_info = table.getColumnInfo();
 
   // Then
   BOOST_CHECK_EQUAL(column_info->getDescription(0).name, "A");
@@ -328,7 +297,6 @@ BOOST_FIXTURE_TEST_CASE(ReadOverrideNames, AsciiReader_Fixture) {
   BOOST_CHECK_EQUAL(column_info->getDescription(2).name, "C");
   BOOST_CHECK_EQUAL(column_info->getDescription(3).name, "D");
   BOOST_CHECK_EQUAL(column_info->getDescription(4).name, "E");
-
 }
 
 //-----------------------------------------------------------------------------
@@ -338,19 +306,18 @@ BOOST_FIXTURE_TEST_CASE(ReadOverrideNames, AsciiReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ReadNoData, AsciiReader_Fixture) {
 
   // Given
-  std::stringstream in1 {only_hash_comments};
-  std::stringstream in2 {only_double_slash_comments};
+  std::stringstream in1{only_hash_comments};
+  std::stringstream in2{only_double_slash_comments};
 
   // When
-  AsciiReader hashReader {in1};
+  AsciiReader hashReader{in1};
   hashReader.setCommentIndicator("#");
-  AsciiReader doubleSlashReader {in2};
+  AsciiReader doubleSlashReader{in2};
   doubleSlashReader.setCommentIndicator("//");
 
   // Then
   BOOST_CHECK_THROW(hashReader.read(), Elements::Exception);
   BOOST_CHECK_THROW(doubleSlashReader.read(), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -360,21 +327,20 @@ BOOST_FIXTURE_TEST_CASE(ReadNoData, AsciiReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ReadWrongColumnNamesNumber, AsciiReader_Fixture) {
 
   // Given
-  std::vector<std::string> wrong_names_less {"1","2","3"};
-  std::vector<std::string> wrong_names_more {"1","2","3","4","5","6","7","8","9","10","11","12"};
-  std::stringstream inless {all_types};
-  std::stringstream inmore {all_types};
+  std::vector<std::string> wrong_names_less{"1", "2", "3"};
+  std::vector<std::string> wrong_names_more{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"};
+  std::stringstream        inless{all_types};
+  std::stringstream        inmore{all_types};
 
   // When
-  AsciiReader lessReader {inless};
+  AsciiReader lessReader{inless};
   lessReader.fixColumnNames(wrong_names_less);
-  AsciiReader moreReader {inmore};
+  AsciiReader moreReader{inmore};
   moreReader.fixColumnNames(wrong_names_more);
 
   // Then
   BOOST_CHECK_THROW(lessReader.read(), Elements::Exception);
   BOOST_CHECK_THROW(moreReader.read(), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -384,23 +350,21 @@ BOOST_FIXTURE_TEST_CASE(ReadWrongColumnNamesNumber, AsciiReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ReadWrongColumnTypesNumber, AsciiReader_Fixture) {
 
   // Given
-  std::vector<std::type_index> wrong_types_less {typeid(bool),typeid(bool),typeid(bool)};
-  std::vector<std::type_index> wrong_types_more {typeid(bool),typeid(bool),typeid(bool),typeid(bool),
-                                                 typeid(bool),typeid(bool),typeid(bool),typeid(bool),
-                                                 typeid(bool),typeid(bool),typeid(bool),typeid(bool)};
-  std::stringstream inless {all_types};
-  std::stringstream inmore {all_types};
+  std::vector<std::type_index> wrong_types_less{typeid(bool), typeid(bool), typeid(bool)};
+  std::vector<std::type_index> wrong_types_more{typeid(bool), typeid(bool), typeid(bool), typeid(bool), typeid(bool), typeid(bool),
+                                                typeid(bool), typeid(bool), typeid(bool), typeid(bool), typeid(bool), typeid(bool)};
+  std::stringstream            inless{all_types};
+  std::stringstream            inmore{all_types};
 
   // When
-  AsciiReader lessReader {inless};
+  AsciiReader lessReader{inless};
   lessReader.fixColumnTypes(wrong_types_less);
-  AsciiReader moreReader {inmore};
+  AsciiReader moreReader{inmore};
   moreReader.fixColumnTypes(wrong_types_more);
 
   // Then
   BOOST_CHECK_THROW(lessReader.read(), Elements::Exception);
   BOOST_CHECK_THROW(moreReader.read(), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -410,14 +374,13 @@ BOOST_FIXTURE_TEST_CASE(ReadWrongColumnTypesNumber, AsciiReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ReadDifferentNumberOfColumns, AsciiReader_Fixture) {
 
   // Given
-  std::stringstream in {different_number_of_columns};
+  std::stringstream in{different_number_of_columns};
 
-  //When
-  AsciiReader reader {in};
+  // When
+  AsciiReader reader{in};
 
   // Then
   BOOST_CHECK_THROW(reader.read(), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -427,14 +390,13 @@ BOOST_FIXTURE_TEST_CASE(ReadDifferentNumberOfColumns, AsciiReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ReadDuplicateColumnNames, AsciiReader_Fixture) {
 
   // Given
-  std::stringstream in {duplicate_column_names};
+  std::stringstream in{duplicate_column_names};
 
-  //When
-  AsciiReader reader {in};
+  // When
+  AsciiReader reader{in};
 
   // Then
   BOOST_CHECK_THROW(reader.read(), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -444,11 +406,11 @@ BOOST_FIXTURE_TEST_CASE(ReadDuplicateColumnNames, AsciiReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ReadWrongCellValues, AsciiReader_Fixture) {
 
   // Given
-  std::stringstream bool_in {wrong_bool};
-  std::stringstream int32_in {wrong_int32};
-  std::stringstream int64_in {wrong_int64};
-  std::stringstream float_in {wrong_float};
-  std::stringstream double_in {wrong_double};
+  std::stringstream bool_in{wrong_bool};
+  std::stringstream int32_in{wrong_int32};
+  std::stringstream int64_in{wrong_int64};
+  std::stringstream float_in{wrong_float};
+  std::stringstream double_in{wrong_double};
 
   // Then
   BOOST_CHECK_THROW(AsciiReader{bool_in}.read(), Elements::Exception);
@@ -456,7 +418,6 @@ BOOST_FIXTURE_TEST_CASE(ReadWrongCellValues, AsciiReader_Fixture) {
   BOOST_CHECK_THROW(AsciiReader{int64_in}.read(), Elements::Exception);
   BOOST_CHECK_THROW(AsciiReader{float_in}.read(), Elements::Exception);
   BOOST_CHECK_THROW(AsciiReader{double_in}.read(), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -480,15 +441,15 @@ BOOST_FIXTURE_TEST_CASE(ReadComment, AsciiReader_Fixture) {
 
 BOOST_FIXTURE_TEST_CASE(WithQuotes, AsciiReader_Fixture) {
   // Given
-  std::vector<std::type_index> types {typeid(bool), typeid(std::string)};
-  std::stringstream input{with_quotes};
+  std::vector<std::type_index> types{typeid(bool), typeid(std::string)};
+  std::stringstream            input{with_quotes};
 
   // When
   auto reader = AsciiReader{input};
   reader.setCommentIndicator("#");
 
-  Table table = reader.read();
-  auto column_info = table.getColumnInfo();
+  Table table       = reader.read();
+  auto  column_info = table.getColumnInfo();
 
   // Then
   BOOST_CHECK(column_info->getDescription(0).type == typeid(bool));
@@ -504,4 +465,4 @@ BOOST_FIXTURE_TEST_CASE(WithQuotes, AsciiReader_Fixture) {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Table/tests/src/AsciiWriterHelper_test.cpp
+++ b/Table/tests/src/AsciiWriterHelper_test.cpp
@@ -1,77 +1,78 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file tests/src/AsciiWriterHelper_test.cpp
  * @date April 11, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
 #include "ElementsKernel/Exception.h"
 #include "Table/ColumnInfo.h"
 #include "Table/Row.h"
 #include "Table/Table.h"
 #include "src/lib/AsciiWriterHelper.h"
+#include <boost/test/unit_test.hpp>
 
 struct AsciiWriterHelper_Fixture {
-  std::vector<Euclid::Table::ColumnInfo::info_type> info_list {
+  std::vector<Euclid::Table::ColumnInfo::info_type> info_list{
       Euclid::Table::ColumnInfo::info_type("Boolean", typeid(bool)),
       Euclid::Table::ColumnInfo::info_type("ThisIsAVeryLongColumnName", typeid(std::string)),
       Euclid::Table::ColumnInfo::info_type("Integer", typeid(int32_t)),
       Euclid::Table::ColumnInfo::info_type("D", typeid(double)),
       Euclid::Table::ColumnInfo::info_type("F", typeid(float)),
-      Euclid::Table::ColumnInfo::info_type("DoubleVector", typeid(std::vector<double>))
-  };
-  std::shared_ptr<Euclid::Table::ColumnInfo> column_info {new Euclid::Table::ColumnInfo {info_list}};
-  std::vector<Euclid::Table::Row::cell_type> values0 {true, std::string{"Two-1"}, 1, 4.1, 0.f, std::vector<double>{1.1, 1.2}};
-  Euclid::Table::Row row0 {values0, column_info};
-  std::vector<Euclid::Table::Row::cell_type> values1 {false, std::string{"Two-2"}, 1234567890, 42e-16, 0.f, std::vector<double>{2.1, 2.2}};
-  Euclid::Table::Row row1 {values1, column_info};
-  std::vector<Euclid::Table::Row::cell_type> values2 {true, std::string{"Two-3"}, 234, 4.3, 0.f, std::vector<double>{3.1, 3.2, 3.3, 3.4}};
-  Euclid::Table::Row row2 {values2, column_info};
-  std::vector<Euclid::Table::Row> row_list {row0, row1, row2};
-  Euclid::Table::Table table {row_list};
+      Euclid::Table::ColumnInfo::info_type("DoubleVector", typeid(std::vector<double>))};
+  std::shared_ptr<Euclid::Table::ColumnInfo> column_info{new Euclid::Table::ColumnInfo{info_list}};
+  std::vector<Euclid::Table::Row::cell_type> values0{true, std::string{"Two-1"}, 1, 4.1, 0.f, std::vector<double>{1.1, 1.2}};
+  Euclid::Table::Row                         row0{values0, column_info};
+  std::vector<Euclid::Table::Row::cell_type> values1{false, std::string{"Two-2"},         1234567890, 42e-16,
+                                                     0.f,   std::vector<double>{2.1, 2.2}};
+  Euclid::Table::Row                         row1{values1, column_info};
+  std::vector<Euclid::Table::Row::cell_type> values2{
+      true, std::string{"Two-3"}, 234, 4.3, 0.f, std::vector<double>{3.1, 3.2, 3.3, 3.4}};
+  Euclid::Table::Row              row2{values2, column_info};
+  std::vector<Euclid::Table::Row> row_list{row0, row1, row2};
+  Euclid::Table::Table            table{row_list};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (AsciiWriterHelper_test)
+BOOST_AUTO_TEST_SUITE(AsciiWriterHelper_test)
 
 //-----------------------------------------------------------------------------
 // Test the typeToKeyword
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(typeToKeyword, AsciiWriterHelper_Fixture) {
-  
+
   // When
-  std::string bool_key = Euclid::Table::typeToKeyword(typeid(bool));
-  std::string int32_key = Euclid::Table::typeToKeyword(typeid(int32_t));
-  std::string int64_key = Euclid::Table::typeToKeyword(typeid(int64_t));
-  std::string float_key = Euclid::Table::typeToKeyword(typeid(float));
-  std::string double_key = Euclid::Table::typeToKeyword(typeid(double));
-  std::string string_key = Euclid::Table::typeToKeyword(typeid(std::string));
-  std::string vector_bool_key = Euclid::Table::typeToKeyword(typeid(std::vector<bool>));
-  std::string vector_int32_key = Euclid::Table::typeToKeyword(typeid(std::vector<int32_t>));
-  std::string vector_int64_key = Euclid::Table::typeToKeyword(typeid(std::vector<int64_t>));
-  std::string vector_float_key = Euclid::Table::typeToKeyword(typeid(std::vector<float>));
+  std::string bool_key          = Euclid::Table::typeToKeyword(typeid(bool));
+  std::string int32_key         = Euclid::Table::typeToKeyword(typeid(int32_t));
+  std::string int64_key         = Euclid::Table::typeToKeyword(typeid(int64_t));
+  std::string float_key         = Euclid::Table::typeToKeyword(typeid(float));
+  std::string double_key        = Euclid::Table::typeToKeyword(typeid(double));
+  std::string string_key        = Euclid::Table::typeToKeyword(typeid(std::string));
+  std::string vector_bool_key   = Euclid::Table::typeToKeyword(typeid(std::vector<bool>));
+  std::string vector_int32_key  = Euclid::Table::typeToKeyword(typeid(std::vector<int32_t>));
+  std::string vector_int64_key  = Euclid::Table::typeToKeyword(typeid(std::vector<int64_t>));
+  std::string vector_float_key  = Euclid::Table::typeToKeyword(typeid(std::vector<float>));
   std::string vector_double_key = Euclid::Table::typeToKeyword(typeid(std::vector<double>));
-  
+
   // Then
   BOOST_CHECK_EQUAL(bool_key, "bool");
   BOOST_CHECK_EQUAL(int32_key, "int");
@@ -84,7 +85,6 @@ BOOST_FIXTURE_TEST_CASE(typeToKeyword, AsciiWriterHelper_Fixture) {
   BOOST_CHECK_EQUAL(vector_int64_key, "[long]");
   BOOST_CHECK_EQUAL(vector_float_key, "[float]");
   BOOST_CHECK_EQUAL(vector_double_key, "[double]");
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -92,10 +92,10 @@ BOOST_FIXTURE_TEST_CASE(typeToKeyword, AsciiWriterHelper_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(calculateColumnLengths, AsciiWriterHelper_Fixture) {
-  
+
   // When
   auto sizes = Euclid::Table::calculateColumnLengths(table);
-  
+
   // Then
   BOOST_CHECK_EQUAL(sizes[0], 8);
   BOOST_CHECK_EQUAL(sizes[1], 26);
@@ -103,9 +103,8 @@ BOOST_FIXTURE_TEST_CASE(calculateColumnLengths, AsciiWriterHelper_Fixture) {
   BOOST_CHECK_EQUAL(sizes[3], 8);
   BOOST_CHECK_EQUAL(sizes[4], 2);
   BOOST_CHECK_EQUAL(sizes[5], 16);
-  
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Table/tests/src/AsciiWriter_test.cpp
+++ b/Table/tests/src/AsciiWriter_test.cpp
@@ -27,38 +27,34 @@
 #include "ElementsKernel/Exception.h"
 #include "Table/AsciiWriter.h"
 
-
 using namespace Euclid::Table;
 using namespace Euclid::NdArray;
 
 struct AsciiWriter_Fixture {
-  std::vector<ColumnInfo::info_type> info_list {
-      ColumnInfo::info_type("Boolean", typeid(bool), "unit1", "Desc1"),
-      ColumnInfo::info_type("A Long Column Name", typeid(std::string)),
-      ColumnInfo::info_type("Integer", typeid(int32_t), "unit3"),
-      ColumnInfo::info_type("D", typeid(double), "", "Desc4"),
-      ColumnInfo::info_type("F", typeid(float)),
-      ColumnInfo::info_type("DoubleVector", typeid(std::vector<double>)),
-      ColumnInfo::info_type("NdArray", typeid(NdArray<double>))
-  };
-  std::shared_ptr<ColumnInfo> column_info {new ColumnInfo {info_list}};
-  std::vector<Row::cell_type> values0 {
-    true, std::string{"Two 1"}, 1, 4.1, 0.f, std::vector<double>{1.1, 1.2}, NdArray<double>{{2,2}, {1,2,3,4}}};
-  Row row0 {values0, column_info};
-  std::vector<Row::cell_type> values1 {
-    false, std::string{"Two 2"}, 1234567890, 42e-16, 0.f, std::vector<double>{2.1, 2.2}, NdArray<double>{{2,2}, {9,8,7,6}}};
-  Row row1 {values1, column_info};
-  std::vector<Row::cell_type> values2 {
-    true, std::string{"Two 3"}, 234, 4.3, 0.f, std::vector<double>{3.1, 3.2, 3.3, 3.4}, NdArray<double>{{2,2}, {1,3,5,7}}};
-  Row row2 {values2, column_info};
-  std::vector<Row> row_list {row0, row1, row2};
-  Table table {row_list};
+  std::vector<ColumnInfo::info_type> info_list{ColumnInfo::info_type("Boolean", typeid(bool), "unit1", "Desc1"),
+                                               ColumnInfo::info_type("A Long Column Name", typeid(std::string)),
+                                               ColumnInfo::info_type("Integer", typeid(int32_t), "unit3"),
+                                               ColumnInfo::info_type("D", typeid(double), "", "Desc4"),
+                                               ColumnInfo::info_type("F", typeid(float)),
+                                               ColumnInfo::info_type("DoubleVector", typeid(std::vector<double>)),
+                                               ColumnInfo::info_type("NdArray", typeid(NdArray<double>))};
+  std::shared_ptr<ColumnInfo>        column_info{new ColumnInfo{info_list}};
+  std::vector<Row::cell_type>        values0{
+      true, std::string{"Two 1"}, 1, 4.1, 0.f, std::vector<double>{1.1, 1.2}, NdArray<double>{{2, 2}, {1, 2, 3, 4}}};
+  Row                         row0{values0, column_info};
+  std::vector<Row::cell_type> values1{
+      false, std::string{"Two 2"}, 1234567890, 42e-16, 0.f, std::vector<double>{2.1, 2.2}, NdArray<double>{{2, 2}, {9, 8, 7, 6}}};
+  Row                         row1{values1, column_info};
+  std::vector<Row::cell_type> values2{
+      true, std::string{"Two 3"}, 234, 4.3, 0.f, std::vector<double>{3.1, 3.2, 3.3, 3.4}, NdArray<double>{{2, 2}, {1, 3, 5, 7}}};
+  Row              row2{values2, column_info};
+  std::vector<Row> row_list{row0, row1, row2};
+  Table            table{row_list};
 };
-
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (AsciiWriter_test)
+BOOST_AUTO_TEST_SUITE(AsciiWriter_test)
 
 //-----------------------------------------------------------------------------
 // Test that setting the empty string as comment indicator throws exception
@@ -67,15 +63,14 @@ BOOST_AUTO_TEST_SUITE (AsciiWriter_test)
 BOOST_AUTO_TEST_CASE(EmptyCommentIndicator) {
 
   // Given
-  std::stringstream stream {};
-  std::string comment = "";
+  std::stringstream stream{};
+  std::string       comment = "";
 
   // When
-  AsciiWriter writer {stream};
+  AsciiWriter writer{stream};
 
   // Then
   BOOST_CHECK_THROW(writer.setCommentIndicator(comment), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -85,10 +80,10 @@ BOOST_AUTO_TEST_CASE(EmptyCommentIndicator) {
 BOOST_FIXTURE_TEST_CASE(addData, AsciiWriter_Fixture) {
 
   // Given
-  std::stringstream stream_hash {};
-  std::stringstream stream_double_slash {};
-  AsciiWriter writer_hash {stream_hash};
-  AsciiWriter writer_double_slash {stream_double_slash};
+  std::stringstream stream_hash{};
+  std::stringstream stream_double_slash{};
+  AsciiWriter       writer_hash{stream_hash};
+  AsciiWriter       writer_double_slash{stream_double_slash};
   writer_double_slash.setCommentIndicator("//");
 
   // When
@@ -96,35 +91,35 @@ BOOST_FIXTURE_TEST_CASE(addData, AsciiWriter_Fixture) {
   writer_double_slash.addData(table);
 
   // Then
-  BOOST_CHECK_EQUAL(stream_hash.str(), std::string(
-"# Column: Boolean bool (unit1) - Desc1\n"
-"# Column: \"A Long Column Name\" string\n"
-"# Column: Integer int (unit3)\n"
-"# Column: D double - Desc4\n"
-"# Column: F float\n"
-"# Column: DoubleVector [double]\n"
-"# Column: NdArray [double+]\n"
-"\n"
-"# Boolean \"A Long Column Name\"    Integer       D F    DoubleVector      NdArray\n"
-"\n"
-"        1              \"Two 1\"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
-"        0              \"Two 2\" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
-"        1              \"Two 3\"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"));
+  BOOST_CHECK_EQUAL(stream_hash.str(),
+                    std::string("# Column: Boolean bool (unit1) - Desc1\n"
+                                "# Column: \"A Long Column Name\" string\n"
+                                "# Column: Integer int (unit3)\n"
+                                "# Column: D double - Desc4\n"
+                                "# Column: F float\n"
+                                "# Column: DoubleVector [double]\n"
+                                "# Column: NdArray [double+]\n"
+                                "\n"
+                                "# Boolean \"A Long Column Name\"    Integer       D F    DoubleVector      NdArray\n"
+                                "\n"
+                                "        1              \"Two 1\"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
+                                "        0              \"Two 2\" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
+                                "        1              \"Two 3\"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"));
 
-  BOOST_CHECK_EQUAL(stream_double_slash.str(), std::string(
-"// Column: Boolean bool (unit1) - Desc1\n"
-"// Column: \"A Long Column Name\" string\n"
-"// Column: Integer int (unit3)\n"
-"// Column: D double - Desc4\n"
-"// Column: F float\n"
-"// Column: DoubleVector [double]\n"
-"// Column: NdArray [double+]\n"
-"\n"
-"// Boolean \"A Long Column Name\"    Integer       D F    DoubleVector      NdArray\n"
-"\n"
-"         1              \"Two 1\"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
-"         0              \"Two 2\" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
-"         1              \"Two 3\"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"));
+  BOOST_CHECK_EQUAL(stream_double_slash.str(),
+                    std::string("// Column: Boolean bool (unit1) - Desc1\n"
+                                "// Column: \"A Long Column Name\" string\n"
+                                "// Column: Integer int (unit3)\n"
+                                "// Column: D double - Desc4\n"
+                                "// Column: F float\n"
+                                "// Column: DoubleVector [double]\n"
+                                "// Column: NdArray [double+]\n"
+                                "\n"
+                                "// Boolean \"A Long Column Name\"    Integer       D F    DoubleVector      NdArray\n"
+                                "\n"
+                                "         1              \"Two 1\"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
+                                "         0              \"Two 2\" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
+                                "         1              \"Two 3\"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"));
 }
 
 //-----------------------------------------------------------------------------
@@ -134,10 +129,10 @@ BOOST_FIXTURE_TEST_CASE(addData, AsciiWriter_Fixture) {
 BOOST_FIXTURE_TEST_CASE(addDataNoColumnInfo, AsciiWriter_Fixture) {
 
   // Given
-  std::stringstream stream_hash {};
-  std::stringstream stream_double_slash {};
-  AsciiWriter writer_hash {stream_hash};
-  AsciiWriter writer_double_slash {stream_double_slash};
+  std::stringstream stream_hash{};
+  std::stringstream stream_double_slash{};
+  AsciiWriter       writer_hash{stream_hash};
+  AsciiWriter       writer_double_slash{stream_double_slash};
   writer_double_slash.setCommentIndicator("//");
 
   // When
@@ -147,18 +142,18 @@ BOOST_FIXTURE_TEST_CASE(addDataNoColumnInfo, AsciiWriter_Fixture) {
   writer_double_slash.addData(table);
 
   // Then
-  BOOST_CHECK_EQUAL(stream_hash.str(), std::string(
-"# Boolean \"A Long Column Name\"    Integer       D F    DoubleVector      NdArray\n"
-"\n"
-"        1              \"Two 1\"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
-"        0              \"Two 2\" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
-"        1              \"Two 3\"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"));
-  BOOST_CHECK_EQUAL(stream_double_slash.str(), std::string(
-"// Boolean \"A Long Column Name\"    Integer       D F    DoubleVector      NdArray\n"
-"\n"
-"         1              \"Two 1\"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
-"         0              \"Two 2\" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
-"         1              \"Two 3\"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"));
+  BOOST_CHECK_EQUAL(stream_hash.str(),
+                    std::string("# Boolean \"A Long Column Name\"    Integer       D F    DoubleVector      NdArray\n"
+                                "\n"
+                                "        1              \"Two 1\"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
+                                "        0              \"Two 2\" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
+                                "        1              \"Two 3\"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"));
+  BOOST_CHECK_EQUAL(stream_double_slash.str(),
+                    std::string("// Boolean \"A Long Column Name\"    Integer       D F    DoubleVector      NdArray\n"
+                                "\n"
+                                "         1              \"Two 1\"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
+                                "         0              \"Two 2\" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
+                                "         1              \"Two 3\"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"));
 }
 
 //-----------------------------------------------------------------------------
@@ -168,15 +163,12 @@ BOOST_FIXTURE_TEST_CASE(addDataNoColumnInfo, AsciiWriter_Fixture) {
 BOOST_FIXTURE_TEST_CASE(addDataComments, AsciiWriter_Fixture) {
 
   // Given
-  std::stringstream stream_hash {};
-  std::stringstream stream_double_slash {};
-  AsciiWriter writer_hash {stream_hash};
-  AsciiWriter writer_double_slash {stream_double_slash};
+  std::stringstream stream_hash{};
+  std::stringstream stream_double_slash{};
+  AsciiWriter       writer_hash{stream_hash};
+  AsciiWriter       writer_double_slash{stream_double_slash};
   writer_double_slash.setCommentIndicator("//");
-  std::vector<std::string> comments {
-    "First comment",
-    "Second comment"
-  };
+  std::vector<std::string> comments{"First comment", "Second comment"};
 
   // When
   for (auto& c : comments) {
@@ -187,42 +179,42 @@ BOOST_FIXTURE_TEST_CASE(addDataComments, AsciiWriter_Fixture) {
   writer_double_slash.addData(table);
 
   // Then
-  BOOST_CHECK_EQUAL(stream_hash.str(), std::string(
-"# First comment\n"
-"# Second comment\n"
-"\n"
-"# Column: Boolean bool (unit1) - Desc1\n"
-"# Column: \"A Long Column Name\" string\n"
-"# Column: Integer int (unit3)\n"
-"# Column: D double - Desc4\n"
-"# Column: F float\n"
-"# Column: DoubleVector [double]\n"
-"# Column: NdArray [double+]\n"
-"\n"
-"# Boolean \"A Long Column Name\"    Integer       D F    DoubleVector      NdArray\n"
-"\n"
-"        1              \"Two 1\"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
-"        0              \"Two 2\" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
-"        1              \"Two 3\"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"));
-  BOOST_CHECK_EQUAL(stream_double_slash.str(), std::string(
-"// First comment\n"
-"// Second comment\n"
-"\n"
-"// Column: Boolean bool (unit1) - Desc1\n"
-"// Column: \"A Long Column Name\" string\n"
-"// Column: Integer int (unit3)\n"
-"// Column: D double - Desc4\n"
-"// Column: F float\n"
-"// Column: DoubleVector [double]\n"
-"// Column: NdArray [double+]\n"
-"\n"
-"// Boolean \"A Long Column Name\"    Integer       D F    DoubleVector      NdArray\n"
-"\n"
-"         1              \"Two 1\"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
-"         0              \"Two 2\" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
-"         1              \"Two 3\"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"));
+  BOOST_CHECK_EQUAL(stream_hash.str(),
+                    std::string("# First comment\n"
+                                "# Second comment\n"
+                                "\n"
+                                "# Column: Boolean bool (unit1) - Desc1\n"
+                                "# Column: \"A Long Column Name\" string\n"
+                                "# Column: Integer int (unit3)\n"
+                                "# Column: D double - Desc4\n"
+                                "# Column: F float\n"
+                                "# Column: DoubleVector [double]\n"
+                                "# Column: NdArray [double+]\n"
+                                "\n"
+                                "# Boolean \"A Long Column Name\"    Integer       D F    DoubleVector      NdArray\n"
+                                "\n"
+                                "        1              \"Two 1\"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
+                                "        0              \"Two 2\" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
+                                "        1              \"Two 3\"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"));
+  BOOST_CHECK_EQUAL(stream_double_slash.str(),
+                    std::string("// First comment\n"
+                                "// Second comment\n"
+                                "\n"
+                                "// Column: Boolean bool (unit1) - Desc1\n"
+                                "// Column: \"A Long Column Name\" string\n"
+                                "// Column: Integer int (unit3)\n"
+                                "// Column: D double - Desc4\n"
+                                "// Column: F float\n"
+                                "// Column: DoubleVector [double]\n"
+                                "// Column: NdArray [double+]\n"
+                                "\n"
+                                "// Boolean \"A Long Column Name\"    Integer       D F    DoubleVector      NdArray\n"
+                                "\n"
+                                "         1              \"Two 1\"          1     4.1 0         1.1,1.2 <2,2>1,2,3,4\n"
+                                "         0              \"Two 2\" 1234567890 4.2e-15 0         2.1,2.2 <2,2>9,8,7,6\n"
+                                "         1              \"Two 3\"        234     4.3 0 3.1,3.2,3.3,3.4 <2,2>1,3,5,7\n"));
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Table/tests/src/CastVisitor_test.cpp
+++ b/Table/tests/src/CastVisitor_test.cpp
@@ -1,20 +1,20 @@
-/*  
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+/*
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
- */  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 /**
  * @file tests/src/CastVisitor_test.cpp
@@ -24,46 +24,46 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include "Table/Row.h"
 #include "Table/CastVisitor.h"
+#include "Table/Row.h"
 
 using namespace Euclid::Table;
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (CastVisitor_test)
+BOOST_AUTO_TEST_SUITE(CastVisitor_test)
 
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(castToString) {
 
   // Given
-  Row::cell_type string_cell = std::string{"text"};
-  Row::cell_type double_cell = 12.345;
-  Row::cell_type float_cell = 12.34F;
-  Row::cell_type long_cell = std::int64_t{12345};
-  Row::cell_type int_cell = std::int32_t{1234};
-  Row::cell_type bool_cell = true;
+  Row::cell_type string_cell        = std::string{"text"};
+  Row::cell_type double_cell        = 12.345;
+  Row::cell_type float_cell         = 12.34F;
+  Row::cell_type long_cell          = std::int64_t{12345};
+  Row::cell_type int_cell           = std::int32_t{1234};
+  Row::cell_type bool_cell          = true;
   Row::cell_type vector_double_cell = std::vector<double>{1.23, 4.56, 7.89};
-  Row::cell_type vector_float_cell = std::vector<float>{1.2, 3.4, 5.6, 7.8};
-  Row::cell_type vector_long_cell = std::vector<std::int64_t>{123, 456, 789};
-  Row::cell_type vector_int_cell = std::vector<std::int32_t>{12, 34, 56, 78};
-  Row::cell_type vector_bool_cell = std::vector<bool>{true, false, true};
-  
+  Row::cell_type vector_float_cell  = std::vector<float>{1.2, 3.4, 5.6, 7.8};
+  Row::cell_type vector_long_cell   = std::vector<std::int64_t>{123, 456, 789};
+  Row::cell_type vector_int_cell    = std::vector<std::int32_t>{12, 34, 56, 78};
+  Row::cell_type vector_bool_cell   = std::vector<bool>{true, false, true};
+
   // When
-  CastVisitor<std::string> cast {};
-  auto string_res = boost::apply_visitor(cast, string_cell);
-  auto double_res = boost::apply_visitor(cast, double_cell);
-  auto float_res = boost::apply_visitor(cast, float_cell);
-  auto long_res = boost::apply_visitor(cast, long_cell);
-  auto int_res = boost::apply_visitor(cast, int_cell);
-  auto bool_res = boost::apply_visitor(cast, bool_cell);
-  auto vector_double_res = boost::apply_visitor(cast, vector_double_cell);
-  auto vector_float_res = boost::apply_visitor(cast, vector_float_cell);
-  auto vector_long_res = boost::apply_visitor(cast, vector_long_cell);
-  auto vector_int_res = boost::apply_visitor(cast, vector_int_cell);
-  auto vector_bool_res = boost::apply_visitor(cast, vector_bool_cell);
-  
+  CastVisitor<std::string> cast{};
+  auto                     string_res        = boost::apply_visitor(cast, string_cell);
+  auto                     double_res        = boost::apply_visitor(cast, double_cell);
+  auto                     float_res         = boost::apply_visitor(cast, float_cell);
+  auto                     long_res          = boost::apply_visitor(cast, long_cell);
+  auto                     int_res           = boost::apply_visitor(cast, int_cell);
+  auto                     bool_res          = boost::apply_visitor(cast, bool_cell);
+  auto                     vector_double_res = boost::apply_visitor(cast, vector_double_cell);
+  auto                     vector_float_res  = boost::apply_visitor(cast, vector_float_cell);
+  auto                     vector_long_res   = boost::apply_visitor(cast, vector_long_cell);
+  auto                     vector_int_res    = boost::apply_visitor(cast, vector_int_cell);
+  auto                     vector_bool_res   = boost::apply_visitor(cast, vector_bool_cell);
+
   // Then
   BOOST_CHECK_EQUAL(typeid(string_res).name(), typeid(std::string).name());
   BOOST_CHECK_EQUAL(string_res, "text");
@@ -87,7 +87,6 @@ BOOST_AUTO_TEST_CASE(castToString) {
   BOOST_CHECK_EQUAL(vector_int_res, "12,34,56,78");
   BOOST_CHECK_EQUAL(typeid(vector_bool_res).name(), typeid(std::string).name());
   BOOST_CHECK_EQUAL(vector_bool_res, "1,0,1");
-
 }
 
 //-----------------------------------------------------------------------------
@@ -95,29 +94,29 @@ BOOST_AUTO_TEST_CASE(castToString) {
 BOOST_AUTO_TEST_CASE(castToDouble) {
 
   // Given
-  Row::cell_type string_cell = std::string{"12.345"};
-  Row::cell_type double_cell = 12.345;
-  Row::cell_type float_cell = 12.34F;
-  Row::cell_type long_cell = std::int64_t{12345};
-  Row::cell_type int_cell = std::int32_t{1234};
-  Row::cell_type bool_cell = true;
-  Row::cell_type vector_double_cell = std::vector<double>{1.23, 4.56, 7.89};
-  Row::cell_type vector_float_cell = std::vector<float>{1.2, 3.4, 5.6, 7.8};
-  Row::cell_type vector_long_cell = std::vector<std::int64_t>{123, 456, 789};
-  Row::cell_type vector_int_cell = std::vector<std::int32_t>{12, 34, 56, 78};
-  Row::cell_type vector_bool_cell = std::vector<bool>{true, false, true};
-  Row::cell_type bad_string_cell = std::string{"str12.345"};
+  Row::cell_type string_cell          = std::string{"12.345"};
+  Row::cell_type double_cell          = 12.345;
+  Row::cell_type float_cell           = 12.34F;
+  Row::cell_type long_cell            = std::int64_t{12345};
+  Row::cell_type int_cell             = std::int32_t{1234};
+  Row::cell_type bool_cell            = true;
+  Row::cell_type vector_double_cell   = std::vector<double>{1.23, 4.56, 7.89};
+  Row::cell_type vector_float_cell    = std::vector<float>{1.2, 3.4, 5.6, 7.8};
+  Row::cell_type vector_long_cell     = std::vector<std::int64_t>{123, 456, 789};
+  Row::cell_type vector_int_cell      = std::vector<std::int32_t>{12, 34, 56, 78};
+  Row::cell_type vector_bool_cell     = std::vector<bool>{true, false, true};
+  Row::cell_type bad_string_cell      = std::string{"str12.345"};
   Row::cell_type overflow_string_cell = std::string{"1.79e+400"};
-  Row::cell_type big_string_cell = std::string{"3.40282e+40"};
-  
+  Row::cell_type big_string_cell      = std::string{"3.40282e+40"};
+
   // When
-  CastVisitor<double> cast {};
-  auto string_res = boost::apply_visitor(cast, string_cell);
-  auto double_res = boost::apply_visitor(cast, double_cell);
-  auto float_res = boost::apply_visitor(cast, float_cell);
-  auto long_res = boost::apply_visitor(cast, long_cell);
-  auto int_res = boost::apply_visitor(cast, int_cell);
-  auto bool_res = boost::apply_visitor(cast, bool_cell);
+  CastVisitor<double> cast{};
+  auto                string_res = boost::apply_visitor(cast, string_cell);
+  auto                double_res = boost::apply_visitor(cast, double_cell);
+  auto                float_res  = boost::apply_visitor(cast, float_cell);
+  auto                long_res   = boost::apply_visitor(cast, long_cell);
+  auto                int_res    = boost::apply_visitor(cast, int_cell);
+  auto                bool_res   = boost::apply_visitor(cast, bool_cell);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_double_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_float_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_long_cell), Elements::Exception);
@@ -142,7 +141,6 @@ BOOST_AUTO_TEST_CASE(castToDouble) {
   BOOST_CHECK_EQUAL(bool_res, 1);
   BOOST_CHECK_EQUAL(typeid(big_string_res).name(), typeid(double).name());
   BOOST_CHECK_EQUAL(big_string_res, 3.40282e+40);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -150,28 +148,28 @@ BOOST_AUTO_TEST_CASE(castToDouble) {
 BOOST_AUTO_TEST_CASE(castToFloat) {
 
   // Given
-  Row::cell_type string_cell = std::string{"12.345"};
-  Row::cell_type double_cell = 12.345;
-  Row::cell_type float_cell = 12.34F;
-  Row::cell_type long_cell = std::int64_t{12345};
-  Row::cell_type int_cell = std::int32_t{1234};
-  Row::cell_type bool_cell = true;
-  Row::cell_type vector_double_cell = std::vector<double>{1.23, 4.56, 7.89};
-  Row::cell_type vector_float_cell = std::vector<float>{1.2, 3.4, 5.6, 7.8};
-  Row::cell_type vector_long_cell = std::vector<std::int64_t>{123, 456, 789};
-  Row::cell_type vector_int_cell = std::vector<std::int32_t>{12, 34, 56, 78};
-  Row::cell_type vector_bool_cell = std::vector<bool>{true, false, true};
-  Row::cell_type bad_string_cell = std::string{"str12.345"};
+  Row::cell_type string_cell          = std::string{"12.345"};
+  Row::cell_type double_cell          = 12.345;
+  Row::cell_type float_cell           = 12.34F;
+  Row::cell_type long_cell            = std::int64_t{12345};
+  Row::cell_type int_cell             = std::int32_t{1234};
+  Row::cell_type bool_cell            = true;
+  Row::cell_type vector_double_cell   = std::vector<double>{1.23, 4.56, 7.89};
+  Row::cell_type vector_float_cell    = std::vector<float>{1.2, 3.4, 5.6, 7.8};
+  Row::cell_type vector_long_cell     = std::vector<std::int64_t>{123, 456, 789};
+  Row::cell_type vector_int_cell      = std::vector<std::int32_t>{12, 34, 56, 78};
+  Row::cell_type vector_bool_cell     = std::vector<bool>{true, false, true};
+  Row::cell_type bad_string_cell      = std::string{"str12.345"};
   Row::cell_type overflow_string_cell = std::string{"3.40282e+40"};
 
   // When
-  CastVisitor<float> cast {};
-  auto string_res = boost::apply_visitor(cast, string_cell);
+  CastVisitor<float> cast{};
+  auto               string_res = boost::apply_visitor(cast, string_cell);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, double_cell), Elements::Exception);
   auto float_res = boost::apply_visitor(cast, float_cell);
-  auto long_res = boost::apply_visitor(cast, long_cell);
-  auto int_res = boost::apply_visitor(cast, int_cell);
-  auto bool_res = boost::apply_visitor(cast, bool_cell);
+  auto long_res  = boost::apply_visitor(cast, long_cell);
+  auto int_res   = boost::apply_visitor(cast, int_cell);
+  auto bool_res  = boost::apply_visitor(cast, bool_cell);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_double_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_float_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_long_cell), Elements::Exception);
@@ -191,7 +189,6 @@ BOOST_AUTO_TEST_CASE(castToFloat) {
   BOOST_CHECK_EQUAL(int_res, 1234);
   BOOST_CHECK_EQUAL(typeid(bool_res).name(), typeid(float).name());
   BOOST_CHECK_EQUAL(bool_res, 1);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -199,28 +196,28 @@ BOOST_AUTO_TEST_CASE(castToFloat) {
 BOOST_AUTO_TEST_CASE(castToInt64) {
 
   // Given
-  Row::cell_type string_cell = std::string{"12345"};
-  Row::cell_type double_cell = 12.345;
-  Row::cell_type float_cell = 12.34F;
-  Row::cell_type long_cell = std::int64_t{12345};
-  Row::cell_type int_cell = std::int32_t{1234};
-  Row::cell_type bool_cell = true;
+  Row::cell_type string_cell        = std::string{"12345"};
+  Row::cell_type double_cell        = 12.345;
+  Row::cell_type float_cell         = 12.34F;
+  Row::cell_type long_cell          = std::int64_t{12345};
+  Row::cell_type int_cell           = std::int32_t{1234};
+  Row::cell_type bool_cell          = true;
   Row::cell_type vector_double_cell = std::vector<double>{1.23, 4.56, 7.89};
-  Row::cell_type vector_float_cell = std::vector<float>{1.2, 3.4, 5.6, 7.8};
-  Row::cell_type vector_long_cell = std::vector<std::int64_t>{123, 456, 789};
-  Row::cell_type vector_int_cell = std::vector<std::int32_t>{12, 34, 56, 78};
-  Row::cell_type vector_bool_cell = std::vector<bool>{true, false, true};
-  Row::cell_type bad_string_cell = std::string{"str12345"};
-  Row::cell_type long_string_cell = std::string{"8589934592"};
-  Row::cell_type long2_string_cell = std::string{"-2147483650"};
+  Row::cell_type vector_float_cell  = std::vector<float>{1.2, 3.4, 5.6, 7.8};
+  Row::cell_type vector_long_cell   = std::vector<std::int64_t>{123, 456, 789};
+  Row::cell_type vector_int_cell    = std::vector<std::int32_t>{12, 34, 56, 78};
+  Row::cell_type vector_bool_cell   = std::vector<bool>{true, false, true};
+  Row::cell_type bad_string_cell    = std::string{"str12345"};
+  Row::cell_type long_string_cell   = std::string{"8589934592"};
+  Row::cell_type long2_string_cell  = std::string{"-2147483650"};
 
   // When
-  CastVisitor<int64_t> cast {};
-  auto string_res = boost::apply_visitor(cast, string_cell);
+  CastVisitor<int64_t> cast{};
+  auto                 string_res = boost::apply_visitor(cast, string_cell);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, double_cell), Elements::Exception);
-  BOOST_CHECK_THROW( boost::apply_visitor(cast, float_cell), Elements::Exception);
+  BOOST_CHECK_THROW(boost::apply_visitor(cast, float_cell), Elements::Exception);
   auto long_res = boost::apply_visitor(cast, long_cell);
-  auto int_res = boost::apply_visitor(cast, int_cell);
+  auto int_res  = boost::apply_visitor(cast, int_cell);
   auto bool_res = boost::apply_visitor(cast, bool_cell);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_double_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_float_cell), Elements::Exception);
@@ -228,7 +225,7 @@ BOOST_AUTO_TEST_CASE(castToInt64) {
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_int_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_bool_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, bad_string_cell), Elements::Exception);
-  auto long_string_res = boost::apply_visitor(cast, long_string_cell);
+  auto long_string_res  = boost::apply_visitor(cast, long_string_cell);
   auto long2_string_res = boost::apply_visitor(cast, long2_string_cell);
 
   // Then
@@ -251,28 +248,28 @@ BOOST_AUTO_TEST_CASE(castToInt64) {
 BOOST_AUTO_TEST_CASE(castToInt32) {
 
   // Given
-  Row::cell_type string_cell = std::string{"12345"};
-  Row::cell_type double_cell = 12.345;
-  Row::cell_type float_cell = 12.34F;
-  Row::cell_type long_cell = std::int64_t{12345};
-  Row::cell_type int_cell = std::int32_t{1234};
-  Row::cell_type bool_cell = true;
-  Row::cell_type vector_double_cell = std::vector<double>{1.23, 4.56, 7.89};
-  Row::cell_type vector_float_cell = std::vector<float>{1.2, 3.4, 5.6, 7.8};
-  Row::cell_type vector_long_cell = std::vector<std::int64_t>{123, 456, 789};
-  Row::cell_type vector_int_cell = std::vector<std::int32_t>{12, 34, 56, 78};
-  Row::cell_type vector_bool_cell = std::vector<bool>{true, false, true};
-  Row::cell_type bad_string_cell = std::string{"str12345"};
-  Row::cell_type overflow_string_cell = std::string{"8589934592"};
+  Row::cell_type string_cell           = std::string{"12345"};
+  Row::cell_type double_cell           = 12.345;
+  Row::cell_type float_cell            = 12.34F;
+  Row::cell_type long_cell             = std::int64_t{12345};
+  Row::cell_type int_cell              = std::int32_t{1234};
+  Row::cell_type bool_cell             = true;
+  Row::cell_type vector_double_cell    = std::vector<double>{1.23, 4.56, 7.89};
+  Row::cell_type vector_float_cell     = std::vector<float>{1.2, 3.4, 5.6, 7.8};
+  Row::cell_type vector_long_cell      = std::vector<std::int64_t>{123, 456, 789};
+  Row::cell_type vector_int_cell       = std::vector<std::int32_t>{12, 34, 56, 78};
+  Row::cell_type vector_bool_cell      = std::vector<bool>{true, false, true};
+  Row::cell_type bad_string_cell       = std::string{"str12345"};
+  Row::cell_type overflow_string_cell  = std::string{"8589934592"};
   Row::cell_type overflow2_string_cell = std::string{"-2147483650"};
-  
+
   // When
-  CastVisitor<int32_t> cast {};
-  auto string_res = boost::apply_visitor(cast, string_cell);
+  CastVisitor<int32_t> cast{};
+  auto                 string_res = boost::apply_visitor(cast, string_cell);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, double_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, float_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, long_cell), Elements::Exception);
-  auto int_res = boost::apply_visitor(cast, int_cell);
+  auto int_res  = boost::apply_visitor(cast, int_cell);
   auto bool_res = boost::apply_visitor(cast, bool_cell);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_double_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_float_cell), Elements::Exception);
@@ -289,7 +286,6 @@ BOOST_AUTO_TEST_CASE(castToInt32) {
   BOOST_CHECK_EQUAL(int_res, 1234);
   BOOST_CHECK_EQUAL(typeid(bool_res).name(), typeid(int32_t).name());
   BOOST_CHECK_EQUAL(bool_res, 1);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -297,32 +293,32 @@ BOOST_AUTO_TEST_CASE(castToInt32) {
 BOOST_AUTO_TEST_CASE(castToDoubleVector) {
 
   // Given
-  Row::cell_type string_cell = std::string{"1.23,4.56,7.89"};
-  Row::cell_type double_cell = 12.345;
-  Row::cell_type float_cell = 12.34F;
-  Row::cell_type long_cell = std::int64_t{12345};
-  Row::cell_type int_cell = std::int32_t{1234};
-  Row::cell_type bool_cell = true;
+  Row::cell_type string_cell        = std::string{"1.23,4.56,7.89"};
+  Row::cell_type double_cell        = 12.345;
+  Row::cell_type float_cell         = 12.34F;
+  Row::cell_type long_cell          = std::int64_t{12345};
+  Row::cell_type int_cell           = std::int32_t{1234};
+  Row::cell_type bool_cell          = true;
   Row::cell_type vector_double_cell = std::vector<double>{1.23, 4.56, 7.89};
-  Row::cell_type vector_float_cell = std::vector<float>{1.2, 3.4, 5.6, 7.8};
-  Row::cell_type vector_long_cell = std::vector<std::int64_t>{123, 456, 789};
-  Row::cell_type vector_int_cell = std::vector<std::int32_t>{12, 34, 56, 78};
-  Row::cell_type vector_bool_cell = std::vector<bool>{true, false, true};
-  
+  Row::cell_type vector_float_cell  = std::vector<float>{1.2, 3.4, 5.6, 7.8};
+  Row::cell_type vector_long_cell   = std::vector<std::int64_t>{123, 456, 789};
+  Row::cell_type vector_int_cell    = std::vector<std::int32_t>{12, 34, 56, 78};
+  Row::cell_type vector_bool_cell   = std::vector<bool>{true, false, true};
+
   // When
-  CastVisitor<std::vector<double>> cast {};
-  auto string_res = boost::apply_visitor(cast, string_cell);
-  auto double_res = boost::apply_visitor(cast, double_cell);
-  auto float_res = boost::apply_visitor(cast, float_cell);
-  auto long_res = boost::apply_visitor(cast, long_cell);
-  auto int_res = boost::apply_visitor(cast, int_cell);
-  auto bool_res = boost::apply_visitor(cast, bool_cell);
-  auto vector_double_res = boost::apply_visitor(cast, vector_double_cell);
-  auto vector_float_res = boost::apply_visitor(cast, vector_float_cell);
-  auto vector_long_res = boost::apply_visitor(cast, vector_long_cell);
-  auto vector_int_res = boost::apply_visitor(cast, vector_int_cell);
-  auto vector_bool_res = boost::apply_visitor(cast, vector_bool_cell);
-  
+  CastVisitor<std::vector<double>> cast{};
+  auto                             string_res        = boost::apply_visitor(cast, string_cell);
+  auto                             double_res        = boost::apply_visitor(cast, double_cell);
+  auto                             float_res         = boost::apply_visitor(cast, float_cell);
+  auto                             long_res          = boost::apply_visitor(cast, long_cell);
+  auto                             int_res           = boost::apply_visitor(cast, int_cell);
+  auto                             bool_res          = boost::apply_visitor(cast, bool_cell);
+  auto                             vector_double_res = boost::apply_visitor(cast, vector_double_cell);
+  auto                             vector_float_res  = boost::apply_visitor(cast, vector_float_cell);
+  auto                             vector_long_res   = boost::apply_visitor(cast, vector_long_cell);
+  auto                             vector_int_res    = boost::apply_visitor(cast, vector_int_cell);
+  auto                             vector_bool_res   = boost::apply_visitor(cast, vector_bool_cell);
+
   // Then
   BOOST_CHECK_EQUAL(typeid(string_res).name(), typeid(std::vector<double>).name());
   BOOST_CHECK_EQUAL(string_res.size(), 3);
@@ -371,7 +367,6 @@ BOOST_AUTO_TEST_CASE(castToDoubleVector) {
   BOOST_CHECK_EQUAL(vector_bool_res[0], 1);
   BOOST_CHECK_EQUAL(vector_bool_res[1], 0);
   BOOST_CHECK_EQUAL(vector_bool_res[2], 1);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -379,32 +374,32 @@ BOOST_AUTO_TEST_CASE(castToDoubleVector) {
 BOOST_AUTO_TEST_CASE(castToFloatVector) {
 
   // Given
-  Row::cell_type string_cell = std::string{"1.23,4.56,7.89"};
-  Row::cell_type double_cell = 12.345;
-  Row::cell_type float_cell = 12.34F;
-  Row::cell_type long_cell = std::int64_t{12345};
-  Row::cell_type int_cell = std::int32_t{1234};
-  Row::cell_type bool_cell = true;
+  Row::cell_type string_cell        = std::string{"1.23,4.56,7.89"};
+  Row::cell_type double_cell        = 12.345;
+  Row::cell_type float_cell         = 12.34F;
+  Row::cell_type long_cell          = std::int64_t{12345};
+  Row::cell_type int_cell           = std::int32_t{1234};
+  Row::cell_type bool_cell          = true;
   Row::cell_type vector_double_cell = std::vector<double>{1.23, 4.56, 7.89};
-  Row::cell_type vector_float_cell = std::vector<float>{1.2, 3.4, 5.6, 7.8};
-  Row::cell_type vector_long_cell = std::vector<std::int64_t>{123, 456, 789};
-  Row::cell_type vector_int_cell = std::vector<std::int32_t>{12, 34, 56, 78};
-  Row::cell_type vector_bool_cell = std::vector<bool>{true, false, true};
-  
+  Row::cell_type vector_float_cell  = std::vector<float>{1.2, 3.4, 5.6, 7.8};
+  Row::cell_type vector_long_cell   = std::vector<std::int64_t>{123, 456, 789};
+  Row::cell_type vector_int_cell    = std::vector<std::int32_t>{12, 34, 56, 78};
+  Row::cell_type vector_bool_cell   = std::vector<bool>{true, false, true};
+
   // When
-  CastVisitor<std::vector<float>> cast {};
-  auto string_res = boost::apply_visitor(cast, string_cell);
+  CastVisitor<std::vector<float>> cast{};
+  auto                            string_res = boost::apply_visitor(cast, string_cell);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, double_cell), Elements::Exception);
   auto float_res = boost::apply_visitor(cast, float_cell);
-  auto long_res = boost::apply_visitor(cast, long_cell);
-  auto int_res = boost::apply_visitor(cast, int_cell);
-  auto bool_res = boost::apply_visitor(cast, bool_cell);
+  auto long_res  = boost::apply_visitor(cast, long_cell);
+  auto int_res   = boost::apply_visitor(cast, int_cell);
+  auto bool_res  = boost::apply_visitor(cast, bool_cell);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_double_cell), Elements::Exception);
   auto vector_float_res = boost::apply_visitor(cast, vector_float_cell);
-  auto vector_long_res = boost::apply_visitor(cast, vector_long_cell);
-  auto vector_int_res = boost::apply_visitor(cast, vector_int_cell);
-  auto vector_bool_res = boost::apply_visitor(cast, vector_bool_cell);
-  
+  auto vector_long_res  = boost::apply_visitor(cast, vector_long_cell);
+  auto vector_int_res   = boost::apply_visitor(cast, vector_int_cell);
+  auto vector_bool_res  = boost::apply_visitor(cast, vector_bool_cell);
+
   // Then
   BOOST_CHECK_EQUAL(typeid(string_res).name(), typeid(std::vector<float>).name());
   BOOST_CHECK_EQUAL(string_res.size(), 3);
@@ -445,7 +440,6 @@ BOOST_AUTO_TEST_CASE(castToFloatVector) {
   BOOST_CHECK_EQUAL(vector_bool_res[0], 1);
   BOOST_CHECK_EQUAL(vector_bool_res[1], 0);
   BOOST_CHECK_EQUAL(vector_bool_res[2], 1);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -453,30 +447,30 @@ BOOST_AUTO_TEST_CASE(castToFloatVector) {
 BOOST_AUTO_TEST_CASE(castToLongVector) {
 
   // Given
-  Row::cell_type string_cell = std::string{"123,456,789"};
-  Row::cell_type double_cell = 12.345;
-  Row::cell_type float_cell = 12.34F;
-  Row::cell_type long_cell = std::int64_t{12345};
-  Row::cell_type int_cell = std::int32_t{1234};
-  Row::cell_type bool_cell = true;
+  Row::cell_type string_cell        = std::string{"123,456,789"};
+  Row::cell_type double_cell        = 12.345;
+  Row::cell_type float_cell         = 12.34F;
+  Row::cell_type long_cell          = std::int64_t{12345};
+  Row::cell_type int_cell           = std::int32_t{1234};
+  Row::cell_type bool_cell          = true;
   Row::cell_type vector_double_cell = std::vector<double>{1.23, 4.56, 7.89};
-  Row::cell_type vector_float_cell = std::vector<float>{1.2, 3.4, 5.6, 7.8};
-  Row::cell_type vector_long_cell = std::vector<std::int64_t>{123, 456, 789};
-  Row::cell_type vector_int_cell = std::vector<std::int32_t>{12, 34, 56, 78};
-  Row::cell_type vector_bool_cell = std::vector<bool>{true, false, true};
+  Row::cell_type vector_float_cell  = std::vector<float>{1.2, 3.4, 5.6, 7.8};
+  Row::cell_type vector_long_cell   = std::vector<std::int64_t>{123, 456, 789};
+  Row::cell_type vector_int_cell    = std::vector<std::int32_t>{12, 34, 56, 78};
+  Row::cell_type vector_bool_cell   = std::vector<bool>{true, false, true};
 
   // When
-  CastVisitor<std::vector<std::int64_t>> cast {};
-  auto string_res = boost::apply_visitor(cast, string_cell);
+  CastVisitor<std::vector<std::int64_t>> cast{};
+  auto                                   string_res = boost::apply_visitor(cast, string_cell);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, double_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, float_cell), Elements::Exception);
   auto long_res = boost::apply_visitor(cast, long_cell);
-  auto int_res = boost::apply_visitor(cast, int_cell);
+  auto int_res  = boost::apply_visitor(cast, int_cell);
   auto bool_res = boost::apply_visitor(cast, bool_cell);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_double_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_float_cell), Elements::Exception);
   auto vector_long_res = boost::apply_visitor(cast, vector_long_cell);
-  auto vector_int_res = boost::apply_visitor(cast, vector_int_cell);
+  auto vector_int_res  = boost::apply_visitor(cast, vector_int_cell);
   auto vector_bool_res = boost::apply_visitor(cast, vector_bool_cell);
 
   // Then
@@ -510,7 +504,6 @@ BOOST_AUTO_TEST_CASE(castToLongVector) {
   BOOST_CHECK_EQUAL(vector_bool_res[0], 1);
   BOOST_CHECK_EQUAL(vector_bool_res[1], 0);
   BOOST_CHECK_EQUAL(vector_bool_res[2], 1);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -518,32 +511,32 @@ BOOST_AUTO_TEST_CASE(castToLongVector) {
 BOOST_AUTO_TEST_CASE(castToIntVector) {
 
   // Given
-  Row::cell_type string_cell = std::string{"123,456,789"};
-  Row::cell_type double_cell = 12.345;
-  Row::cell_type float_cell = 12.34F;
-  Row::cell_type long_cell = std::int64_t{12345};
-  Row::cell_type int_cell = std::int32_t{1234};
-  Row::cell_type bool_cell = true;
+  Row::cell_type string_cell        = std::string{"123,456,789"};
+  Row::cell_type double_cell        = 12.345;
+  Row::cell_type float_cell         = 12.34F;
+  Row::cell_type long_cell          = std::int64_t{12345};
+  Row::cell_type int_cell           = std::int32_t{1234};
+  Row::cell_type bool_cell          = true;
   Row::cell_type vector_double_cell = std::vector<double>{1.23, 4.56, 7.89};
-  Row::cell_type vector_float_cell = std::vector<float>{1.2, 3.4, 5.6, 7.8};
-  Row::cell_type vector_long_cell = std::vector<std::int64_t>{123, 456, 789};
-  Row::cell_type vector_int_cell = std::vector<std::int32_t>{12, 34, 56, 78};
-  Row::cell_type vector_bool_cell = std::vector<bool>{true, false, true};
-  
+  Row::cell_type vector_float_cell  = std::vector<float>{1.2, 3.4, 5.6, 7.8};
+  Row::cell_type vector_long_cell   = std::vector<std::int64_t>{123, 456, 789};
+  Row::cell_type vector_int_cell    = std::vector<std::int32_t>{12, 34, 56, 78};
+  Row::cell_type vector_bool_cell   = std::vector<bool>{true, false, true};
+
   // When
-  CastVisitor<std::vector<std::int32_t>> cast {};
-  auto string_res = boost::apply_visitor(cast, string_cell);
+  CastVisitor<std::vector<std::int32_t>> cast{};
+  auto                                   string_res = boost::apply_visitor(cast, string_cell);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, double_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, float_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, long_cell), Elements::Exception);
-  auto int_res = boost::apply_visitor(cast, int_cell);
+  auto int_res  = boost::apply_visitor(cast, int_cell);
   auto bool_res = boost::apply_visitor(cast, bool_cell);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_double_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_float_cell), Elements::Exception);
   BOOST_CHECK_THROW(boost::apply_visitor(cast, vector_long_cell), Elements::Exception);
-  auto vector_int_res = boost::apply_visitor(cast, vector_int_cell);
+  auto vector_int_res  = boost::apply_visitor(cast, vector_int_cell);
   auto vector_bool_res = boost::apply_visitor(cast, vector_bool_cell);
-  
+
   // Then
   BOOST_CHECK_EQUAL(typeid(string_res).name(), typeid(std::vector<std::int32_t>).name());
   BOOST_CHECK_EQUAL(string_res.size(), 3);
@@ -567,11 +560,8 @@ BOOST_AUTO_TEST_CASE(castToIntVector) {
   BOOST_CHECK_EQUAL(vector_bool_res[0], 1);
   BOOST_CHECK_EQUAL(vector_bool_res[1], 0);
   BOOST_CHECK_EQUAL(vector_bool_res[2], 1);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/Table/tests/src/ColumnDescription_test.cpp
+++ b/Table/tests/src/ColumnDescription_test.cpp
@@ -31,27 +31,26 @@ using namespace Euclid::Table;
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (ColumnDescription_test)
+BOOST_AUTO_TEST_SUITE(ColumnDescription_test)
 
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(NominalCase) {
 
   // Given
-  std::string name = "Name";
-  std::type_index type = typeid(double);
-  std::string unit = "u";
-  std::string description = "Desc";
+  std::string     name        = "Name";
+  std::type_index type        = typeid(double);
+  std::string     unit        = "u";
+  std::string     description = "Desc";
 
   // When
-  ColumnDescription result {name, type, unit, description};
+  ColumnDescription result{name, type, unit, description};
 
   // Then
   BOOST_CHECK_EQUAL(result.name, name);
   BOOST_CHECK_EQUAL(result.type.name(), type.name());
   BOOST_CHECK_EQUAL(result.unit, unit);
   BOOST_CHECK_EQUAL(result.description, description);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -62,14 +61,13 @@ BOOST_AUTO_TEST_CASE(DefaultValues) {
   std::string name = "Name";
 
   // When
-  ColumnDescription result {name};
+  ColumnDescription result{name};
 
   // Then
   BOOST_CHECK_EQUAL(result.name, name);
   BOOST_CHECK_EQUAL(result.type.name(), typeid(std::string).name());
   BOOST_CHECK_EQUAL(result.unit, "");
   BOOST_CHECK_EQUAL(result.description, "");
-
 }
 
 //-----------------------------------------------------------------------------
@@ -81,7 +79,6 @@ BOOST_AUTO_TEST_CASE(EmptyStringName) {
 
   // Then
   BOOST_CHECK_THROW(ColumnDescription{name}, Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -89,11 +86,11 @@ BOOST_AUTO_TEST_CASE(EmptyStringName) {
 BOOST_AUTO_TEST_CASE(NameWithWhitespaces) {
 
   // Given
-  std::string space = "Sp ace";
-  std::string tab = "Ta\tb";
+  std::string space           = "Sp ace";
+  std::string tab             = "Ta\tb";
   std::string carriage_return = "Carrage\rReturn";
-  std::string new_line = "New\nLine";
-  std::string new_page = "New\fPage";
+  std::string new_line        = "New\nLine";
+  std::string new_page        = "New\fPage";
 
   // Then
   ColumnDescription{space};
@@ -101,11 +98,8 @@ BOOST_AUTO_TEST_CASE(NameWithWhitespaces) {
   BOOST_CHECK_THROW(ColumnDescription{carriage_return}, Elements::Exception);
   BOOST_CHECK_THROW(ColumnDescription{new_line}, Elements::Exception);
   BOOST_CHECK_THROW(ColumnDescription{new_page}, Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/Table/tests/src/ColumnInfo_test.cpp
+++ b/Table/tests/src/ColumnInfo_test.cpp
@@ -1,47 +1,46 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file tests/src/ColumnInfo_test.cpp
  * @date April 7, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
 #include "ElementsKernel/Exception.h"
 #include "Table/ColumnInfo.h"
+#include <boost/test/unit_test.hpp>
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (ColumnInfo_test)
+BOOST_AUTO_TEST_SUITE(ColumnInfo_test)
 
 //-----------------------------------------------------------------------------
 // Test the constructor throws an exception for empty names list
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(ConstructorEmptyNamesList) {
-  
+
   // Given
-  std::vector<Euclid::Table::ColumnInfo::info_type> info_list {};
-  
+  std::vector<Euclid::Table::ColumnInfo::info_type> info_list{};
+
   // Then
-  BOOST_CHECK_THROW(Euclid::Table::ColumnInfo {info_list}, Elements::Exception);
-  
+  BOOST_CHECK_THROW(Euclid::Table::ColumnInfo{info_list}, Elements::Exception);
 }
 
 //-----------------------------------------------------------------------------
@@ -49,19 +48,18 @@ BOOST_AUTO_TEST_CASE(ConstructorEmptyNamesList) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(ConstructorDuplicateNames) {
-  
+
   // Given
-  std::vector<Euclid::Table::ColumnInfo::info_type> info_list {};
+  std::vector<Euclid::Table::ColumnInfo::info_type> info_list{};
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("First", typeid(std::string)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Second", typeid(std::string)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Third", typeid(double)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Second", typeid(double)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Fifth", typeid(int)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Sixth", typeid(std::vector<double>)));
-  
+
   // Then
-  BOOST_CHECK_THROW(Euclid::Table::ColumnInfo {info_list}, Elements::Exception);
-  
+  BOOST_CHECK_THROW(Euclid::Table::ColumnInfo{info_list}, Elements::Exception);
 }
 
 //-----------------------------------------------------------------------------
@@ -69,62 +67,61 @@ BOOST_AUTO_TEST_CASE(ConstructorDuplicateNames) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(equalityOperators) {
-  
+
   // Given
-  std::vector<Euclid::Table::ColumnInfo::info_type> info_list_1 {};
+  std::vector<Euclid::Table::ColumnInfo::info_type> info_list_1{};
   info_list_1.push_back(Euclid::Table::ColumnInfo::info_type("First", typeid(std::string)));
   info_list_1.push_back(Euclid::Table::ColumnInfo::info_type("Second", typeid(std::string)));
   info_list_1.push_back(Euclid::Table::ColumnInfo::info_type("Third", typeid(double)));
   info_list_1.push_back(Euclid::Table::ColumnInfo::info_type("Fourth", typeid(double)));
   info_list_1.push_back(Euclid::Table::ColumnInfo::info_type("Fifth", typeid(int)));
   info_list_1.push_back(Euclid::Table::ColumnInfo::info_type("Sixth", typeid(std::vector<double>)));
-  std::vector<Euclid::Table::ColumnInfo::info_type> info_list_2 {};
+  std::vector<Euclid::Table::ColumnInfo::info_type> info_list_2{};
   info_list_2.push_back(Euclid::Table::ColumnInfo::info_type("First", typeid(std::string)));
   info_list_2.push_back(Euclid::Table::ColumnInfo::info_type("Second", typeid(std::string)));
   info_list_2.push_back(Euclid::Table::ColumnInfo::info_type("Third", typeid(double)));
   info_list_2.push_back(Euclid::Table::ColumnInfo::info_type("Fourth", typeid(double)));
   info_list_2.push_back(Euclid::Table::ColumnInfo::info_type("Fifth", typeid(int)));
   info_list_2.push_back(Euclid::Table::ColumnInfo::info_type("Sixth", typeid(std::vector<double>)));
-  
+
   // When
-  Euclid::Table::ColumnInfo columnInfo1 {info_list_1};
-  Euclid::Table::ColumnInfo columnInfo2 {info_list_2};
-  
+  Euclid::Table::ColumnInfo columnInfo1{info_list_1};
+  Euclid::Table::ColumnInfo columnInfo2{info_list_2};
+
   // Then
   BOOST_CHECK(columnInfo1 == columnInfo2);
   BOOST_CHECK(!(columnInfo1 != columnInfo2));
-  
+
   // Given
-  std::vector<Euclid::Table::ColumnInfo::info_type> info_list_3 {};
+  std::vector<Euclid::Table::ColumnInfo::info_type> info_list_3{};
   info_list_3.push_back(Euclid::Table::ColumnInfo::info_type("First", typeid(std::string)));
   info_list_3.push_back(Euclid::Table::ColumnInfo::info_type("Second", typeid(std::string)));
   info_list_3.push_back(Euclid::Table::ColumnInfo::info_type("Third", typeid(double)));
   info_list_3.push_back(Euclid::Table::ColumnInfo::info_type("Fourth", typeid(double)));
   info_list_1.push_back(Euclid::Table::ColumnInfo::info_type("Fifth", typeid(int)));
-  
+
   // When
-  Euclid::Table::ColumnInfo columnInfo3 {info_list_3};
-  
+  Euclid::Table::ColumnInfo columnInfo3{info_list_3};
+
   // Then
   BOOST_CHECK(!(columnInfo1 == columnInfo3));
   BOOST_CHECK(columnInfo1 != columnInfo3);
-  
+
   // Given
-  std::vector<Euclid::Table::ColumnInfo::info_type> info_list_4 {};
+  std::vector<Euclid::Table::ColumnInfo::info_type> info_list_4{};
   info_list_4.push_back(Euclid::Table::ColumnInfo::info_type("First", typeid(std::string)));
   info_list_4.push_back(Euclid::Table::ColumnInfo::info_type("Second", typeid(std::string)));
   info_list_4.push_back(Euclid::Table::ColumnInfo::info_type("WRONG", typeid(double)));
   info_list_4.push_back(Euclid::Table::ColumnInfo::info_type("Fourth", typeid(double)));
   info_list_4.push_back(Euclid::Table::ColumnInfo::info_type("Fifth", typeid(int)));
   info_list_2.push_back(Euclid::Table::ColumnInfo::info_type("Sixth", typeid(std::vector<double>)));
-  
+
   // When
-  Euclid::Table::ColumnInfo columnInfo4 {info_list_4};
-  
+  Euclid::Table::ColumnInfo columnInfo4{info_list_4};
+
   // Then
   BOOST_CHECK(!(columnInfo1 == columnInfo4));
   BOOST_CHECK(columnInfo1 != columnInfo4);
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -132,23 +129,22 @@ BOOST_AUTO_TEST_CASE(equalityOperators) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(size) {
-  
+
   // Given
-  std::vector<Euclid::Table::ColumnInfo::info_type> info_list {};
+  std::vector<Euclid::Table::ColumnInfo::info_type> info_list{};
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("First", typeid(std::string)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Second", typeid(std::string)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Third", typeid(double)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Fourth", typeid(double)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Fifth", typeid(int)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Sixth", typeid(std::vector<double>)));
-  Euclid::Table::ColumnInfo columnInfo {info_list};
-  
+  Euclid::Table::ColumnInfo columnInfo{info_list};
+
   // When
   std::size_t size_test_value = columnInfo.size();
-  
+
   // Then
   BOOST_CHECK_EQUAL(size_test_value, 6u);
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -156,58 +152,57 @@ BOOST_AUTO_TEST_CASE(size) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(getDescription) {
-  
+
   // Given
-  std::vector<Euclid::Table::ColumnInfo::info_type> info_list {};
+  std::vector<Euclid::Table::ColumnInfo::info_type> info_list{};
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("First", typeid(std::string), "deg", "Desc1"));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Second", typeid(std::string), "mag", "Desc2"));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Third", typeid(double), "", "Desc3"));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Fourth", typeid(double), "ph", "Desc4"));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Fifth", typeid(int), "s"));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Sixth", typeid(std::vector<double>)));
-  Euclid::Table::ColumnInfo columnInfo {info_list};
-  
+  Euclid::Table::ColumnInfo columnInfo{info_list};
+
   // When
-  auto& desc0  = columnInfo.getDescription(0);
-  auto& desc1  = columnInfo.getDescription(1);
-  auto& desc2  = columnInfo.getDescription(2);
-  auto& desc3  = columnInfo.getDescription(3);
-  auto& desc4  = columnInfo.getDescription(4);
-  auto& desc5  = columnInfo.getDescription(5);
-  
+  auto& desc0 = columnInfo.getDescription(0);
+  auto& desc1 = columnInfo.getDescription(1);
+  auto& desc2 = columnInfo.getDescription(2);
+  auto& desc3 = columnInfo.getDescription(3);
+  auto& desc4 = columnInfo.getDescription(4);
+  auto& desc5 = columnInfo.getDescription(5);
+
   // Then
   BOOST_CHECK_EQUAL(desc0.name, info_list[0].name);
   BOOST_CHECK_EQUAL(desc0.type.name(), info_list[0].type.name());
   BOOST_CHECK_EQUAL(desc0.unit, info_list[0].unit);
   BOOST_CHECK_EQUAL(desc0.description, info_list[0].description);
-  
+
   BOOST_CHECK_EQUAL(desc1.name, info_list[1].name);
   BOOST_CHECK_EQUAL(desc1.type.name(), info_list[1].type.name());
   BOOST_CHECK_EQUAL(desc1.unit, info_list[1].unit);
   BOOST_CHECK_EQUAL(desc1.description, info_list[1].description);
-  
+
   BOOST_CHECK_EQUAL(desc2.name, info_list[2].name);
   BOOST_CHECK_EQUAL(desc2.type.name(), info_list[2].type.name());
   BOOST_CHECK_EQUAL(desc2.unit, info_list[2].unit);
   BOOST_CHECK_EQUAL(desc2.description, info_list[2].description);
-  
+
   BOOST_CHECK_EQUAL(desc3.name, info_list[3].name);
   BOOST_CHECK_EQUAL(desc3.type.name(), info_list[3].type.name());
   BOOST_CHECK_EQUAL(desc3.unit, info_list[3].unit);
   BOOST_CHECK_EQUAL(desc3.description, info_list[3].description);
-  
+
   BOOST_CHECK_EQUAL(desc4.name, info_list[4].name);
   BOOST_CHECK_EQUAL(desc4.type.name(), info_list[4].type.name());
   BOOST_CHECK_EQUAL(desc4.unit, info_list[4].unit);
   BOOST_CHECK_EQUAL(desc4.description, info_list[4].description);
-  
+
   BOOST_CHECK_EQUAL(desc5.name, info_list[5].name);
   BOOST_CHECK_EQUAL(desc5.type.name(), info_list[5].type.name());
   BOOST_CHECK_EQUAL(desc5.unit, info_list[5].unit);
   BOOST_CHECK_EQUAL(desc5.description, info_list[5].description);
-  
+
   BOOST_CHECK_THROW(columnInfo.getDescription(6), Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -215,26 +210,26 @@ BOOST_AUTO_TEST_CASE(getDescription) {
 //-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(find) {
-  
+
   // Given
-  std::vector<Euclid::Table::ColumnInfo::info_type> info_list {};
+  std::vector<Euclid::Table::ColumnInfo::info_type> info_list{};
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("First", typeid(std::string)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Second", typeid(std::string)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Third", typeid(double)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Fourth", typeid(double)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Fifth", typeid(int)));
   info_list.push_back(Euclid::Table::ColumnInfo::info_type("Sixth", typeid(std::vector<double>)));
-  Euclid::Table::ColumnInfo columnInfo {info_list};
-  
+  Euclid::Table::ColumnInfo columnInfo{info_list};
+
   // When
-  std::unique_ptr<size_t> index0  = columnInfo.find("First");
-  std::unique_ptr<size_t> index1  = columnInfo.find("Second");
-  std::unique_ptr<size_t> index2  = columnInfo.find("Third");
-  std::unique_ptr<size_t> index3  = columnInfo.find("Fourth");
-  std::unique_ptr<size_t> index4  = columnInfo.find("Fifth");
-  std::unique_ptr<size_t> index5  = columnInfo.find("Sixth");
-  std::unique_ptr<size_t> index6  = columnInfo.find("NotThere");
-  
+  std::unique_ptr<size_t> index0 = columnInfo.find("First");
+  std::unique_ptr<size_t> index1 = columnInfo.find("Second");
+  std::unique_ptr<size_t> index2 = columnInfo.find("Third");
+  std::unique_ptr<size_t> index3 = columnInfo.find("Fourth");
+  std::unique_ptr<size_t> index4 = columnInfo.find("Fifth");
+  std::unique_ptr<size_t> index5 = columnInfo.find("Sixth");
+  std::unique_ptr<size_t> index6 = columnInfo.find("NotThere");
+
   // Then
   BOOST_CHECK(index0);
   BOOST_CHECK_EQUAL(*index0, 0u);
@@ -249,9 +244,8 @@ BOOST_AUTO_TEST_CASE(find) {
   BOOST_CHECK(index5);
   BOOST_CHECK_EQUAL(*index5, 5u);
   BOOST_CHECK(!index6);
-  
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Table/tests/src/FitsReaderHelper_test.cpp
+++ b/Table/tests/src/FitsReaderHelper_test.cpp
@@ -16,27 +16,27 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/FitsReaderHelper_test.cpp
  * @date April 17, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
-#include <CCfits/CCfits>
 #include "ElementsKernel/Exception.h"
 #include "ElementsKernel/Temporary.h"
 #include "src/lib/FitsReaderHelper.h"
+#include <CCfits/CCfits>
+#include <boost/test/unit_test.hpp>
 
 struct FitsReaderHelper_Fixture {
-  Elements::TempDir temp_dir;
-  std::unique_ptr<CCfits::FITS> fits {new CCfits::FITS(
-        (temp_dir.path()/"FitsReaderHelper_test.fits").native(), CCfits::RWmode::Write)};
+  Elements::TempDir             temp_dir;
+  std::unique_ptr<CCfits::FITS> fits{
+      new CCfits::FITS((temp_dir.path() / "FitsReaderHelper_test.fits").native(), CCfits::RWmode::Write)};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (FitsReaderHelper_test)
+BOOST_AUTO_TEST_SUITE(FitsReaderHelper_test)
 
 //-----------------------------------------------------------------------------
 // Test the autoDetectColumnNames method
@@ -45,9 +45,9 @@ BOOST_AUTO_TEST_SUITE (FitsReaderHelper_test)
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnNames, FitsReaderHelper_Fixture) {
 
   // Given
-  std::vector<std::string> names {"First","Second","","Fourth"};
-  std::vector<std::string> types {"J","J","J","J"};
-  CCfits::Table* table_hdu = fits->addTable("CheckNames", 0, names, types);
+  std::vector<std::string> names{"First", "Second", "", "Fourth"};
+  std::vector<std::string> types{"J", "J", "J", "J"};
+  CCfits::Table*           table_hdu = fits->addTable("CheckNames", 0, names, types);
 
   // When
   std::vector<std::string> result = Euclid::Table::autoDetectColumnNames(*table_hdu);
@@ -58,7 +58,6 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnNames, FitsReaderHelper_Fixture) {
   BOOST_CHECK_EQUAL(result[1], "Second");
   BOOST_CHECK_EQUAL(result[2], "Col3");
   BOOST_CHECK_EQUAL(result[3], "Fourth");
-
 }
 
 //-----------------------------------------------------------------------------
@@ -68,10 +67,10 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnNames, FitsReaderHelper_Fixture) {
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnTypesAscii, FitsReaderHelper_Fixture) {
 
   // Given
-  std::vector<std::string> names {"String","Integer","Float1","Float2","Float3"};
-  std::vector<std::string> types {"A10","I6","F4.3","E6.5","D8.7"};
-  std::vector<std::string> units {"","","","",""};
-  CCfits::Table* table_hdu = fits->addTable("ASCII", 0, names, types, units, CCfits::HduType::AsciiTbl);
+  std::vector<std::string> names{"String", "Integer", "Float1", "Float2", "Float3"};
+  std::vector<std::string> types{"A10", "I6", "F4.3", "E6.5", "D8.7"};
+  std::vector<std::string> units{"", "", "", "", ""};
+  CCfits::Table*           table_hdu = fits->addTable("ASCII", 0, names, types, units, CCfits::HduType::AsciiTbl);
 
   // When
   std::vector<std::type_index> result = Euclid::Table::autoDetectColumnTypes(*table_hdu);
@@ -83,7 +82,6 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnTypesAscii, FitsReaderHelper_Fixture) {
   BOOST_CHECK(result[2] == typeid(double));
   BOOST_CHECK(result[3] == typeid(double));
   BOOST_CHECK(result[4] == typeid(double));
-
 }
 
 //-----------------------------------------------------------------------------
@@ -93,10 +91,11 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnTypesAscii, FitsReaderHelper_Fixture) {
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnTypesBinary, FitsReaderHelper_Fixture) {
 
   // Given
-  std::vector<std::string> names {"Bool","Byte","Short","Int","Long","String","Float","Double",
-          "ByteVector","ShortVector","IntVector","LongVector","FloatVector","DoubleVector", "Scalar"};
-  std::vector<std::string> types {"L","B","I","J","K","10A","E","D","2B","3I","4J","5K","6E","7D", "1D"};
-  CCfits::Table* table_hdu = fits->addTable("Binary", 0, names, types);
+  std::vector<std::string> names{"Bool",      "Byte",       "Short",       "Int",          "Long",
+                                 "String",    "Float",      "Double",      "ByteVector",   "ShortVector",
+                                 "IntVector", "LongVector", "FloatVector", "DoubleVector", "Scalar"};
+  std::vector<std::string> types{"L", "B", "I", "J", "K", "10A", "E", "D", "2B", "3I", "4J", "5K", "6E", "7D", "1D"};
+  CCfits::Table*           table_hdu = fits->addTable("Binary", 0, names, types);
 
   // When
   std::vector<std::type_index> result = Euclid::Table::autoDetectColumnTypes(*table_hdu);
@@ -118,7 +117,6 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnTypesBinary, FitsReaderHelper_Fixture) {
   BOOST_CHECK(result[12] == typeid(std::vector<float>));
   BOOST_CHECK(result[13] == typeid(std::vector<double>));
   BOOST_CHECK(result[14] == typeid(double));
-
 }
 
 //-----------------------------------------------------------------------------
@@ -128,29 +126,28 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnTypesBinary, FitsReaderHelper_Fixture) {
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnTypesBinaryUnsupportedTypes, FitsReaderHelper_Fixture) {
 
   // Given
-  std::vector<std::string> names {"Bit"};
-  std::vector<std::string> types {"X"};
-  CCfits::Table* table_hdu = fits->addTable("Bit", 0, names, types);
+  std::vector<std::string> names{"Bit"};
+  std::vector<std::string> types{"X"};
+  CCfits::Table*           table_hdu = fits->addTable("Bit", 0, names, types);
 
   // Then
   BOOST_CHECK_THROW(Euclid::Table::autoDetectColumnTypes(*table_hdu), Elements::Exception);
 
   // Given
-  names = {"FloatComplex"};
-  types = {"C"};
+  names     = {"FloatComplex"};
+  types     = {"C"};
   table_hdu = fits->addTable("FloatComplex", 0, names, types);
 
   // Then
   BOOST_CHECK_THROW(Euclid::Table::autoDetectColumnTypes(*table_hdu), Elements::Exception);
 
   // Given
-  names = {"DoubleComplex"};
-  types = {"M"};
+  names     = {"DoubleComplex"};
+  types     = {"M"};
   table_hdu = fits->addTable("DoubleComplex", 0, names, types);
 
   // Then
   BOOST_CHECK_THROW(Euclid::Table::autoDetectColumnTypes(*table_hdu), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -160,10 +157,10 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnTypesBinaryUnsupportedTypes, FitsReaderH
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnUnits, FitsReaderHelper_Fixture) {
 
   // Given
-  std::vector<std::string> names {"First","Second","","Fourth"};
-  std::vector<std::string> types {"J","J","J","J"};
-  std::vector<std::string> units {"m","mag","pc",""};
-  CCfits::Table* table_hdu = fits->addTable("CheckNames", 0, names, types, units);
+  std::vector<std::string> names{"First", "Second", "", "Fourth"};
+  std::vector<std::string> types{"J", "J", "J", "J"};
+  std::vector<std::string> units{"m", "mag", "pc", ""};
+  CCfits::Table*           table_hdu = fits->addTable("CheckNames", 0, names, types, units);
 
   // When
   std::vector<std::string> result = Euclid::Table::autoDetectColumnUnits(*table_hdu);
@@ -174,7 +171,6 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnUnits, FitsReaderHelper_Fixture) {
   BOOST_CHECK_EQUAL(result[1], "mag");
   BOOST_CHECK_EQUAL(result[2], "pc");
   BOOST_CHECK_EQUAL(result[3], "");
-
 }
 
 //-----------------------------------------------------------------------------
@@ -184,9 +180,9 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnUnits, FitsReaderHelper_Fixture) {
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnUnitsMissingKeywords, FitsReaderHelper_Fixture) {
 
   // Given
-  std::vector<std::string> names {"First","Second","","Fourth"};
-  std::vector<std::string> types {"J","J","J","J"};
-  CCfits::Table* table_hdu = fits->addTable("CheckNames", 0, names, types);
+  std::vector<std::string> names{"First", "Second", "", "Fourth"};
+  std::vector<std::string> types{"J", "J", "J", "J"};
+  CCfits::Table*           table_hdu = fits->addTable("CheckNames", 0, names, types);
 
   // When
   std::vector<std::string> result = Euclid::Table::autoDetectColumnUnits(*table_hdu);
@@ -197,7 +193,6 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnUnitsMissingKeywords, FitsReaderHelper_F
   BOOST_CHECK_EQUAL(result[1], "");
   BOOST_CHECK_EQUAL(result[2], "");
   BOOST_CHECK_EQUAL(result[3], "");
-
 }
 
 //-----------------------------------------------------------------------------
@@ -207,10 +202,10 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnUnitsMissingKeywords, FitsReaderHelper_F
 BOOST_FIXTURE_TEST_CASE(autoDetectColumnDescriptions, FitsReaderHelper_Fixture) {
 
   // Given
-  std::vector<std::string> names {"First","Second","","Fourth"};
-  std::vector<std::string> types {"J","J","J","J"};
-  std::vector<std::string> units {"m","mag","pc",""};
-  CCfits::Table* table_hdu = fits->addTable("CheckNames", 0, names, types, units);
+  std::vector<std::string> names{"First", "Second", "", "Fourth"};
+  std::vector<std::string> types{"J", "J", "J", "J"};
+  std::vector<std::string> units{"m", "mag", "pc", ""};
+  CCfits::Table*           table_hdu = fits->addTable("CheckNames", 0, names, types, units);
   table_hdu->addKey("TDESC1", "Desc1", "");
   table_hdu->addKey("TDESC2", "", "");
   table_hdu->addKey("TDESC4", "Desc4", "");
@@ -224,7 +219,6 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnDescriptions, FitsReaderHelper_Fixture) 
   BOOST_CHECK_EQUAL(result[1], "");
   BOOST_CHECK_EQUAL(result[2], "");
   BOOST_CHECK_EQUAL(result[3], "Desc4");
-
 }
 
 //-----------------------------------------------------------------------------
@@ -234,35 +228,34 @@ BOOST_FIXTURE_TEST_CASE(autoDetectColumnDescriptions, FitsReaderHelper_Fixture) 
 BOOST_FIXTURE_TEST_CASE(translateColumn, FitsReaderHelper_Fixture) {
 
   // Given
-  std::vector<std::string> names {"Bool","Int","Long","String","Float","Double","IntVector","DoubleVector"};
-  std::vector<std::string> types {"L","J","K","10A","E","D","2J","2D"};
-  CCfits::Table* table_hdu = fits->addTable("TranslateColumn", 2, names, types);
-  std::vector<bool> bool_values {true, false};
+  std::vector<std::string> names{"Bool", "Int", "Long", "String", "Float", "Double", "IntVector", "DoubleVector"};
+  std::vector<std::string> types{"L", "J", "K", "10A", "E", "D", "2J", "2D"};
+  CCfits::Table*           table_hdu = fits->addTable("TranslateColumn", 2, names, types);
+  std::vector<bool>        bool_values{true, false};
   table_hdu->column(1).write(bool_values, 1);
-  std::vector<int32_t> int_values {3, -2346};
+  std::vector<int32_t> int_values{3, -2346};
   table_hdu->column(2).write(int_values, 1);
-  std::vector<int64_t> long_values {123456789, -6};
+  std::vector<int64_t> long_values{123456789, -6};
   table_hdu->column(3).write(long_values, 1);
-  std::vector<std::string> string_values {"Small", "1234567890"};
+  std::vector<std::string> string_values{"Small", "1234567890"};
   table_hdu->column(4).write(string_values, 1);
-  std::vector<float> float_values {3.4f, 2.1e-3f};
+  std::vector<float> float_values{3.4f, 2.1e-3f};
   table_hdu->column(5).write(float_values, 1);
-  std::vector<double> double_values {3.4, 2.1e-13};
+  std::vector<double> double_values{3.4, 2.1e-13};
   table_hdu->column(6).write(double_values, 1);
-  std::vector<std::valarray<int32_t>> int_vectors {{1,2}, {3,4}};
+  std::vector<std::valarray<int32_t>> int_vectors{{1, 2}, {3, 4}};
   table_hdu->column(7).writeArrays(int_vectors, 1);
-  std::vector<std::valarray<double>> double_vectors {{1.1,1.2}, {2.1,2.2}};
+  std::vector<std::valarray<double>> double_vectors{{1.1, 1.2}, {2.1, 2.2}};
   table_hdu->column(8).writeArrays(double_vectors, 1);
 
-
   // When
-  auto bool_result = Euclid::Table::translateColumn(table_hdu->column(1), typeid(bool));
-  auto int_result = Euclid::Table::translateColumn(table_hdu->column(2), typeid(int32_t));
-  auto long_result = Euclid::Table::translateColumn(table_hdu->column(3), typeid(int64_t));
-  auto string_result = Euclid::Table::translateColumn(table_hdu->column(4), typeid(std::string));
-  auto float_result = Euclid::Table::translateColumn(table_hdu->column(5), typeid(float));
-  auto double_result = Euclid::Table::translateColumn(table_hdu->column(6), typeid(double));
-  auto int_vector_result = Euclid::Table::translateColumn(table_hdu->column(7), typeid(std::vector<int32_t>));
+  auto bool_result          = Euclid::Table::translateColumn(table_hdu->column(1), typeid(bool));
+  auto int_result           = Euclid::Table::translateColumn(table_hdu->column(2), typeid(int32_t));
+  auto long_result          = Euclid::Table::translateColumn(table_hdu->column(3), typeid(int64_t));
+  auto string_result        = Euclid::Table::translateColumn(table_hdu->column(4), typeid(std::string));
+  auto float_result         = Euclid::Table::translateColumn(table_hdu->column(5), typeid(float));
+  auto double_result        = Euclid::Table::translateColumn(table_hdu->column(6), typeid(double));
+  auto int_vector_result    = Euclid::Table::translateColumn(table_hdu->column(7), typeid(std::vector<int32_t>));
   auto double_vector_result = Euclid::Table::translateColumn(table_hdu->column(8), typeid(std::vector<double>));
 
   // Then
@@ -279,10 +272,10 @@ BOOST_FIXTURE_TEST_CASE(translateColumn, FitsReaderHelper_Fixture) {
   BOOST_CHECK_EQUAL(boost::get<std::string>(string_result[0]), "Small");
   BOOST_CHECK_EQUAL(boost::get<std::string>(string_result[1]), "1234567890");
   BOOST_CHECK_EQUAL(float_result.size(), 2);
-  BOOST_CHECK_EQUAL(boost::get<float>(float_result[0]),3.4f);
+  BOOST_CHECK_EQUAL(boost::get<float>(float_result[0]), 3.4f);
   BOOST_CHECK_EQUAL(boost::get<float>(float_result[1]), 2.1e-3f);
   BOOST_CHECK_EQUAL(double_result.size(), 2);
-  BOOST_CHECK_EQUAL(boost::get<double>(double_result[0]),3.4);
+  BOOST_CHECK_EQUAL(boost::get<double>(double_result[0]), 3.4);
   BOOST_CHECK_EQUAL(boost::get<double>(double_result[1]), 2.1e-13);
   BOOST_CHECK_EQUAL(int_vector_result.size(), 2);
   BOOST_CHECK_EQUAL(boost::get<std::vector<int32_t>>(int_vector_result[0]).size(), 2);
@@ -298,9 +291,8 @@ BOOST_FIXTURE_TEST_CASE(translateColumn, FitsReaderHelper_Fixture) {
   BOOST_CHECK_EQUAL(boost::get<std::vector<double>>(double_vector_result[1]).size(), 2);
   BOOST_CHECK_EQUAL(boost::get<std::vector<double>>(double_vector_result[1])[0], 2.1);
   BOOST_CHECK_EQUAL(boost::get<std::vector<double>>(double_vector_result[1])[1], 2.2);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Table/tests/src/FitsReader_test.cpp
+++ b/Table/tests/src/FitsReader_test.cpp
@@ -24,8 +24,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include "ElementsKernel/Temporary.h"
 #include "ElementsKernel/Exception.h"
+#include "ElementsKernel/Temporary.h"
 
 #include "Table/FitsReader.h"
 
@@ -34,31 +34,32 @@ using namespace Euclid::NdArray;
 
 CCfits::Table* addTable(CCfits::FITS& fits) {
 
-  std::vector<std::string> names {"Bool","Int","Long","String","Float","Double","IntVector","DoubleVector","NdArray","Double1"};
-  std::vector<std::string> types {"L","J","K","10A","E","D","2J","2D", "6D", "1D"};
-  std::vector<std::string> units {"deg","mag","erg","ph","s","m","pc","count", "x", "x"};
-  CCfits::Table* table_hdu = fits.addTable("Success", 2, names, types, units);
-  std::vector<bool> bool_values {true, false};
+  std::vector<std::string> names{"Bool",   "Int",       "Long",         "String",  "Float",
+                                 "Double", "IntVector", "DoubleVector", "NdArray", "Double1"};
+  std::vector<std::string> types{"L", "J", "K", "10A", "E", "D", "2J", "2D", "6D", "1D"};
+  std::vector<std::string> units{"deg", "mag", "erg", "ph", "s", "m", "pc", "count", "x", "x"};
+  CCfits::Table*           table_hdu = fits.addTable("Success", 2, names, types, units);
+  std::vector<bool>        bool_values{true, false};
   table_hdu->column(1).write(bool_values, 1);
-  std::vector<int32_t> int_values {3, -2346};
+  std::vector<int32_t> int_values{3, -2346};
   table_hdu->column(2).write(int_values, 1);
-  std::vector<int64_t> long_values {123456789, -6};
+  std::vector<int64_t> long_values{123456789, -6};
   table_hdu->column(3).write(long_values, 1);
-  std::vector<std::string> string_values {"Small", "1234567890"};
+  std::vector<std::string> string_values{"Small", "1234567890"};
   table_hdu->column(4).write(string_values, 1);
-  std::vector<float> float_values {3.4f, 2.1e-3f};
+  std::vector<float> float_values{3.4f, 2.1e-3f};
   table_hdu->column(5).write(float_values, 1);
-  std::vector<double> double_values {3.4, 2.1e-13};
+  std::vector<double> double_values{3.4, 2.1e-13};
   table_hdu->column(6).write(double_values, 1);
-  std::vector<std::valarray<int32_t>> int_vectors {{1,2}, {3,4}};
+  std::vector<std::valarray<int32_t>> int_vectors{{1, 2}, {3, 4}};
   table_hdu->column(7).writeArrays(int_vectors, 1);
-  std::vector<std::valarray<double>> double_vectors {{1.1,1.2}, {2.1,2.2}};
+  std::vector<std::valarray<double>> double_vectors{{1.1, 1.2}, {2.1, 2.2}};
   table_hdu->column(8).writeArrays(double_vectors, 1);
-  std::vector<std::valarray<double>> double_ndarrays {{1,2,3,4,5,6}, {6,5,4,3,2,1}};
+  std::vector<std::valarray<double>> double_ndarrays{{1, 2, 3, 4, 5, 6}, {6, 5, 4, 3, 2, 1}};
   table_hdu->column(9).writeArrays(double_ndarrays, 1);
   table_hdu->column(10).write(double_values, 1);
 
-  for (int i=1; i<=9; i=i+2) {
+  for (int i = 1; i <= 9; i = i + 2) {
     table_hdu->addKey("TDESC" + std::to_string(i), "Desc" + std::to_string(i), "");
   }
   table_hdu->addKey("TDIM9", "(3,2)", "");
@@ -68,18 +69,17 @@ CCfits::Table* addTable(CCfits::FITS& fits) {
 
 struct FitsReader_Fixture {
 
-  Elements::TempDir temp_dir;
-  std::unique_ptr<CCfits::FITS> fits {new CCfits::FITS(
-          (temp_dir.path()/"FitsReader_test.fits").native(), CCfits::RWmode::Write)};
-  const CCfits::PHDU& primary_hdu = fits->pHDU();
-  std::vector<long> image_size {2,2};
-  CCfits::ExtHDU* image_hdu = fits->addImage("Image", FLOAT_IMG, image_size);
-  CCfits::ExtHDU* table_hdu = addTable(*fits);
+  Elements::TempDir             temp_dir;
+  std::unique_ptr<CCfits::FITS> fits{new CCfits::FITS((temp_dir.path() / "FitsReader_test.fits").native(), CCfits::RWmode::Write)};
+  const CCfits::PHDU&           primary_hdu = fits->pHDU();
+  std::vector<long>             image_size{2, 2};
+  CCfits::ExtHDU*               image_hdu = fits->addImage("Image", FLOAT_IMG, image_size);
+  CCfits::ExtHDU*               table_hdu = addTable(*fits);
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (FitsReader_test)
+BOOST_AUTO_TEST_SUITE(FitsReader_test)
 
 //-----------------------------------------------------------------------------
 // Test the exception for duplicate column names
@@ -88,14 +88,13 @@ BOOST_AUTO_TEST_SUITE (FitsReader_test)
 BOOST_FIXTURE_TEST_CASE(DuplicateColumnNames, FitsReader_Fixture) {
 
   // Given
-  std::vector<std::string> names {"First", "Second", "Third", "Second"};
+  std::vector<std::string> names{"First", "Second", "Third", "Second"};
 
   // When
-  FitsReader reader {*table_hdu};
+  FitsReader reader{*table_hdu};
 
   // Then
   BOOST_CHECK_THROW(reader.fixColumnNames(names), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -105,14 +104,13 @@ BOOST_FIXTURE_TEST_CASE(DuplicateColumnNames, FitsReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(EmptyColumnNames, FitsReader_Fixture) {
 
   // Given
-  std::vector<std::string> names {"First", "Second", "", "Forth"};
+  std::vector<std::string> names{"First", "Second", "", "Forth"};
 
   // When
-  FitsReader reader {*table_hdu};
+  FitsReader reader{*table_hdu};
 
   // Then
   BOOST_CHECK_THROW(reader.fixColumnNames(names), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -122,14 +120,14 @@ BOOST_FIXTURE_TEST_CASE(EmptyColumnNames, FitsReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ColumnNamesWithWhitespaces, FitsReader_Fixture) {
 
   // Given
-  std::vector<std::string> space {"Sp ace"};
-  std::vector<std::string> tab {"T\tab"};
-  std::vector<std::string> carriage_return {"Carriage\rReturn"};
-  std::vector<std::string> new_line {"New\nLine"};
-  std::vector<std::string> new_page {"New\fPage"};
+  std::vector<std::string> space{"Sp ace"};
+  std::vector<std::string> tab{"T\tab"};
+  std::vector<std::string> carriage_return{"Carriage\rReturn"};
+  std::vector<std::string> new_line{"New\nLine"};
+  std::vector<std::string> new_page{"New\fPage"};
 
   // When
-  FitsReader reader {*table_hdu};
+  FitsReader reader{*table_hdu};
 
   // Then
   BOOST_CHECK_THROW(reader.fixColumnNames(space), Elements::Exception);
@@ -137,7 +135,6 @@ BOOST_FIXTURE_TEST_CASE(ColumnNamesWithWhitespaces, FitsReader_Fixture) {
   BOOST_CHECK_THROW(reader.fixColumnNames(carriage_return), Elements::Exception);
   BOOST_CHECK_THROW(reader.fixColumnNames(new_line), Elements::Exception);
   BOOST_CHECK_THROW(reader.fixColumnNames(new_page), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -147,13 +144,12 @@ BOOST_FIXTURE_TEST_CASE(ColumnNamesWithWhitespaces, FitsReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(readNonTable, FitsReader_Fixture) {
 
   // Given
-  FitsReader reader_primary {primary_hdu};
-  FitsReader reader_image {*image_hdu};
+  FitsReader reader_primary{primary_hdu};
+  FitsReader reader_image{*image_hdu};
 
   // Then
   BOOST_CHECK_THROW(reader_primary.read(), Elements::Exception);
   BOOST_CHECK_THROW(reader_image.read(), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -163,15 +159,14 @@ BOOST_FIXTURE_TEST_CASE(readNonTable, FitsReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ReadWrongColumnNamesNumber, FitsReader_Fixture) {
 
   // Given
-  std::vector<std::string> names {"First","Second"};
-  FitsReader reader {*table_hdu};
+  std::vector<std::string> names{"First", "Second"};
+  FitsReader               reader{*table_hdu};
 
   // When
   reader.fixColumnNames(names);
 
   // Then
   BOOST_CHECK_THROW(reader.read(), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -181,10 +176,10 @@ BOOST_FIXTURE_TEST_CASE(ReadWrongColumnNamesNumber, FitsReader_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ReadSuccess, FitsReader_Fixture) {
 
   // Given
-  FitsReader reader {*table_hdu};
+  FitsReader reader{*table_hdu};
 
   // When
-  auto table = reader.read();
+  auto  table       = reader.read();
   auto& column_info = reader.getInfo();
 
   // Then
@@ -209,14 +204,14 @@ BOOST_FIXTURE_TEST_CASE(ReadSuccess, FitsReader_Fixture) {
   BOOST_CHECK(column_info.getDescription(7).type == typeid(std::vector<double>));
   BOOST_CHECK(column_info.getDescription(8).type == typeid(NdArray<double>));
 
-  std::vector<std::string> units {"deg","mag","erg","ph","s","m","pc","count", "x", "x"};
-  for (size_t i=0; i < column_info.size(); ++i) {
-    BOOST_CHECK_EQUAL(column_info.getDescription(i).unit,  units[i]);
+  std::vector<std::string> units{"deg", "mag", "erg", "ph", "s", "m", "pc", "count", "x", "x"};
+  for (size_t i = 0; i < column_info.size(); ++i) {
+    BOOST_CHECK_EQUAL(column_info.getDescription(i).unit, units[i]);
   }
 
-  std::vector<std::string> descriptions {"Desc1","","Desc3","","Desc5","","Desc7","","Desc9", ""};
-  for (size_t i=0; i < column_info.size(); ++i) {
-    BOOST_CHECK_EQUAL(column_info.getDescription(i).description,  descriptions[i]);
+  std::vector<std::string> descriptions{"Desc1", "", "Desc3", "", "Desc5", "", "Desc7", "", "Desc9", ""};
+  for (size_t i = 0; i < column_info.size(); ++i) {
+    BOOST_CHECK_EQUAL(column_info.getDescription(i).description, descriptions[i]);
   }
 
   BOOST_CHECK_EQUAL(boost::get<bool>(table[0][0]), true);
@@ -249,14 +244,12 @@ BOOST_FIXTURE_TEST_CASE(ReadSuccess, FitsReader_Fixture) {
   auto ndarray = boost::get<NdArray<double>>(table[1][8]);
   BOOST_CHECK_EQUAL(ndarray.shape()[0], 2);
   BOOST_CHECK_EQUAL(ndarray.shape()[1], 3);
-  BOOST_CHECK_EQUAL(ndarray.at(0,0), 6);
-  BOOST_CHECK_EQUAL(ndarray.at(1,2), 1);
+  BOOST_CHECK_EQUAL(ndarray.at(0, 0), 6);
+  BOOST_CHECK_EQUAL(ndarray.at(1, 2), 1);
 
   BOOST_CHECK_EQUAL(reader.getComment(), "TEST COMMENT\nWITH LINES");
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/Table/tests/src/FitsWriterHelper_test.cpp
+++ b/Table/tests/src/FitsWriterHelper_test.cpp
@@ -1,55 +1,53 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file tests/src/FitsWriterHelper_test.cpp
  * @date April 23, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
 #include "ElementsKernel/Exception.h"
-#include "Table/Table.h"
 #include "Table/ColumnInfo.h"
 #include "Table/Row.h"
+#include "Table/Table.h"
 #include "src/lib/FitsWriterHelper.h"
+#include <boost/test/unit_test.hpp>
 
 struct FitsWriterHelper_Fixture {
-  std::vector<Euclid::Table::ColumnInfo::info_type> info_list {
-      Euclid::Table::ColumnInfo::info_type("Boolean", typeid(bool)),
-      Euclid::Table::ColumnInfo::info_type("Integer", typeid(int32_t)),
-      Euclid::Table::ColumnInfo::info_type("Long", typeid(int64_t)),
-      Euclid::Table::ColumnInfo::info_type("Float", typeid(float)),
-      Euclid::Table::ColumnInfo::info_type("Double", typeid(double)),
-      Euclid::Table::ColumnInfo::info_type("String", typeid(std::string))
-  };
-  std::shared_ptr<Euclid::Table::ColumnInfo> column_info {new Euclid::Table::ColumnInfo {info_list}};
-  std::vector<Euclid::Table::Row::cell_type> values0 {true, 1, int64_t{123}, 0.f, 0., std::string{"first"}};
-  Euclid::Table::Row row0 {values0, column_info};
-  std::vector<Euclid::Table::Row::cell_type> values1 {false, 12345, int64_t{123456789}, 2.3e-2f, 1.12345e-18, std::string{"second"}};
-  Euclid::Table::Row row1 {values1, column_info};
-  std::vector<Euclid::Table::Row> row_list {row0, row1};
-  Euclid::Table::Table table {row_list};
+  std::vector<Euclid::Table::ColumnInfo::info_type> info_list{Euclid::Table::ColumnInfo::info_type("Boolean", typeid(bool)),
+                                                              Euclid::Table::ColumnInfo::info_type("Integer", typeid(int32_t)),
+                                                              Euclid::Table::ColumnInfo::info_type("Long", typeid(int64_t)),
+                                                              Euclid::Table::ColumnInfo::info_type("Float", typeid(float)),
+                                                              Euclid::Table::ColumnInfo::info_type("Double", typeid(double)),
+                                                              Euclid::Table::ColumnInfo::info_type("String", typeid(std::string))};
+  std::shared_ptr<Euclid::Table::ColumnInfo>        column_info{new Euclid::Table::ColumnInfo{info_list}};
+  std::vector<Euclid::Table::Row::cell_type>        values0{true, 1, int64_t{123}, 0.f, 0., std::string{"first"}};
+  Euclid::Table::Row                                row0{values0, column_info};
+  std::vector<Euclid::Table::Row::cell_type> values1{false, 12345, int64_t{123456789}, 2.3e-2f, 1.12345e-18, std::string{"second"}};
+  Euclid::Table::Row                         row1{values1, column_info};
+  std::vector<Euclid::Table::Row>            row_list{row0, row1};
+  Euclid::Table::Table                       table{row_list};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (FitsWriterHelper_test)
+BOOST_AUTO_TEST_SUITE(FitsWriterHelper_test)
 
 //-----------------------------------------------------------------------------
 // Test the getAsciiFormatList method
@@ -68,7 +66,6 @@ BOOST_FIXTURE_TEST_CASE(getAsciiFormatList, FitsWriterHelper_Fixture) {
   BOOST_CHECK_EQUAL(format_list[3], "E12");
   BOOST_CHECK_EQUAL(format_list[4], "E12");
   BOOST_CHECK_EQUAL(format_list[5], "A6");
-
 }
 
 //-----------------------------------------------------------------------------
@@ -88,9 +85,8 @@ BOOST_FIXTURE_TEST_CASE(getBinaryFormatList, FitsWriterHelper_Fixture) {
   BOOST_CHECK_EQUAL(format_list[3], "E");
   BOOST_CHECK_EQUAL(format_list[4], "D");
   BOOST_CHECK_EQUAL(format_list[5], "6A");
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Table/tests/src/FitsWriter_test.cpp
+++ b/Table/tests/src/FitsWriter_test.cpp
@@ -22,64 +22,69 @@
  * @author nikoapos
  */
 
-#include <boost/test/unit_test.hpp>
-#include <CCfits/CCfits>
 #include "ElementsKernel/Temporary.h"
 #include "Table/FitsWriter.h"
+#include <CCfits/CCfits>
+#include <boost/test/unit_test.hpp>
 
 using namespace Euclid::Table;
 using namespace Euclid::NdArray;
 
 struct BinaryFitsWriter_Fixture {
-  std::vector<ColumnInfo::info_type> info_list {
-      ColumnInfo::info_type("Boolean", typeid(bool), "deg", "Desc1"),
-      ColumnInfo::info_type("Integer", typeid(int32_t), "mag", "Desc2"),
-      ColumnInfo::info_type("Long", typeid(int64_t), "", "Desc3"),
-      ColumnInfo::info_type("Float", typeid(float), "ph", "Desc4"),
-      ColumnInfo::info_type("Double", typeid(double), "s", "Desc5"),
-      ColumnInfo::info_type("String", typeid(std::string), "m", "Desc6"),
-      ColumnInfo::info_type("NdArray", typeid(NdArray<double>), "x", "Desc7"),
-      ColumnInfo::info_type("ScalarNdArray", typeid(NdArray<double>), "x", "Desc8")
-  };
-  std::shared_ptr<ColumnInfo> column_info {new ColumnInfo {info_list}};
-  std::vector<Row::cell_type> values0{true, 1, int64_t{123}, 0.F, 0., std::string{"first"},
+  std::vector<ColumnInfo::info_type> info_list{ColumnInfo::info_type("Boolean", typeid(bool), "deg", "Desc1"),
+                                               ColumnInfo::info_type("Integer", typeid(int32_t), "mag", "Desc2"),
+                                               ColumnInfo::info_type("Long", typeid(int64_t), "", "Desc3"),
+                                               ColumnInfo::info_type("Float", typeid(float), "ph", "Desc4"),
+                                               ColumnInfo::info_type("Double", typeid(double), "s", "Desc5"),
+                                               ColumnInfo::info_type("String", typeid(std::string), "m", "Desc6"),
+                                               ColumnInfo::info_type("NdArray", typeid(NdArray<double>), "x", "Desc7"),
+                                               ColumnInfo::info_type("ScalarNdArray", typeid(NdArray<double>), "x", "Desc8")};
+  std::shared_ptr<ColumnInfo>        column_info{new ColumnInfo{info_list}};
+  std::vector<Row::cell_type>        values0{true,
+                                      1,
+                                      int64_t{123},
+                                      0.F,
+                                      0.,
+                                      std::string{"first"},
                                       NdArray<double>({2, 3}, {1, 2, 3, 4, 5, 6}),
                                       NdArray<double>({1}, std::vector<double>{41.})};
-  Row row0 {values0, column_info};
-  std::vector<Row::cell_type> values1{false, 12345, int64_t{123456789}, 2.3e-2F, 1.12345e-18,
+  Row                                row0{values0, column_info};
+  std::vector<Row::cell_type>        values1{false,
+                                      12345,
+                                      int64_t{123456789},
+                                      2.3e-2F,
+                                      1.12345e-18,
                                       std::string{"second with spaces on top of that"},
-                                      NdArray<double>({ 2, 3 }, { 6, 5, 4, 3, 2, 1 }),
+                                      NdArray<double>({2, 3}, {6, 5, 4, 3, 2, 1}),
                                       NdArray<double>({1}, std::vector<double>{42.})};
-  Row row1 {values1, column_info};
-  std::vector<Row> row_list {row0, row1};
-  Table table {row_list};
-  Elements::TempDir temp_dir;
-  std::string fits_file_path = (temp_dir.path()/"FitsWriter_test.fits").native();
+  Row                                row1{values1, column_info};
+  std::vector<Row>                   row_list{row0, row1};
+  Table                              table{row_list};
+  Elements::TempDir                  temp_dir;
+  std::string                        fits_file_path = (temp_dir.path() / "FitsWriter_test.fits").native();
 };
 
 struct AsciiFitsWriter_Fixture {
-  std::vector<ColumnInfo::info_type> info_list {
-    ColumnInfo::info_type("Boolean", typeid(bool), "deg", "Desc1"),
-    ColumnInfo::info_type("Integer", typeid(int32_t), "mag", "Desc2"),
-    ColumnInfo::info_type("Long", typeid(int64_t), "", "Desc3"),
-    ColumnInfo::info_type("Float", typeid(float), "ph", "Desc4"),
-    ColumnInfo::info_type("Double", typeid(double), "s", "Desc5"),
-    ColumnInfo::info_type("String", typeid(std::string), "m", "Desc6")
-  };
-  std::shared_ptr<ColumnInfo> column_info {new ColumnInfo {info_list}};
-  std::vector<Row::cell_type> values0{true, 1, int64_t{123}, 0.F, 0., std::string{"first"}};
-  Row row0 {values0, column_info};
-  std::vector<Row::cell_type> values1{false, 12345, int64_t{123456789}, 2.3e-2F, 1.12345e-18, std::string{"very spaced"}};
-  Row row1 {values1, column_info};
-  std::vector<Row> row_list {row0, row1};
-  Table table {row_list};
-  Elements::TempDir temp_dir;
-  std::string fits_file_path = (temp_dir.path()/"FitsWriter_test.fits").native();
+  std::vector<ColumnInfo::info_type> info_list{ColumnInfo::info_type("Boolean", typeid(bool), "deg", "Desc1"),
+                                               ColumnInfo::info_type("Integer", typeid(int32_t), "mag", "Desc2"),
+                                               ColumnInfo::info_type("Long", typeid(int64_t), "", "Desc3"),
+                                               ColumnInfo::info_type("Float", typeid(float), "ph", "Desc4"),
+                                               ColumnInfo::info_type("Double", typeid(double), "s", "Desc5"),
+                                               ColumnInfo::info_type("String", typeid(std::string), "m", "Desc6")};
+  std::shared_ptr<ColumnInfo>        column_info{new ColumnInfo{info_list}};
+  std::vector<Row::cell_type>        values0{true, 1, int64_t{123}, 0.F, 0., std::string{"first"}};
+  Row                                row0{values0, column_info};
+  std::vector<Row::cell_type>        values1{false, 12345, int64_t{123456789}, 2.3e-2F, 1.12345e-18, std::string{"very spaced"}};
+  Row                                row1{values1, column_info};
+  std::vector<Row>                   row_list{row0, row1};
+  Table                              table{row_list};
+  Elements::TempDir                  temp_dir;
+  std::string                        fits_file_path = (temp_dir.path() / "FitsWriter_test.fits").native();
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (FitsWriter_test)
+BOOST_AUTO_TEST_SUITE(FitsWriter_test)
 
 //-----------------------------------------------------------------------------
 // Test the write Binary
@@ -88,14 +93,14 @@ BOOST_AUTO_TEST_SUITE (FitsWriter_test)
 BOOST_FIXTURE_TEST_CASE(writeBinary, BinaryFitsWriter_Fixture) {
 
   // Given
-  FitsWriter writer {fits_file_path};
+  FitsWriter writer{fits_file_path};
   writer.setFormat(FitsWriter::Format::BINARY);
   writer.setHduName("BinaryTable");
 
   // When
   writer.addData(table);
-  CCfits::FITS fits {fits_file_path, CCfits::RWmode::Read};
-  auto& result = fits.extension("BinaryTable");
+  CCfits::FITS fits{fits_file_path, CCfits::RWmode::Read};
+  auto&        result = fits.extension("BinaryTable");
   result.readAllKeys();
 
   // Then
@@ -138,7 +143,7 @@ BOOST_FIXTURE_TEST_CASE(writeBinary, BinaryFitsWriter_Fixture) {
   BOOST_CHECK_EQUAL(result.keyWord("TDESC7").value(tmp), "Desc7");
 
   // When
-  std::vector<bool> bool_data {};
+  std::vector<bool> bool_data{};
   result.column(1).read(bool_data, 1, 2);
 
   // Then
@@ -146,7 +151,7 @@ BOOST_FIXTURE_TEST_CASE(writeBinary, BinaryFitsWriter_Fixture) {
   BOOST_CHECK_EQUAL(bool_data[1], false);
 
   // When
-  std::vector<int32_t> int_data {};
+  std::vector<int32_t> int_data{};
   result.column(2).read(int_data, 1, 2);
 
   // Then
@@ -154,7 +159,7 @@ BOOST_FIXTURE_TEST_CASE(writeBinary, BinaryFitsWriter_Fixture) {
   BOOST_CHECK_EQUAL(int_data[1], 12345);
 
   // When
-  std::vector<int64_t> long_data {};
+  std::vector<int64_t> long_data{};
   result.column(3).read(long_data, 1, 2);
 
   // Then
@@ -162,7 +167,7 @@ BOOST_FIXTURE_TEST_CASE(writeBinary, BinaryFitsWriter_Fixture) {
   BOOST_CHECK_EQUAL(long_data[1], 123456789);
 
   // When
-  std::vector<float> float_data {};
+  std::vector<float> float_data{};
   result.column(4).read(float_data, 1, 2);
 
   // Then
@@ -170,7 +175,7 @@ BOOST_FIXTURE_TEST_CASE(writeBinary, BinaryFitsWriter_Fixture) {
   BOOST_CHECK_EQUAL(float_data[1], 2.3e-2F);
 
   // When
-  std::vector<double> double_data {};
+  std::vector<double> double_data{};
   result.column(5).read(double_data, 1, 2);
 
   // Then
@@ -178,7 +183,7 @@ BOOST_FIXTURE_TEST_CASE(writeBinary, BinaryFitsWriter_Fixture) {
   BOOST_CHECK_EQUAL(double_data[1], 1.12345e-18);
 
   // When
-  std::vector<std::string> string_data {};
+  std::vector<std::string> string_data{};
   result.column(6).read(string_data, 1, 2);
 
   // Then
@@ -214,14 +219,14 @@ BOOST_FIXTURE_TEST_CASE(writeBinary, BinaryFitsWriter_Fixture) {
 BOOST_FIXTURE_TEST_CASE(writeAscii, AsciiFitsWriter_Fixture) {
 
   // Given
-  FitsWriter writer {fits_file_path};
+  FitsWriter writer{fits_file_path};
   writer.setFormat(FitsWriter::Format::ASCII);
   writer.setHduName("AsciiTable");
 
   // When
   writer.addData(table);
-  CCfits::FITS fits {fits_file_path, CCfits::RWmode::Read};
-  auto& result = fits.extension("AsciiTable");
+  CCfits::FITS fits{fits_file_path, CCfits::RWmode::Read};
+  auto&        result = fits.extension("AsciiTable");
   result.readAllKeys();
 
   // Then
@@ -257,9 +262,8 @@ BOOST_FIXTURE_TEST_CASE(writeAscii, AsciiFitsWriter_Fixture) {
   BOOST_CHECK_EQUAL(result.keyWord("TDESC5").value(tmp), "Desc5");
   BOOST_CHECK_EQUAL(result.keyWord("TDESC6").value(tmp), "Desc6");
 
-
   // When
-  std::vector<int32_t> bool_data {};
+  std::vector<int32_t> bool_data{};
   result.column(1).read(bool_data, 1, 2);
 
   // Then
@@ -267,7 +271,7 @@ BOOST_FIXTURE_TEST_CASE(writeAscii, AsciiFitsWriter_Fixture) {
   BOOST_CHECK_EQUAL(bool_data[1], 0);
 
   // When
-  std::vector<int32_t> int_data {};
+  std::vector<int32_t> int_data{};
   result.column(2).read(int_data, 1, 2);
 
   // Then
@@ -275,7 +279,7 @@ BOOST_FIXTURE_TEST_CASE(writeAscii, AsciiFitsWriter_Fixture) {
   BOOST_CHECK_EQUAL(int_data[1], 12345);
 
   // When
-  std::vector<int64_t> long_data {};
+  std::vector<int64_t> long_data{};
   result.column(3).read(long_data, 1, 2);
 
   // Then
@@ -283,7 +287,7 @@ BOOST_FIXTURE_TEST_CASE(writeAscii, AsciiFitsWriter_Fixture) {
   BOOST_CHECK_EQUAL(long_data[1], 123456789);
 
   // When
-  std::vector<float> float_data {};
+  std::vector<float> float_data{};
   result.column(4).read(float_data, 1, 2);
 
   // Then
@@ -291,7 +295,7 @@ BOOST_FIXTURE_TEST_CASE(writeAscii, AsciiFitsWriter_Fixture) {
   BOOST_CHECK_EQUAL(float_data[1], 2.3e-2F);
 
   // When
-  std::vector<double> double_data {};
+  std::vector<double> double_data{};
   result.column(5).read(double_data, 1, 2);
 
   // Then
@@ -299,13 +303,12 @@ BOOST_FIXTURE_TEST_CASE(writeAscii, AsciiFitsWriter_Fixture) {
   BOOST_CHECK_CLOSE(double_data[1], 1.12345e-18, 0.001);
 
   // When
-  std::vector<std::string> string_data {};
+  std::vector<std::string> string_data{};
   result.column(6).read(string_data, 1, 2);
 
   // Then
   BOOST_CHECK_EQUAL(string_data[0], "first");
   BOOST_CHECK_EQUAL(string_data[1], "very spaced");
-
 }
 
 //-----------------------------------------------------------------------------
@@ -326,8 +329,8 @@ BOOST_FIXTURE_TEST_CASE(addExisting, BinaryFitsWriter_Fixture) {
   writer.addData(table);
 
   // Then
-  CCfits::FITS fits {fits_file_path, CCfits::RWmode::Read};
-  auto& result = fits.extension("BinaryTable");
+  CCfits::FITS fits{fits_file_path, CCfits::RWmode::Read};
+  auto&        result = fits.extension("BinaryTable");
   result.readAllKeys();
 
   BOOST_CHECK_EQUAL(result.rows(), 4);
@@ -336,6 +339,4 @@ BOOST_FIXTURE_TEST_CASE(addExisting, BinaryFitsWriter_Fixture) {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/Table/tests/src/Row_test.cpp
+++ b/Table/tests/src/Row_test.cpp
@@ -16,31 +16,30 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/Row_test.cpp
  * @date April 8, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
 #include "ElementsKernel/Exception.h"
 #include "Table/Row.h"
+#include <boost/test/unit_test.hpp>
 
 struct Row_Fixture {
-  std::vector<Euclid::Table::ColumnInfo::info_type> info_list {
+  std::vector<Euclid::Table::ColumnInfo::info_type> info_list{
       Euclid::Table::ColumnInfo::info_type("First", typeid(std::string)),
       Euclid::Table::ColumnInfo::info_type("Second", typeid(std::string)),
       Euclid::Table::ColumnInfo::info_type("Third", typeid(double)),
       Euclid::Table::ColumnInfo::info_type("Fourth", typeid(double)),
       Euclid::Table::ColumnInfo::info_type("Fifth", typeid(int)),
-      Euclid::Table::ColumnInfo::info_type("Sixth", typeid(std::vector<double>))
-  };
-  std::shared_ptr<Euclid::Table::ColumnInfo> column_info {new Euclid::Table::ColumnInfo {info_list}};
+      Euclid::Table::ColumnInfo::info_type("Sixth", typeid(std::vector<double>))};
+  std::shared_ptr<Euclid::Table::ColumnInfo> column_info{new Euclid::Table::ColumnInfo{info_list}};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (Row_test)
+BOOST_AUTO_TEST_SUITE(Row_test)
 
 //-----------------------------------------------------------------------------
 // Test the constructor throws an exception for wrong number of cell values
@@ -49,11 +48,10 @@ BOOST_AUTO_TEST_SUITE (Row_test)
 BOOST_FIXTURE_TEST_CASE(ConstructorWrongNumberOfValues, Row_Fixture) {
 
   // Given
-  std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, 3.};
+  std::vector<Euclid::Table::Row::cell_type> values{std::string{"One"}, std::string{"Two"}, 3.};
 
   // Then
   BOOST_CHECK_THROW(Euclid::Table::Row(values, column_info), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -63,12 +61,12 @@ BOOST_FIXTURE_TEST_CASE(ConstructorWrongNumberOfValues, Row_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ConstructorNullColumnInfo, Row_Fixture) {
 
   // Given
-  std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
-  std::shared_ptr<Euclid::Table::ColumnInfo> null_col_info {};
+  std::vector<Euclid::Table::Row::cell_type> values{std::string{"One"},           std::string{"Two"}, 3., 4., 5,
+                                                    std::vector<double>{6.1, 6.2}};
+  std::shared_ptr<Euclid::Table::ColumnInfo> null_col_info{};
 
   // Then
   BOOST_CHECK_THROW(Euclid::Table::Row(values, null_col_info), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -78,11 +76,11 @@ BOOST_FIXTURE_TEST_CASE(ConstructorNullColumnInfo, Row_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ConstructorWrongCellType, Row_Fixture) {
 
   // Given
-  std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, std::string{"Three"}, 4., 5, std::vector<double>{6.1, 6.2}};
+  std::vector<Euclid::Table::Row::cell_type> values{std::string{"One"},           std::string{"Two"}, std::string{"Three"}, 4., 5,
+                                                    std::vector<double>{6.1, 6.2}};
 
   // Then
   BOOST_CHECK_THROW(Euclid::Table::Row(values, column_info), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -92,11 +90,10 @@ BOOST_FIXTURE_TEST_CASE(ConstructorWrongCellType, Row_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ConstructorEmptyCellValue, Row_Fixture) {
 
   // Given
-  std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{""}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
+  std::vector<Euclid::Table::Row::cell_type> values{std::string{"One"}, std::string{""}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
 
   // Then
   BOOST_CHECK_THROW(Euclid::Table::Row(values, column_info), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -106,11 +103,16 @@ BOOST_FIXTURE_TEST_CASE(ConstructorEmptyCellValue, Row_Fixture) {
 BOOST_FIXTURE_TEST_CASE(ConstructorCellValueWithWhitespace, Row_Fixture) {
 
   // Given
-  std::vector<Euclid::Table::Row::cell_type> space {std::string{"One"}, std::string{"Sp ace"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
-  std::vector<Euclid::Table::Row::cell_type> tab {std::string{"One"}, std::string{"T\tab"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
-  std::vector<Euclid::Table::Row::cell_type> carriage_return {std::string{"One"}, std::string{"Carriage\rReturn"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
-  std::vector<Euclid::Table::Row::cell_type> new_line {std::string{"One"}, std::string{"New\nLine"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
-  std::vector<Euclid::Table::Row::cell_type> new_page {std::string{"One"}, std::string{"New\fPage"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
+  std::vector<Euclid::Table::Row::cell_type> space{std::string{"One"},           std::string{"Sp ace"}, 3., 4., 5,
+                                                   std::vector<double>{6.1, 6.2}};
+  std::vector<Euclid::Table::Row::cell_type> tab{std::string{"One"},           std::string{"T\tab"}, 3., 4., 5,
+                                                 std::vector<double>{6.1, 6.2}};
+  std::vector<Euclid::Table::Row::cell_type> carriage_return{
+      std::string{"One"}, std::string{"Carriage\rReturn"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
+  std::vector<Euclid::Table::Row::cell_type> new_line{std::string{"One"},           std::string{"New\nLine"}, 3., 4., 5,
+                                                      std::vector<double>{6.1, 6.2}};
+  std::vector<Euclid::Table::Row::cell_type> new_page{std::string{"One"},           std::string{"New\fPage"}, 3., 4., 5,
+                                                      std::vector<double>{6.1, 6.2}};
 
   // Then
   Euclid::Table::Row(space, column_info);
@@ -118,7 +120,6 @@ BOOST_FIXTURE_TEST_CASE(ConstructorCellValueWithWhitespace, Row_Fixture) {
   BOOST_CHECK_THROW(Euclid::Table::Row(carriage_return, column_info), Elements::Exception);
   BOOST_CHECK_THROW(Euclid::Table::Row(new_line, column_info), Elements::Exception);
   BOOST_CHECK_THROW(Euclid::Table::Row(new_page, column_info), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -128,15 +129,15 @@ BOOST_FIXTURE_TEST_CASE(ConstructorCellValueWithWhitespace, Row_Fixture) {
 BOOST_FIXTURE_TEST_CASE(getColumnInfo, Row_Fixture) {
 
   // Given
-  std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
-  Euclid::Table::Row row {values, column_info};
+  std::vector<Euclid::Table::Row::cell_type> values{std::string{"One"},           std::string{"Two"}, 3., 4., 5,
+                                                    std::vector<double>{6.1, 6.2}};
+  Euclid::Table::Row                         row{values, column_info};
 
   // When
   auto result = row.getColumnInfo();
 
   // Then
   BOOST_CHECK(*result == *column_info);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -146,15 +147,15 @@ BOOST_FIXTURE_TEST_CASE(getColumnInfo, Row_Fixture) {
 BOOST_FIXTURE_TEST_CASE(Size, Row_Fixture) {
 
   // Given
-  std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
-  Euclid::Table::Row row {values, column_info};
+  std::vector<Euclid::Table::Row::cell_type> values{std::string{"One"},           std::string{"Two"}, 3., 4., 5,
+                                                    std::vector<double>{6.1, 6.2}};
+  Euclid::Table::Row                         row{values, column_info};
 
   // When
   std::size_t size = row.size();
 
   // Then
   BOOST_CHECK_EQUAL(size, values.size());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -164,8 +165,9 @@ BOOST_FIXTURE_TEST_CASE(Size, Row_Fixture) {
 BOOST_FIXTURE_TEST_CASE(IndexBracketOperator, Row_Fixture) {
 
   // Given
-  std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
-  Euclid::Table::Row row {values, column_info};
+  std::vector<Euclid::Table::Row::cell_type> values{std::string{"One"},           std::string{"Two"}, 3., 4., 5,
+                                                    std::vector<double>{6.1, 6.2}};
+  Euclid::Table::Row                         row{values, column_info};
 
   // When
   Euclid::Table::Row::cell_type value0 = row[0];
@@ -183,7 +185,6 @@ BOOST_FIXTURE_TEST_CASE(IndexBracketOperator, Row_Fixture) {
   BOOST_CHECK_EQUAL(value4, values[4]);
   BOOST_CHECK_EQUAL(value5, values[5]);
   BOOST_CHECK_THROW(row[6], Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -193,8 +194,9 @@ BOOST_FIXTURE_TEST_CASE(IndexBracketOperator, Row_Fixture) {
 BOOST_FIXTURE_TEST_CASE(StringBracketOperator, Row_Fixture) {
 
   // Given
-  std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
-  Euclid::Table::Row row {values, column_info};
+  std::vector<Euclid::Table::Row::cell_type> values{std::string{"One"},           std::string{"Two"}, 3., 4., 5,
+                                                    std::vector<double>{6.1, 6.2}};
+  Euclid::Table::Row                         row{values, column_info};
 
   // When
   Euclid::Table::Row::cell_type value0 = row["First"];
@@ -212,7 +214,6 @@ BOOST_FIXTURE_TEST_CASE(StringBracketOperator, Row_Fixture) {
   BOOST_CHECK_EQUAL(value4, values[4]);
   BOOST_CHECK_EQUAL(value5, values[5]);
   BOOST_CHECK_THROW(row["None"], Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -222,9 +223,10 @@ BOOST_FIXTURE_TEST_CASE(StringBracketOperator, Row_Fixture) {
 BOOST_FIXTURE_TEST_CASE(Iterator, Row_Fixture) {
 
   // Given
-  std::vector<Euclid::Table::Row::cell_type> values {std::string{"One"}, std::string{"Two"}, 3., 4., 5, std::vector<double>{6.1, 6.2}};
-  Euclid::Table::Row row {values, column_info};
-  auto valuesIter = values.cbegin();
+  std::vector<Euclid::Table::Row::cell_type> values{std::string{"One"},           std::string{"Two"}, 3., 4., 5,
+                                                    std::vector<double>{6.1, 6.2}};
+  Euclid::Table::Row                         row{values, column_info};
+  auto                                       valuesIter = values.cbegin();
 
   // When
   for (auto cell : row) {
@@ -233,7 +235,6 @@ BOOST_FIXTURE_TEST_CASE(Iterator, Row_Fixture) {
     ++valuesIter;
   }
   BOOST_CHECK(valuesIter == values.cend());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -248,7 +249,7 @@ BOOST_FIXTURE_TEST_CASE(Copy, Row_Fixture) {
 
   // When
   Euclid::Table::Row::cell_type target_constructor{source};
-  target = source; // this will fail to compile if any of the cell_type variants can not be copy-assigned
+  target = source;  // this will fail to compile if any of the cell_type variants can not be copy-assigned
 
   // Then
   BOOST_CHECK(target == source);
@@ -257,4 +258,4 @@ BOOST_FIXTURE_TEST_CASE(Copy, Row_Fixture) {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Table/tests/src/TableWriter_test.cpp
+++ b/Table/tests/src/TableWriter_test.cpp
@@ -22,48 +22,41 @@
  * @author nikoapos
  */
 
-#include <boost/test/unit_test.hpp>
 #include "ElementsKernel/EnableGMock.h"
 #include "ElementsKernel/Exception.h"
 #include "Table/TableWriter.h"
+#include <boost/test/unit_test.hpp>
 
 using namespace Euclid::Table;
 using namespace testing;
 
 class MockTableWriter : public TableWriter {
-  
+
 public:
-  
   MOCK_METHOD1(addComment, void(const std::string&));
   MOCK_METHOD1(init, void(const Table&));
   MOCK_METHOD1(append, void(const Table&));
-  
 };
 
 struct TableWriter_Fixture {
-  
-  std::vector<ColumnInfo::info_type> info_list {
-      ColumnInfo::info_type("Column", typeid(int))
-  };
-  std::shared_ptr<ColumnInfo> column_info {new ColumnInfo {info_list}};
-  
-  Row row1 {{1}, column_info};
-  Table table1 {{row1}};
-  
-  Row row2 {{2}, column_info};
-  Table table2 {{row2}};
-  
-  Row row3 {{3}, column_info};
-  Table table3 {{row3}};
-  
-  std::vector<ColumnInfo::info_type> wrong_info_list {
-      ColumnInfo::info_type("WrongColumn", typeid(int))
-  };
-  std::shared_ptr<ColumnInfo> wrong_column_info {new ColumnInfo {wrong_info_list}};
-  
-  Row wrong_row {{4}, wrong_column_info};
-  Table wrong_table {{wrong_row}};
-  
+
+  std::vector<ColumnInfo::info_type> info_list{ColumnInfo::info_type("Column", typeid(int))};
+  std::shared_ptr<ColumnInfo>        column_info{new ColumnInfo{info_list}};
+
+  Row   row1{{1}, column_info};
+  Table table1{{row1}};
+
+  Row   row2{{2}, column_info};
+  Table table2{{row2}};
+
+  Row   row3{{3}, column_info};
+  Table table3{{row3}};
+
+  std::vector<ColumnInfo::info_type> wrong_info_list{ColumnInfo::info_type("WrongColumn", typeid(int))};
+  std::shared_ptr<ColumnInfo>        wrong_column_info{new ColumnInfo{wrong_info_list}};
+
+  Row   wrong_row{{4}, wrong_column_info};
+  Table wrong_table{{wrong_row}};
 };
 
 MATCHER_P(ColumnInfoFirstName, expected, "") {
@@ -76,27 +69,26 @@ MATCHER_P(TableFirstValue, expected, "") {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (TableWriter_test)
+BOOST_AUTO_TEST_SUITE(TableWriter_test)
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(addDataSuccess_test, TableWriter_Fixture) {
 
   // Given
-  MockTableWriter writer {};
-  
+  MockTableWriter writer{};
+
   // Expect
   InSequence dummy;
   EXPECT_CALL(writer, init(ColumnInfoFirstName("Column"))).Times(1);
   EXPECT_CALL(writer, append(TableFirstValue(1))).Times(1);
   EXPECT_CALL(writer, append(TableFirstValue(2))).Times(1);
   EXPECT_CALL(writer, append(TableFirstValue(3))).Times(1);
-  
+
   // When
   writer.addData(table1);
   writer.addData(table2);
   writer.addData(table3);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -104,23 +96,20 @@ BOOST_FIXTURE_TEST_CASE(addDataSuccess_test, TableWriter_Fixture) {
 BOOST_FIXTURE_TEST_CASE(addDataWrongColumn_test, TableWriter_Fixture) {
 
   // Given
-  MockTableWriter writer {};
-  
+  MockTableWriter writer{};
+
   // Expect
   InSequence dummy;
   EXPECT_CALL(writer, init(ColumnInfoFirstName("Column"))).Times(1);
   EXPECT_CALL(writer, append(TableFirstValue(1))).Times(1);
-  
+
   // When
   writer.addData(table1);
-  
+
   // Then
   BOOST_CHECK_THROW(writer.addData(wrong_table), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/Table/tests/src/Table_test.cpp
+++ b/Table/tests/src/Table_test.cpp
@@ -1,70 +1,66 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /** 
+
+/**
  * @file tests/src/Table_test.cpp
  * @date April 9, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <boost/test/unit_test.hpp>
 #include "ElementsKernel/Exception.h"
 #include "Table/Table.h"
+#include <boost/test/unit_test.hpp>
 
 struct Table_Fixture {
-  std::vector<Euclid::Table::ColumnInfo::info_type> info_list {
-      Euclid::Table::ColumnInfo::info_type("First", typeid(std::string)),
-      Euclid::Table::ColumnInfo::info_type("Second", typeid(std::string)),
-      Euclid::Table::ColumnInfo::info_type("Third", typeid(double)),
-      Euclid::Table::ColumnInfo::info_type("Fourth", typeid(double)),
-      Euclid::Table::ColumnInfo::info_type("Fifth", typeid(int))
-  };
-  std::shared_ptr<Euclid::Table::ColumnInfo> column_info {new Euclid::Table::ColumnInfo {info_list}};
-  std::vector<Euclid::Table::Row::cell_type> values0 {std::string{"One-1"}, std::string{"Two-1"}, 3.1, 4.1, 51};
-  Euclid::Table::Row row0 {values0, column_info};
-  std::vector<Euclid::Table::Row::cell_type> values1 {std::string{"One-2"}, std::string{"Two-2"}, 3.2, 4.2, 52};
-  Euclid::Table::Row row1 {values1, column_info};
-  std::vector<Euclid::Table::Row::cell_type> values2 {std::string{"One-3"}, std::string{"Two-3"}, 3.3, 4.3, 53};
-  Euclid::Table::Row row2 {values2, column_info};
-  std::vector<Euclid::Table::Row> row_list {row0, row1, row2};
+  std::vector<Euclid::Table::ColumnInfo::info_type> info_list{Euclid::Table::ColumnInfo::info_type("First", typeid(std::string)),
+                                                              Euclid::Table::ColumnInfo::info_type("Second", typeid(std::string)),
+                                                              Euclid::Table::ColumnInfo::info_type("Third", typeid(double)),
+                                                              Euclid::Table::ColumnInfo::info_type("Fourth", typeid(double)),
+                                                              Euclid::Table::ColumnInfo::info_type("Fifth", typeid(int))};
+  std::shared_ptr<Euclid::Table::ColumnInfo>        column_info{new Euclid::Table::ColumnInfo{info_list}};
+  std::vector<Euclid::Table::Row::cell_type>        values0{std::string{"One-1"}, std::string{"Two-1"}, 3.1, 4.1, 51};
+  Euclid::Table::Row                                row0{values0, column_info};
+  std::vector<Euclid::Table::Row::cell_type>        values1{std::string{"One-2"}, std::string{"Two-2"}, 3.2, 4.2, 52};
+  Euclid::Table::Row                                row1{values1, column_info};
+  std::vector<Euclid::Table::Row::cell_type>        values2{std::string{"One-3"}, std::string{"Two-3"}, 3.3, 4.3, 53};
+  Euclid::Table::Row                                row2{values2, column_info};
+  std::vector<Euclid::Table::Row>                   row_list{row0, row1, row2};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (ColumnInfo_test)
+BOOST_AUTO_TEST_SUITE(ColumnInfo_test)
 
 //-----------------------------------------------------------------------------
 // Test the constructor throws an exception if any row has different column info
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(ConstructorDifferentColumnInfo, Table_Fixture) {
-  
+
   // Given
-  std::vector<Euclid::Table::ColumnInfo::info_type> wrong_info_list {
-      Euclid::Table::ColumnInfo::info_type("First", typeid(std::string))
-  };
-  std::shared_ptr<Euclid::Table::ColumnInfo> wrong_column_info {new Euclid::Table::ColumnInfo(wrong_info_list)};
-  Euclid::Table::Row wrong_row ({std::string{"Test"}}, wrong_column_info);
-  std::vector<Euclid::Table::Row> wrong_row_list {row_list.cbegin(), row_list.cend()};
+  std::vector<Euclid::Table::ColumnInfo::info_type> wrong_info_list{
+      Euclid::Table::ColumnInfo::info_type("First", typeid(std::string))};
+  std::shared_ptr<Euclid::Table::ColumnInfo> wrong_column_info{new Euclid::Table::ColumnInfo(wrong_info_list)};
+  Euclid::Table::Row                         wrong_row({std::string{"Test"}}, wrong_column_info);
+  std::vector<Euclid::Table::Row>            wrong_row_list{row_list.cbegin(), row_list.cend()};
   wrong_row_list.push_back(wrong_row);
-  
+
   BOOST_CHECK_THROW(Euclid::Table::Table{wrong_row_list}, Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -72,12 +68,11 @@ BOOST_FIXTURE_TEST_CASE(ConstructorDifferentColumnInfo, Table_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(ConstructorNoRows, Table_Fixture) {
-  
+
   // Given
-  std::vector<Euclid::Table::Row> wrong_row_list {};
-  
+  std::vector<Euclid::Table::Row> wrong_row_list{};
+
   BOOST_CHECK_THROW(Euclid::Table::Table{wrong_row_list}, Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -85,16 +80,15 @@ BOOST_FIXTURE_TEST_CASE(ConstructorNoRows, Table_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(getColumnInfo, Table_Fixture) {
-  
+
   // Given
   Euclid::Table::Table table{row_list};
-  
+
   // When
   auto result = table.getColumnInfo();
-  
+
   // Then
   BOOST_CHECK(*result == *column_info);
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -102,16 +96,15 @@ BOOST_FIXTURE_TEST_CASE(getColumnInfo, Table_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(size, Table_Fixture) {
-  
+
   // Given
   Euclid::Table::Table table{row_list};
-  
+
   // When
   std::size_t size_test_value = table.size();
-  
+
   // Then
   BOOST_CHECK_EQUAL(size_test_value, row_list.size());
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -119,23 +112,22 @@ BOOST_FIXTURE_TEST_CASE(size, Table_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(BracketOperator, Table_Fixture) {
-  
+
   // Given
   Euclid::Table::Table table{row_list};
-  
+
   // When
   auto result0 = table[0];
   auto result1 = table[1];
   auto result2 = table[2];
-  
+
   // Then
-  for(std::size_t i=0; i<column_info->size(); ++i) {
+  for (std::size_t i = 0; i < column_info->size(); ++i) {
     BOOST_CHECK_EQUAL(result0[i], row0[i]);
     BOOST_CHECK_EQUAL(result1[i], row1[i]);
     BOOST_CHECK_EQUAL(result2[i], row2[i]);
   }
   BOOST_CHECK_THROW(table[3], Elements::Exception);
-  
 }
 
 //-----------------------------------------------------------------------------
@@ -143,23 +135,22 @@ BOOST_FIXTURE_TEST_CASE(BracketOperator, Table_Fixture) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Iterator, Table_Fixture) {
-  
+
   // Given
   Euclid::Table::Table table{row_list};
-  auto rows_iter = row_list.cbegin();
-  
+  auto                 rows_iter = row_list.cbegin();
+
   // When
   for (auto row : table) {
     // Then
-    for(std::size_t i=0; i<column_info->size(); ++i) {
+    for (std::size_t i = 0; i < column_info->size(); ++i) {
       BOOST_CHECK_EQUAL(row[i], (*rows_iter)[i]);
     }
     ++rows_iter;
   }
   BOOST_CHECK(rows_iter == row_list.cend());
-  
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/XYDataset/XYDataset/AsciiParser.h
+++ b/XYDataset/XYDataset/AsciiParser.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file XYDataset/AsciiParser.h
  *
  * @date Apr 14, 2014
@@ -28,9 +28,8 @@
 
 #include "ElementsKernel/Export.h"
 
-#include "XYDataset/XYDataset.h"
 #include "XYDataset/FileParser.h"
-
+#include "XYDataset/XYDataset.h"
 
 namespace Euclid {
 namespace XYDataset {
@@ -51,10 +50,8 @@ namespace XYDataset {
  * @throw
  * ElementException : File not found
  */
-class ELEMENTS_API AsciiParser : public FileParser
-{
- public:
-
+class ELEMENTS_API AsciiParser : public FileParser {
+public:
   /**
    * @brief Constructor
    * Tool for reading ASCII tables from streams
@@ -62,7 +59,7 @@ class ELEMENTS_API AsciiParser : public FileParser
    * The regex for extracting the dataset name. The default is defined as
    * "^\\s*#\\s*(\\w+)\\s*$".
    */
-  explicit AsciiParser(const std::string& regex_str="^\\s*#\\s*(\\w+)\\s*$") : FileParser(), m_regex_name(regex_str) {}
+  explicit AsciiParser(const std::string& regex_str = "^\\s*#\\s*(\\w+)\\s*$") : FileParser(), m_regex_name(regex_str) {}
 
   /**
    * @brief
@@ -84,21 +81,21 @@ class ELEMENTS_API AsciiParser : public FileParser
   std::string getName(const std::string& file) override;
 
   /**
-  * @brief
-  * Get the parameter identified by a given key_word value from a file
-  * @details
-  * This function gets the the parameter if present in the fits HDU keyword.
-  * Return an empty string if the key word is not present.
-  * @param file
-  * Filename of the file to be read including absolute path
-  * @param key_word
-  * key word identifying the parameter
-  * @return
-  * The name of the datatset
-  * @throw
-  * ElementException : File not found
-  */
- std::string getParameter(const std::string& file, const std::string& key_word) override;
+   * @brief
+   * Get the parameter identified by a given key_word value from a file
+   * @details
+   * This function gets the the parameter if present in the fits HDU keyword.
+   * Return an empty string if the key word is not present.
+   * @param file
+   * Filename of the file to be read including absolute path
+   * @param key_word
+   * key word identifying the parameter
+   * @return
+   * The name of the datatset
+   * @throw
+   * ElementException : File not found
+   */
+  std::string getParameter(const std::string& file, const std::string& key_word) override;
 
   /**
    * @brief
@@ -114,31 +111,27 @@ class ELEMENTS_API AsciiParser : public FileParser
   std::unique_ptr<XYDataset> getDataset(const std::string& file) override;
 
   /**
-    * @brief
-    * Check that the ASCII file is a dataset file(with at least one line with
-    * 2 double values)
-    * @details
-    * This checking should avoid reading any files which do not contain
-    * any dataset.
-    * @param file
-    * Filename of the FITS file to be read including the absolute path.
-    * @return
-    * true if it is a FITS file with dataset(at least with one HDU table)
-    */
+   * @brief
+   * Check that the ASCII file is a dataset file(with at least one line with
+   * 2 double values)
+   * @details
+   * This checking should avoid reading any files which do not contain
+   * any dataset.
+   * @param file
+   * Filename of the FITS file to be read including the absolute path.
+   * @return
+   * true if it is a FITS file with dataset(at least with one HDU table)
+   */
   bool isDatasetFile(const std::string& file) override;
 
   /// Default destructor
   virtual ~AsciiParser() = default;
 
- private:
-
+private:
   std::string m_regex_name;
-
 };
 
 } /* namespace XYDataset */
-} // end of namespace Euclid
+}  // end of namespace Euclid
 
-
-
-#endif // ASCIIPARSER_H_
+#endif  // ASCIIPARSER_H_

--- a/XYDataset/XYDataset/CachedProvider.h
+++ b/XYDataset/XYDataset/CachedProvider.h
@@ -28,8 +28,8 @@
 #include <string>
 
 #include "ElementsKernel/Export.h"
-#include "XYDatasetProvider.h"
 #include "QualifiedName.h"
+#include "XYDatasetProvider.h"
 
 namespace Euclid {
 namespace XYDataset {
@@ -41,10 +41,9 @@ namespace XYDataset {
  * the results, so following calls are cheaper.
  *
  */
-class ELEMENTS_API CachedProvider: public XYDatasetProvider {
+class ELEMENTS_API CachedProvider : public XYDatasetProvider {
 
 public:
-
   /**
    * @brief Destructor
    */
@@ -86,12 +85,11 @@ public:
    */
   std::unique_ptr<XYDataset> getDataset(const QualifiedName& qualified_name) override;
 
-
   std::string getParameter(const QualifiedName& qualified_name, const std::string& key_word) override;
 
 private:
-  std::shared_ptr<XYDatasetProvider> m_provider;
-  std::map<std::string, std::vector<QualifiedName>> m_list_cache;
+  std::shared_ptr<XYDatasetProvider>                  m_provider;
+  std::map<std::string, std::vector<QualifiedName>>   m_list_cache;
   std::map<QualifiedName, std::unique_ptr<XYDataset>> m_dataset;
 
 };  // End of CachedProvider class

--- a/XYDataset/XYDataset/FileParser.h
+++ b/XYDataset/XYDataset/FileParser.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file XYDataset/FileParser.h
  *
  * @date Apr 11, 2014
@@ -39,10 +39,8 @@ namespace XYDataset {
  * the data itself stored into a XYDataset object.
  */
 
-class FileParser
-{
- public:
-
+class FileParser {
+public:
   /**
    * @brief
    * Get the dataset name or identifier from a file
@@ -51,47 +49,45 @@ class FileParser
    * @return
    * A dataset name
    */
-   virtual std::string getName(const std::string& file) = 0;
+  virtual std::string getName(const std::string& file) = 0;
 
-   /**
-    * @brief
-    * Get the parameter identified by a given key_word value from a file
-    * @param file
-    * Filename including absolute path
-    * @param key_word
-    * key word identifying the parameter
-    * @return
-    * A dataset name
-    */
-   virtual std::string getParameter(const std::string& file, const std::string& key_word)= 0;
+  /**
+   * @brief
+   * Get the parameter identified by a given key_word value from a file
+   * @param file
+   * Filename including absolute path
+   * @param key_word
+   * key word identifying the parameter
+   * @return
+   * A dataset name
+   */
+  virtual std::string getParameter(const std::string& file, const std::string& key_word) = 0;
 
-   /**
-    * @brief
-    * Get the dataset from a file
-    * @param file
-    * Filename including absolute path
-    * @return
-    * A unique pointer of a XYDataset object or a null pointer
-    */
-   virtual std::unique_ptr<XYDataset> getDataset(const std::string& file) = 0;
+  /**
+   * @brief
+   * Get the dataset from a file
+   * @param file
+   * Filename including absolute path
+   * @return
+   * A unique pointer of a XYDataset object or a null pointer
+   */
+  virtual std::unique_ptr<XYDataset> getDataset(const std::string& file) = 0;
 
-   /**
-    * @brief
-    * Check that we are in presence of a dataset file
-    * @param file
-    * Filename including the absolute path
-    * @return
-    * true: it is file containing datasets
-    */
-   virtual bool isDatasetFile(const std::string& file) = 0;
+  /**
+   * @brief
+   * Check that we are in presence of a dataset file
+   * @param file
+   * Filename including the absolute path
+   * @return
+   * true: it is file containing datasets
+   */
+  virtual bool isDatasetFile(const std::string& file) = 0;
 
-   /// Default destructor
-   virtual ~FileParser() = default;
-
+  /// Default destructor
+  virtual ~FileParser() = default;
 };
 
 } /* namespace XYDataset */
-} // end of namespace Euclid
+}  // end of namespace Euclid
 
-
-#endif // FILEPARSER_H_ 
+#endif  // FILEPARSER_H_

--- a/XYDataset/XYDataset/FileSystemProvider.h
+++ b/XYDataset/XYDataset/FileSystemProvider.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file XYDataset/FileSystemProvider.h
  *
  * @date Apr 11, 2014
@@ -26,17 +26,16 @@
 #ifndef FILESYSTEMPROVIDER_H_
 #define FILESYSTEMPROVIDER_H_
 
-
-#include <memory>
-#include <vector>
-#include <string>
 #include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "ElementsKernel/Export.h"
 
+#include "XYDataset/FileParser.h"
 #include "XYDataset/XYDataset.h"
 #include "XYDataset/XYDatasetProvider.h"
-#include "XYDataset/FileParser.h"
 
 namespace Euclid {
 namespace XYDataset {
@@ -55,10 +54,8 @@ namespace XYDataset {
  * operations (it gets dataset name and data).
  */
 
-class ELEMENTS_API FileSystemProvider : public XYDatasetProvider
-{
- public:
-
+class ELEMENTS_API FileSystemProvider : public XYDatasetProvider {
+public:
   /**
    * @brief constructor
    * The FileSystemProvider handles files in a directory tree.
@@ -117,15 +114,12 @@ class ELEMENTS_API FileSystemProvider : public XYDatasetProvider
    */
   std::vector<QualifiedName> listContents(const std::string& group) override;
 
-
-
   std::string getParameter(const QualifiedName& qualified_name, const std::string& key_word) override;
 
   // Default destructor
   ~FileSystemProvider() = default;
 
- private:
-
+private:
   std::string                          m_root_path;
   std::unique_ptr<FileParser>          m_parser;
   std::map<QualifiedName, std::string> m_name_file_map;
@@ -133,6 +127,6 @@ class ELEMENTS_API FileSystemProvider : public XYDatasetProvider
 };
 
 } /* namespace XYDataset */
-} // end of namespace Euclid
+}  // end of namespace Euclid
 
-#endif // FILESYSTEMPROVIDER_H_
+#endif  // FILESYSTEMPROVIDER_H_

--- a/XYDataset/XYDataset/FitsParser.h
+++ b/XYDataset/XYDataset/FitsParser.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file XYDataset/FitsParser.h
  *
  * @date Apr 14, 2014
@@ -28,8 +28,8 @@
 
 #include "ElementsKernel/Export.h"
 
-#include "XYDataset/XYDataset.h"
 #include "XYDataset/FileParser.h"
+#include "XYDataset/XYDataset.h"
 
 namespace Euclid {
 namespace XYDataset {
@@ -48,10 +48,8 @@ namespace XYDataset {
  * not exist, the dataset name is extracted from the FITS filename itself
  * removing the path and extension (.fits).
  */
-class ELEMENTS_API FitsParser : public FileParser
-{
- public:
-
+class ELEMENTS_API FitsParser : public FileParser {
+public:
   /**
    * @brief Constructor
    * Tool for reading FITS tables from streams
@@ -78,7 +76,7 @@ class ELEMENTS_API FitsParser : public FileParser
    */
   std::string getName(const std::string& file) override;
 
-   /**
+  /**
    * @brief
    * Get the parameter identified by a given key_word value from a file
    * @details
@@ -124,16 +122,12 @@ class ELEMENTS_API FitsParser : public FileParser
    */
   bool isDatasetFile(const std::string& file) override;
 
- private:
-
+private:
   // keyword name of the dataset
   std::string m_name_keyword;
-
 };
 
 } /* namespace XYDataset */
-} // end of namespace Euclid
+}  // end of namespace Euclid
 
-
-
-#endif // FITSPARSER_H_
+#endif  // FITSPARSER_H_

--- a/XYDataset/XYDataset/QualifiedName.h
+++ b/XYDataset/XYDataset/QualifiedName.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file XYDataset/QualifiedName.h
  * @date May 19, 2014
  * @author Nikolaos Apostolakos
@@ -25,10 +25,10 @@
 #ifndef PHZDATAMODEL_QUALIFIEDNAME_H
 #define PHZDATAMODEL_QUALIFIEDNAME_H
 
-#include <string>
-#include <vector>
 #include <functional>
 #include <iostream>
+#include <string>
+#include <vector>
 
 #include "ElementsKernel/Export.h"
 
@@ -66,7 +66,6 @@ namespace XYDataset {
 class ELEMENTS_API QualifiedName {
 
 public:
-
   /**
    * @brief
    * Constructs a QualifiedName with the given group and name
@@ -90,7 +89,7 @@ public:
    * @throws Elements::Exception
    *    if the given string is an invalid qualified name
    */
-  QualifiedName(const std::string& );
+  QualifiedName(const std::string&);
 
   /**
    * @brief Copy constructor
@@ -101,12 +100,12 @@ public:
    * @brief Copy assignment operator
    * @return A reference to the QualifiedName which was copied to
    */
-  QualifiedName& operator=(const QualifiedName& ) = default;
+  QualifiedName& operator=(const QualifiedName&) = default;
 
   /**
    * @brief Move constructor
    */
-  QualifiedName(QualifiedName&& ) = default;
+  QualifiedName(QualifiedName&&) = default;
 
   /**
    * @brief Move assignment operator
@@ -196,21 +195,18 @@ public:
   };
 
 private:
-
   std::vector<std::string> m_groups;
-  std::string m_dataset_name;
-  std::string m_qualified_name;
-  mutable size_t m_hash {0};
+  std::string              m_dataset_name;
+  std::string              m_qualified_name;
+  mutable size_t           m_hash{0};
 
-}; // class QualifiedName
-
+};  // class QualifiedName
 
 /// Make the QualifiedName streamable
 std::ostream& operator<<(std::ostream& stream, const QualifiedName& qualified_name);
 
-
-} // namespace XYDataset
-} // end of namespace Euclid
+}  // namespace XYDataset
+}  // end of namespace Euclid
 
 namespace std {
 
@@ -230,6 +226,6 @@ struct hash<Euclid::XYDataset::QualifiedName> {
   }
 };
 
-} // namespace std
+}  // namespace std
 
-#endif // PHZDATAMODEL_QUALIFIEDNAME_H
+#endif  // PHZDATAMODEL_QUALIFIEDNAME_H

--- a/XYDataset/XYDataset/XYDataset.h
+++ b/XYDataset/XYDataset/XYDataset.h
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file XYDataset/XYDataset.h
  *
  * @date Apr 8, 2014
@@ -26,11 +26,11 @@
 #ifndef XYDATASET_H_
 #define XYDATASET_H_
 
-#include <memory>
-#include <vector>
-#include <string>
 #include <iterator>
+#include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "ElementsKernel/Export.h"
 
@@ -56,110 +56,105 @@ namespace XYDataset {
  * ElementException :  Vectors must have the same size!
  */
 
- class ELEMENTS_API XYDataset
- {
+class ELEMENTS_API XYDataset {
 
- public:
+public:
+  typedef std::vector<std::pair<double, double>>::const_iterator const_iterator;
 
-   typedef std::vector<std::pair<double, double>>::const_iterator const_iterator;
+  /**
+   * @brief Constructor
+   * XYDataset interface represents an immutable data set
+   *
+   * @details
+   * XYDataset interface represents an immutable data set, where both X and Y axes contain double values.
+   * It provides iterators both for the (X,Y) pairs and for the axes values independently.
+   *
+   * @param values
+   * A vector of pair of doubles
+   *
+   */
+  XYDataset(std::vector<std::pair<double, double>> values) : m_values(std::move(values)){};
 
-   /**
-    * @brief Constructor
-    * XYDataset interface represents an immutable data set
-    *
-    * @details
-    * XYDataset interface represents an immutable data set, where both X and Y axes contain double values.
-    * It provides iterators both for the (X,Y) pairs and for the axes values independently.
-    *
-    * @param values
-    * A vector of pair of doubles
-    *
-    */
-   XYDataset(std::vector<std::pair<double, double>> values)
-             : m_values(std::move(values)) {  };
+  /// Copy constructor
+  XYDataset(const XYDataset&) = default;
 
-   /// Copy constructor
-   XYDataset(const XYDataset&) = default;
+  /// Move constructor
+  XYDataset(XYDataset&&) = default;
 
-   /// Move constructor
-   XYDataset(XYDataset&&) = default;
+  /**
+   * @brief
+   * Make a XYDataset object from a vector of pair of doubles
+   * @param vector_pair
+   * A vector of pair of doubles
+   * @return
+   * A unique pointer of XYDataset type
+   */
+  static XYDataset factory(std::vector<std::pair<double, double>> vector_pair);
 
-   /**
-    * @brief
-    * Make a XYDataset object from a vector of pair of doubles
-    * @param vector_pair
-    * A vector of pair of doubles
-     * @return
-    * A unique pointer of XYDataset type
-    */
-   static XYDataset factory(std::vector<std::pair<double, double>> vector_pair);
+  /**
+   * @brief
+   * Make a XYDataset object from two vectors of doubles
+   * @param x
+   * A vector of double values
+   * @param y
+   * A vector of double values
+   * @return
+   * A unique pointer of XYDataset type
+   */
+  static XYDataset factory(const std::vector<double>& x, const std::vector<double>& y);
 
-   /**
-    * @brief
-    * Make a XYDataset object from two vectors of doubles
-    * @param x
-    * A vector of double values
-    * @param y
-    * A vector of double values
-     * @return
-    * A unique pointer of XYDataset type
-    */
-   static XYDataset factory(const std::vector<double>& x, const std::vector<double>& y);
+  /**
+   * @brief Destructor
+   */
+  virtual ~XYDataset() = default;
 
-   /**
-    * @brief Destructor
-    */
-   virtual ~XYDataset() = default;
+  /**
+   * @brief
+   * Returns a const iterator to the first pair of the dataset
+   * @return
+   * An iterator to the first pair
+   */
+  const_iterator begin() const;
 
-   /**
-    * @brief
-    * Returns a const iterator to the first pair of the dataset
-    * @return
-    * An iterator to the first pair
-    */
-   const_iterator begin() const;
+  /**
+   * @brief
+   * Returns a const iterator to the one after last pair dataset
+   * @return
+   * An iterator to the last pair dataset
+   */
+  const_iterator end() const;
 
-   /**
-    * @brief
-    * Returns a const iterator to the one after last pair dataset
-    * @return
-    * An iterator to the last pair dataset
-    */
-   const_iterator end() const;
+  /**
+   * @brief
+   * Returns a reference to the first pair of the dataset
+   * @return
+   * A reference to the first pair of the dataset
+   */
+  const std::pair<double, double>& front() const;
 
-   /**
-    * @brief
-    * Returns a reference to the first pair of the dataset
-    * @return
-    * A reference to the first pair of the dataset
-    */
-   const std::pair<double, double>& front() const;
+  /**
+   * @brief
+   * Returns a reference to the last pair of the dataset
+   * @return
+   * A reference to the last pair of the dataset
+   */
+  const std::pair<double, double>& back() const;
 
-   /**
-    * @brief
-    * Returns a reference to the last pair of the dataset
-    * @return
-    * A reference to the last pair of the dataset
-    */
-   const std::pair<double, double>& back() const;
+  /**
+   * @brief
+   *  Get the size of the vector container
+   * @return
+   *  The size of the container which is the number of Source objects
+   */
+  size_t size() const {
+    return m_values.size();
+  }
 
-   /**
-    * @brief
-    *  Get the size of the vector container
-    * @return
-    *  The size of the container which is the number of Source objects
-    */
-   size_t size() const { return m_values.size(); }
-
- private:
-
-   std::vector<std::pair<double, double>> m_values { };
-
- };
+private:
+  std::vector<std::pair<double, double>> m_values{};
+};
 
 } /* namespace XYDataset */
-} // end of namespace Euclid
+}  // end of namespace Euclid
 
-
-
-#endif // XYDATASET_H_
+#endif  // XYDATASET_H_

--- a/XYDataset/XYDataset/XYDatasetProvider.h
+++ b/XYDataset/XYDataset/XYDatasetProvider.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file XYDataset/XYDatasetProvider.h
  *
  * @date Apr 10, 2014
@@ -26,11 +26,11 @@
 #ifndef XYDATASETPROVIDER_H_
 #define XYDATASETPROVIDER_H_
 
-#include <memory>
-#include <vector>
-#include <string>
-#include "XYDataset/XYDataset.h"
 #include "XYDataset/QualifiedName.h"
+#include "XYDataset/XYDataset.h"
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace Euclid {
 namespace XYDataset {
@@ -46,9 +46,8 @@ namespace XYDataset {
  * getDatatset function gets from a qualified name the dataset of a XYDataset type.
  */
 
-class XYDatasetProvider
-{
- public:
+class XYDatasetProvider {
+public:
   /**
    * @brief
    * Virtual function to list all files contents in the "group" path
@@ -70,10 +69,9 @@ class XYDatasetProvider
    * @return
    * A vector of the qualified names of all datasets inside the given group (recursively)
    */
-   virtual std::vector<QualifiedName> listContents(const std::string& group) = 0;
+  virtual std::vector<QualifiedName> listContents(const std::string& group) = 0;
 
-
-   virtual std::string getParameter(const QualifiedName& qualified_name, const std::string& key_word) =0;
+  virtual std::string getParameter(const QualifiedName& qualified_name, const std::string& key_word) = 0;
 
   /**
    * @brief
@@ -84,15 +82,14 @@ class XYDatasetProvider
    * @return
    * A unique pointer of XYDataset type to the dataset
    */
-   virtual std::unique_ptr<XYDataset> getDataset(const QualifiedName& qualified_name) = 0;
+  virtual std::unique_ptr<XYDataset> getDataset(const QualifiedName& qualified_name) = 0;
 
-   virtual ~XYDatasetProvider() = default;
+  virtual ~XYDatasetProvider() = default;
 
- private:
-
+private:
 };
 
 } /* namespace XYDataset */
-} // end of namespace Euclid
+}  // end of namespace Euclid
 
-#endif // XYDATASETPROVIDER_H_ 
+#endif  // XYDATASETPROVIDER_H_

--- a/XYDataset/src/lib/AsciiParser.cpp
+++ b/XYDataset/src/lib/AsciiParser.cpp
@@ -1,30 +1,30 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file src/lib/AsciiParser.cpp
  *
  * @date May 13, 2014
  * @author Nicolas Morisset
  */
 
-#include <boost/regex.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/regex.hpp>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -32,9 +32,9 @@
 #include "boost/lexical_cast.hpp"
 
 #include "ElementsKernel/Exception.h"
+#include "StringFunctions.h"
 #include "Table/AsciiReader.h"
 #include "XYDataset/AsciiParser.h"
-#include "StringFunctions.h"
 
 using boost::regex;
 using boost::regex_match;
@@ -61,44 +61,42 @@ std::string AsciiParser::getName(const std::string& file) {
     std::getline(sfile, line);
   }
 
-  boost::regex expression(m_regex_name);
+  boost::regex  expression(m_regex_name);
   boost::smatch s_match;
   if (boost::regex_match(line, s_match, expression)) {
-     dataset_name = s_match[1].str();
+    dataset_name = s_match[1].str();
+  } else {
+    // Dataset name is the filename without extension and path
+    std::string str{};
+    str          = removeAllBeforeLastSlash(file);
+    dataset_name = removeExtension(str);
   }
-  else {
-     // Dataset name is the filename without extension and path
-     std::string str {};
-     str          = removeAllBeforeLastSlash(file);
-     dataset_name = removeExtension(str);
- }
 
   return dataset_name;
 }
 
-
 std::string AsciiParser::getParameter(const std::string& file, const std::string& key_word) {
   std::ifstream sfile(file);
   if (!sfile) {
-     throw Elements::Exception() << "File does not exist : " << file;
-   }
+    throw Elements::Exception() << "File does not exist : " << file;
+  }
 
-  std::string value{};
-  std::string line{};
-  std::string dataset_name{};
+  std::string  value{};
+  std::string  line{};
+  std::string  dataset_name{};
   std::string  reg_ex_str = "^\\s*#\\s*" + key_word + "\\s+(\\w+)\\s*$";
   boost::regex expression(reg_ex_str);
 
   while (sfile.good()) {
-   std::getline(sfile, line);
-   boost::smatch s_match;
-   if (!line.empty() && boost::regex_match(line, s_match, expression)) {
+    std::getline(sfile, line);
+    boost::smatch s_match;
+    if (!line.empty() && boost::regex_match(line, s_match, expression)) {
       // extract the parameter value
-      size_t start_position = line.find(key_word)+key_word.length();
-      value =  line.substr (start_position);
+      size_t start_position = line.find(key_word) + key_word.length();
+      value                 = line.substr(start_position);
       boost::trim(value);
       break;
-   }
+    }
   }
   return value;
 }
@@ -108,8 +106,8 @@ std::string AsciiParser::getParameter(const std::string& file, const std::string
 //
 std::unique_ptr<XYDataset> AsciiParser::getDataset(const std::string& file) {
 
-  std::unique_ptr<XYDataset> dataset_ptr {};
-  std::ifstream sfile(file);
+  std::unique_ptr<XYDataset> dataset_ptr{};
+  std::ifstream              sfile(file);
   // Check file exists
   if (sfile) {
     // Read file into a Table object
@@ -117,23 +115,23 @@ std::unique_ptr<XYDataset> AsciiParser::getDataset(const std::string& file) {
     // Put the Table data into vector pair
     std::vector<std::pair<double, double>> vector_pair;
     for (auto row : table) {
-        vector_pair.push_back(std::make_pair( boost::get<double>(row[0]), boost::get<double>(row[1]) ));
+      vector_pair.push_back(std::make_pair(boost::get<double>(row[0]), boost::get<double>(row[1])));
     }
-    dataset_ptr = std::unique_ptr<XYDataset> { new XYDataset(vector_pair) };
+    dataset_ptr = std::unique_ptr<XYDataset>{new XYDataset(vector_pair)};
   }
 
- return dataset_ptr;
+  return dataset_ptr;
 }
 
 bool AsciiParser::isDatasetFile(const std::string& file) {
-  bool is_a_dataset_file = false;
+  bool          is_a_dataset_file = false;
   std::ifstream sfile(file);
   // Check file exists
   if (sfile) {
     std::string line{};
     // Convention: read until found first non empty line, removing empty lines.
     // Escape also the dataset name and comment lines
-    boost::regex expression("\\s*#.*");
+    boost::regex  expression("\\s*#.*");
     boost::smatch s_match;
     while ((line.empty() || boost::regex_match(line, s_match, expression)) && sfile.good()) {
       std::getline(sfile, line);
@@ -142,25 +140,23 @@ bool AsciiParser::isDatasetFile(const std::string& file) {
       // We should have 2 double values only on one line
       try {
         std::stringstream ss(line);
-        std::string empty_string{};
-        std::string d1, d2;
+        std::string       empty_string{};
+        std::string       d1, d2;
         ss >> d1 >> d2 >> empty_string;
         boost::lexical_cast<double>(d1);
         boost::lexical_cast<double>(d2);
-        if (!empty_string.empty()){
+        if (!empty_string.empty()) {
           is_a_dataset_file = false;
-        }
-        else {
+        } else {
           is_a_dataset_file = true;
         }
-      }
-      catch(...){
+      } catch (...) {
         is_a_dataset_file = false;
       }
-    }// Eof sfile.good()
-  } // Eof sfile
- return is_a_dataset_file;
+    }  // Eof sfile.good()
+  }    // Eof sfile
+  return is_a_dataset_file;
 }
 
-} // XYDataset namespace
-} // end of namespace Euclid
+}  // namespace XYDataset
+}  // end of namespace Euclid

--- a/XYDataset/src/lib/CachedProvider.cpp
+++ b/XYDataset/src/lib/CachedProvider.cpp
@@ -26,28 +26,22 @@
 namespace Euclid {
 namespace XYDataset {
 
+CachedProvider::CachedProvider(std::shared_ptr<Euclid::XYDataset::XYDatasetProvider> provider) : m_provider(provider) {}
 
-CachedProvider::CachedProvider(std::shared_ptr<Euclid::XYDataset::XYDatasetProvider> provider)
-  : m_provider(provider)
-{
-}
-
-
-std::vector<QualifiedName> CachedProvider::listContents(const std::string &group) {
+std::vector<QualifiedName> CachedProvider::listContents(const std::string& group) {
   auto i = m_list_cache.find(group);
   if (i == m_list_cache.end()) {
     auto contents = m_provider->listContents(group);
-    i = m_list_cache.insert(std::make_pair(group, contents)).first;
+    i             = m_list_cache.insert(std::make_pair(group, contents)).first;
   }
   return i->second;
 }
 
-
-std::unique_ptr<XYDataset> CachedProvider::getDataset(const Euclid::XYDataset::QualifiedName &qualified_name) {
+std::unique_ptr<XYDataset> CachedProvider::getDataset(const Euclid::XYDataset::QualifiedName& qualified_name) {
   auto i = m_dataset.find(qualified_name);
   if (i == m_dataset.end()) {
     auto dataset = m_provider->getDataset(qualified_name);
-    i = m_dataset.insert(std::make_pair(qualified_name, std::move(dataset))).first;
+    i            = m_dataset.insert(std::make_pair(qualified_name, std::move(dataset))).first;
   }
   if (i->second)
     return std::unique_ptr<XYDataset>(new XYDataset(*i->second));
@@ -55,8 +49,8 @@ std::unique_ptr<XYDataset> CachedProvider::getDataset(const Euclid::XYDataset::Q
     return nullptr;
 }
 
-std::string CachedProvider::getParameter(const QualifiedName& qualified_name, const std::string& key_word){
-   return m_provider->getParameter(qualified_name, key_word);
+std::string CachedProvider::getParameter(const QualifiedName& qualified_name, const std::string& key_word) {
+  return m_provider->getParameter(qualified_name, key_word);
 }
 
 }  // namespace XYDataset

--- a/XYDataset/src/lib/FileSystemProvider.cpp
+++ b/XYDataset/src/lib/FileSystemProvider.cpp
@@ -1,38 +1,38 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file src/lib/FileSystemProvider.cpp
  *
  * @date Apr 14, 2014
  * @author Nicolas Morisset
  */
 
-#include <fstream>
-#include <string>
-#include <unordered_set>
-#include <set>
-#include <boost/filesystem.hpp>
-#include <boost/algorithm/string.hpp>
+#include "XYDataset/FileSystemProvider.h"
 #include "ElementsKernel/Exception.h"
 #include "ElementsKernel/Logging.h"
-#include "XYDataset/FileSystemProvider.h"
 #include "StringFunctions.h"
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
+#include <fstream>
+#include <set>
+#include <string>
+#include <unordered_set>
 
 namespace fs = boost::filesystem;
 
@@ -50,13 +50,13 @@ static Elements::Logging logger = Elements::Logging::getLogger("FileSystemProvid
  * @return The contents of the directory, ordered as described in order.txt
  */
 static std::vector<fs::path> getOrder(const fs::path& dir) {
-  std::vector<fs::path> result {};
-  
+  std::vector<fs::path> result{};
+
   // First add the files in the order.txt
-  auto order_file = dir / "order.txt";
-  std::unordered_set<std::string> ordered_names {};
+  auto                            order_file = dir / "order.txt";
+  std::unordered_set<std::string> ordered_names{};
   if (fs::exists(order_file)) {
-    std::ifstream in {order_file.c_str()};
+    std::ifstream in{order_file.c_str()};
     while (in) {
       std::string line;
       getline(in, line);
@@ -76,28 +76,27 @@ static std::vector<fs::path> getOrder(const fs::path& dir) {
       }
     }
   }
-  
+
   // Now we add any other files in the directory, which were not in the order.txt
   // file. We use a set in order to avoid sorting problem between platforms.
-  std::set<fs::path> remaining_files {};
-  for (fs::directory_iterator iter {dir}; iter != fs::directory_iterator{}; ++ iter) {
+  std::set<fs::path> remaining_files{};
+  for (fs::directory_iterator iter{dir}; iter != fs::directory_iterator{}; ++iter) {
     if (ordered_names.count(iter->path().filename().string()) == 0) {
       remaining_files.emplace(*iter);
     }
   }
-  
+
   // Put the remaining files into the result vector
-  for (auto& file : remaining_files){
+  for (auto& file : remaining_files) {
     result.emplace_back(file);
   }
 
   return result;
 }
 
-
 static std::vector<fs::path> getRecursiveDirectoryContents(const fs::path& dir) {
-  std::vector<fs::path> result {};
-  auto ordered_contents = getOrder(dir);
+  std::vector<fs::path> result{};
+  auto                  ordered_contents = getOrder(dir);
   for (auto& name : ordered_contents) {
     if (fs::is_directory(name)) {
       auto sub_dir_contents = getRecursiveDirectoryContents(name);
@@ -114,7 +113,7 @@ static std::vector<fs::path> getRecursiveDirectoryContents(const fs::path& dir) 
 //-----------------------------------------------------------------------------
 
 FileSystemProvider::FileSystemProvider(const std::string& root_path, std::unique_ptr<FileParser> parser)
-                   : XYDatasetProvider(), m_root_path(root_path), m_parser(std::move(parser)) {
+    : XYDatasetProvider(), m_root_path(root_path), m_parser(std::move(parser)) {
 
   std::vector<std::string> string_vector{};
 
@@ -124,47 +123,42 @@ FileSystemProvider::FileSystemProvider(const std::string& root_path, std::unique
   // Convert path to boost filesytem object
   fs::path fspath(m_root_path);
   if (!fs::exists(fspath)) {
-    throw Elements::Exception() << "From FileSystemProvider: root path not found : "
-                                << fspath;
+    throw Elements::Exception() << "From FileSystemProvider: root path not found : " << fspath;
   }
 
   // Get all files below the root directory
   if (fs::is_directory(fspath)) {
     auto dir_contents = getRecursiveDirectoryContents(fspath);
     for (auto& file : dir_contents) {
-      if (fs::is_regular_file(file) && m_parser->isDatasetFile(file.string()))
-      {
+      if (fs::is_regular_file(file) && m_parser->isDatasetFile(file.string())) {
         std::string dataset_name = m_parser->getName(file.string());
         // Remove empty dataset name
         if (dataset_name.empty()) {
-           continue;
+          continue;
         }
         // Remove the root part
         std::string str = file.string();
-        str = str.substr(m_root_path.length(), str.length());
+        str             = str.substr(m_root_path.length(), str.length());
         // Split by the character '/'
-        std::vector<std::string> groups {};
+        std::vector<std::string> groups{};
         boost::split(groups, str, boost::is_any_of("/"));
         // The last string is the file name, so we remove it
         groups.pop_back();
-        QualifiedName qualified_name {groups, dataset_name};
+        QualifiedName qualified_name{groups, dataset_name};
         // Fill up a map
         auto ret = m_name_file_map.insert(make_pair(qualified_name, file.string()));
         m_order_names.push_back(qualified_name);
         // Check for unique record
         if (!ret.second) {
           throw Elements::Exception() << "Qualified name can not be inserted "
-                                    << "in the map. Qualify name : "
-                                    << qualified_name.qualifiedName()
-                                    << " Path :" << file.string();
+                                      << "in the map. Qualify name : " << qualified_name.qualifiedName()
+                                      << " Path :" << file.string();
         }
       }
     }
-  }
-  else {
+  } else {
     throw Elements::Exception() << " Root path : " << fspath.string() << " is not a directory!";
   }
-
 }
 
 //-----------------------------------------------------------------------------
@@ -173,50 +167,48 @@ FileSystemProvider::FileSystemProvider(const std::string& root_path, std::unique
 
 std::vector<QualifiedName> FileSystemProvider::listContents(const std::string& group) {
 
- std::string my_group = group;
- // Make sure the group finishes with a "/" and only one
- while (!my_group.empty() && my_group.back() == '/') {
-   my_group.pop_back();
- }
- // Make sure the group do not start with a "/"
- size_t pos = my_group.find_first_not_of("/");
- if (!my_group.empty() && pos != 0) {
-   my_group = my_group.substr(pos);
- }
- if (!my_group.empty()) {
-  my_group.push_back('/');
- }
+  std::string my_group = group;
+  // Make sure the group finishes with a "/" and only one
+  while (!my_group.empty() && my_group.back() == '/') {
+    my_group.pop_back();
+  }
+  // Make sure the group do not start with a "/"
+  size_t pos = my_group.find_first_not_of("/");
+  if (!my_group.empty() && pos != 0) {
+    my_group = my_group.substr(pos);
+  }
+  if (!my_group.empty()) {
+    my_group.push_back('/');
+  }
 
- std::vector<QualifiedName> qualified_name_vector{};
+  std::vector<QualifiedName> qualified_name_vector{};
 
- // Fill up vector with qualified name from the map
- // Insert all qualified name where path contains the group name at the
- // first position
- for (auto qualified_name : m_order_names ) {
-      if (boost::starts_with(qualified_name.qualifiedName(), my_group)) {
-         qualified_name_vector.push_back(qualified_name);
-     }
- } // Eof for
+  // Fill up vector with qualified name from the map
+  // Insert all qualified name where path contains the group name at the
+  // first position
+  for (auto qualified_name : m_order_names) {
+    if (boost::starts_with(qualified_name.qualifiedName(), my_group)) {
+      qualified_name_vector.push_back(qualified_name);
+    }
+  }  // Eof for
 
- return (qualified_name_vector);
+  return (qualified_name_vector);
 }
 
 //-----------------------------------------------------------------------------
 //                             getDataset function
 //-----------------------------------------------------------------------------
 
-std::unique_ptr<XYDataset> FileSystemProvider::getDataset(const QualifiedName & qualified_name) {
+std::unique_ptr<XYDataset> FileSystemProvider::getDataset(const QualifiedName& qualified_name) {
 
- auto it = m_name_file_map.find(qualified_name);
- return (it != m_name_file_map.end()) ? m_parser->getDataset(it->second) : nullptr;
-
+  auto it = m_name_file_map.find(qualified_name);
+  return (it != m_name_file_map.end()) ? m_parser->getDataset(it->second) : nullptr;
 }
 
-
-std::string FileSystemProvider::getParameter(const QualifiedName& qualified_name, const std::string& key_word){
-   auto it = m_name_file_map.find(qualified_name);
-   return (it != m_name_file_map.end()) ? m_parser->getParameter(it->second, key_word) : "";
+std::string FileSystemProvider::getParameter(const QualifiedName& qualified_name, const std::string& key_word) {
+  auto it = m_name_file_map.find(qualified_name);
+  return (it != m_name_file_map.end()) ? m_parser->getParameter(it->second, key_word) : "";
 }
 
 } /* namespace XYDataset */
-} // end of namespace Euclid
+}  // end of namespace Euclid

--- a/XYDataset/src/lib/FitsParser.cpp
+++ b/XYDataset/src/lib/FitsParser.cpp
@@ -1,39 +1,39 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file src/lib/FitsParser.cpp
  *
  * @date May 13, 2014
  * @author Nicolas Morisset
  */
 
+#include <CCfits/CCfits>
 #include <boost/regex.hpp>
 #include <fstream>
 #include <iostream>
-#include <CCfits/CCfits>
 
 #include "ElementsKernel/Exception.h"
 #include "ElementsKernel/Unused.h"
 
+#include "StringFunctions.h"
 #include "Table/FitsReader.h"
 #include "XYDataset/FitsParser.h"
-#include "StringFunctions.h"
 
 using boost::regex;
 using boost::regex_match;
@@ -47,37 +47,36 @@ namespace XYDataset {
 std::string FitsParser::getName(const std::string& file) {
 
   std::string dataset_name = getParameter(file, m_name_keyword);
-  if (dataset_name.empty()){
+  if (dataset_name.empty()) {
     // Dataset name is the filename without extension and path
-    std::string str {};
+    std::string str{};
     str          = removeAllBeforeLastSlash(file);
     dataset_name = removeExtension(str);
   }
   return (dataset_name);
 }
 
-
 std::string FitsParser::getParameter(const std::string& file, const std::string& key_word) {
-   std::string value{};
-   std::ifstream sfile(file);
+  std::string   value{};
+  std::ifstream sfile(file);
 
-    // Check file exists
-    if (!sfile) {
-      throw Elements::Exception() << "File not found : " << file;
-    }
+  // Check file exists
+  if (!sfile) {
+    throw Elements::Exception() << "File not found : " << file;
+  }
 
-   // Read first HDU
-   std::unique_ptr<CCfits::FITS> fits { new CCfits::FITS(file, CCfits::RWmode::Read)};
-   CCfits::ExtHDU& table_hdu = fits->extension(1);
+  // Read first HDU
+  std::unique_ptr<CCfits::FITS> fits{new CCfits::FITS(file, CCfits::RWmode::Read)};
+  CCfits::ExtHDU&               table_hdu = fits->extension(1);
 
-   table_hdu.readAllKeys();
-   auto keyword_map = table_hdu.keyWord();
-   auto iter=keyword_map.find(key_word);
-   if (iter != keyword_map.end()) {
-     iter->second->value(value);
-   }
+  table_hdu.readAllKeys();
+  auto keyword_map = table_hdu.keyWord();
+  auto iter        = keyword_map.find(key_word);
+  if (iter != keyword_map.end()) {
+    iter->second->value(value);
+  }
 
-   return value;
+  return value;
 }
 
 //
@@ -85,14 +84,14 @@ std::string FitsParser::getParameter(const std::string& file, const std::string&
 //
 std::unique_ptr<XYDataset> FitsParser::getDataset(const std::string& file) {
 
-  std::unique_ptr<XYDataset> dataset_ptr {};
-  std::ifstream sfile(file);
+  std::unique_ptr<XYDataset> dataset_ptr{};
+  std::ifstream              sfile(file);
 
   CCfits::FITS::setVerboseMode(true);
 
   // Check file exists
   if (sfile) {
-    std::unique_ptr<CCfits::FITS> fits { new CCfits::FITS(file, CCfits::RWmode::Read)};
+    std::unique_ptr<CCfits::FITS> fits{new CCfits::FITS(file, CCfits::RWmode::Read)};
     try {
       const CCfits::ExtHDU& table_hdu = fits->extension(1);
       // Read first HDU
@@ -101,16 +100,15 @@ std::unique_ptr<XYDataset> FitsParser::getDataset(const std::string& file) {
       // Put the Table data into vector pair
       std::vector<std::pair<double, double>> vector_pair;
       for (auto row : table) {
-          vector_pair.push_back(std::make_pair( boost::get<double>(row[0]), boost::get<double>(row[1]) ));
+        vector_pair.push_back(std::make_pair(boost::get<double>(row[0]), boost::get<double>(row[1])));
       }
-      dataset_ptr = std::unique_ptr<XYDataset> { new XYDataset(vector_pair) };
-    }
-    catch (CCfits::FitsException& fits_except){
+      dataset_ptr = std::unique_ptr<XYDataset>{new XYDataset(vector_pair)};
+    } catch (CCfits::FitsException& fits_except) {
       throw Elements::Exception() << "FitsException catched! File: " << file;
-    } // Eof try-catch
-  } // Eof if
+    }  // Eof try-catch
+  }    // Eof if
 
- return(dataset_ptr);
+  return (dataset_ptr);
 }
 
 //
@@ -119,18 +117,14 @@ std::unique_ptr<XYDataset> FitsParser::getDataset(const std::string& file) {
 bool FitsParser::isDatasetFile(const std::string& file) {
   bool is_a_dataset_file = true;
   try {
-      std::unique_ptr<CCfits::FITS> fits { new CCfits::FITS(file, CCfits::RWmode::Read)};
-      const CCfits::ExtHDU& table_hdu = fits->extension(1);
-      ELEMENTS_UNUSED auto& temp = dynamic_cast<const CCfits::Table&>(table_hdu);
-  }
-  catch (CCfits::FitsException& fits_except){
+    std::unique_ptr<CCfits::FITS> fits{new CCfits::FITS(file, CCfits::RWmode::Read)};
+    const CCfits::ExtHDU&         table_hdu = fits->extension(1);
+    ELEMENTS_UNUSED auto&         temp      = dynamic_cast<const CCfits::Table&>(table_hdu);
+  } catch (CCfits::FitsException& fits_except) {
     is_a_dataset_file = false;
   }
- return is_a_dataset_file;
+  return is_a_dataset_file;
 }
 
-} // XYDataset namespace
-} // end of namespace Euclid
-
-
-
+}  // namespace XYDataset
+}  // end of namespace Euclid

--- a/XYDataset/src/lib/QualifiedName.cpp
+++ b/XYDataset/src/lib/QualifiedName.cpp
@@ -16,26 +16,26 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/QualifiedName.cpp
  * @date May 19, 2014
  * @author Nikolaos Apostolakos
  */
 
+#include "XYDataset/QualifiedName.h"
+#include <ElementsKernel/Exception.h>
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
-#include <ElementsKernel/Exception.h>
-#include "XYDataset/QualifiedName.h"
 
 namespace Euclid {
 namespace XYDataset {
 
 QualifiedName::QualifiedName(std::vector<std::string> groups, std::string name)
-            : m_groups {std::move(groups)}, m_dataset_name {std::move(name)} {
+    : m_groups{std::move(groups)}, m_dataset_name{std::move(name)} {
   for (auto& group : m_groups) {
     if (group.empty() || group.find('/') != std::string::npos) {
       throw Elements::Exception() << "Invalid group name : \"" << group << "\""
-          << " in qualified name : \"" << m_qualified_name.append(group).append("/") << "\"";
+                                  << " in qualified name : \"" << m_qualified_name.append(group).append("/") << "\"";
     }
     m_qualified_name.append(group).append("/");
   }
@@ -46,7 +46,7 @@ QualifiedName::QualifiedName(std::vector<std::string> groups, std::string name)
 }
 
 std::vector<std::string> getGroups(const std::string& qualified_name) {
-  std::vector<std::string> groups {};
+  std::vector<std::string> groups{};
   boost::split(groups, qualified_name, boost::is_any_of("/"));
   // The last one is the name, so we remove it
   groups.pop_back();
@@ -54,13 +54,13 @@ std::vector<std::string> getGroups(const std::string& qualified_name) {
 }
 
 std::string getName(const std::string& qualified_name) {
-  std::vector<std::string> groups {};
+  std::vector<std::string> groups{};
   boost::split(groups, qualified_name, boost::is_any_of("/"));
   return groups.back();
 }
 
 QualifiedName::QualifiedName(const std::string& qualified_name)
-            : QualifiedName(getGroups(qualified_name), getName(qualified_name)) { }
+    : QualifiedName(getGroups(qualified_name), getName(qualified_name)) {}
 
 const std::vector<std::string>& QualifiedName::groups() const {
   return m_groups;
@@ -75,40 +75,37 @@ const std::string& QualifiedName::qualifiedName() const {
 }
 
 bool QualifiedName::belongsInGroup(const QualifiedName& group) const {
-  if (group.m_groups.size()+1 > this->m_groups.size()) {
+  if (group.m_groups.size() + 1 > this->m_groups.size()) {
     return false;
   }
   bool group_check = std::equal(group.m_groups.begin(), group.m_groups.end(), this->m_groups.begin());
-  return group_check
-        ? group.m_dataset_name == this->m_groups.at(group.m_groups.size())
-        : false;
+  return group_check ? group.m_dataset_name == this->m_groups.at(group.m_groups.size()) : false;
 }
 
 size_t QualifiedName::hash() const {
   if (m_hash == 0) {
-      std::hash<std::string> stringHash;
-      m_hash = stringHash(qualifiedName());
-    }
-    return m_hash;
+    std::hash<std::string> stringHash;
+    m_hash = stringHash(qualifiedName());
+  }
+  return m_hash;
 }
 
 bool QualifiedName::operator<(const QualifiedName& other) const {
-  size_t thisHash = this->hash();
+  size_t thisHash  = this->hash();
   size_t otherHash = other.hash();
   if (thisHash != otherHash) {
     return thisHash < otherHash;
-  }
-  else {
+  } else {
     return this->qualifiedName() < other.qualifiedName();
   }
 }
 
 bool QualifiedName::operator==(const QualifiedName& other) const {
-  size_t thisHash = this->hash();
+  size_t thisHash  = this->hash();
   size_t otherHash = other.hash();
   if (thisHash != otherHash) {
     return false;
-  } else{
+  } else {
     return this->qualifiedName() == other.qualifiedName();
   }
 }
@@ -122,5 +119,5 @@ std::ostream& operator<<(std::ostream& stream, const QualifiedName& qualified_na
   return stream;
 }
 
-} // namespace XYDataset
-} // end of namespace Euclid
+}  // namespace XYDataset
+}  // end of namespace Euclid

--- a/XYDataset/src/lib/StringFunctions.cpp
+++ b/XYDataset/src/lib/StringFunctions.cpp
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file src/lib/StringFunctions.cpp
  *
  * @date May 22, 2014
@@ -34,15 +34,14 @@ namespace XYDataset {
 std::string checkBeginSlashes(const std::string& input_str) {
 
   std::string output_str{};
-  size_t pos = input_str.find_first_not_of("/") ;
+  size_t      pos = input_str.find_first_not_of("/");
   if (pos != std::string::npos && pos != 0) {
-     output_str = input_str.substr(pos);
-     output_str = "/" + output_str;
-   }
-   else {
-     // no slash at the beginning
-     output_str = "/" + input_str;
-   }
+    output_str = input_str.substr(pos);
+    output_str = "/" + output_str;
+  } else {
+    // no slash at the beginning
+    output_str = "/" + input_str;
+  }
 
   return (output_str);
 }
@@ -54,12 +53,11 @@ std::string checkNoBeginSlashes(const std::string& input_str) {
 
   std::string output_str{};
 
-  if (! input_str.empty()) {
-    size_t pos = input_str.find_first_not_of("/") ;
-    if ( pos != 0) {
+  if (!input_str.empty()) {
+    size_t pos = input_str.find_first_not_of("/");
+    if (pos != 0) {
       output_str = input_str.substr(pos);
-    }
-    else {
+    } else {
       // no slash
       output_str = input_str;
     }
@@ -76,16 +74,15 @@ std::string checkEndSlashes(const std::string& input_str) {
   std::string output_str{};
 
   size_t pos = input_str.find_last_not_of("/");
-  if (  pos != input_str.length()-1) {
+  if (pos != input_str.length() - 1) {
     // add one
-    output_str = input_str.substr(0, pos+1) + "/";
-  }
-  else {
+    output_str = input_str.substr(0, pos + 1) + "/";
+  } else {
     // No slash at the end
     output_str = input_str + "/";
   }
 
- return (output_str);
+  return (output_str);
 }
 
 //
@@ -95,18 +92,17 @@ std::string removeExtension(const std::string& input_str) {
 
   std::string output_str{};
 
-  if (! input_str.empty()) {
+  if (!input_str.empty()) {
     // Remove any file extension
     size_t pos = input_str.find_last_of(".");
-    if ( pos != std::string::npos) {
-      output_str = input_str.substr(0,pos);
-    }
-    else {
+    if (pos != std::string::npos) {
+      output_str = input_str.substr(0, pos);
+    } else {
       output_str = input_str;
     }
   }
 
-return (output_str);
+  return (output_str);
 }
 
 //
@@ -116,20 +112,18 @@ std::string removeAllBeforeLastSlash(const std::string& input_str) {
 
   std::string output_str{};
 
-  if (! input_str.empty()) {
+  if (!input_str.empty()) {
     // Remove any file extension
     size_t pos = input_str.find_last_of("/");
-    if ( pos != std::string::npos) {
-      output_str = input_str.substr(pos+1);
-    }
-    else {
+    if (pos != std::string::npos) {
+      output_str = input_str.substr(pos + 1);
+    } else {
       output_str = input_str;
     }
   }
 
-return (output_str);
+  return (output_str);
 }
 
-} // XYDataset namespace
-} // end of namespace Euclid
-
+}  // namespace XYDataset
+}  // end of namespace Euclid

--- a/XYDataset/src/lib/StringFunctions.h
+++ b/XYDataset/src/lib/StringFunctions.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file src/lib/StringFunctions.h
  *
  * @date May 21, 2014
@@ -26,8 +26,8 @@
 #ifndef STRINGFUNCTIONS_H_
 #define STRINGFUNCTIONS_H_
 
-#include <string>
 #include <iostream>
+#include <string>
 
 #include "ElementsKernel/Export.h"
 
@@ -54,13 +54,12 @@ std::string checkEndSlashes(const std::string& input_str);
 //
 std::string removeExtension(const std::string& input_str);
 
-
 //
 // Remove all characters before the last "/" character
 //
 std::string removeAllBeforeLastSlash(const std::string& input_str);
 
-} // XYDataset namespace
-} // end of namespace Euclid
+}  // namespace XYDataset
+}  // end of namespace Euclid
 
-#endif // STRINGFUNCTIONS_H_
+#endif  // STRINGFUNCTIONS_H_

--- a/XYDataset/src/lib/XYDataset.cpp
+++ b/XYDataset/src/lib/XYDataset.cpp
@@ -16,16 +16,16 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file src/lib/XYDataset.cpp
  *
  * @date Apr 9, 2014
  * @author Nicolas Morisset
  */
 
-#include <utility>
 #include <algorithm>
 #include <iostream>
+#include <utility>
 
 #include "ElementsKernel/Exception.h"
 #include "XYDataset/XYDataset.h"
@@ -57,10 +57,9 @@ XYDataset XYDataset::factory(const std::vector<double>& x_vector, const std::vec
   size_t x_size = x_vector.size();
   size_t y_size = y_vector.size();
   // Vector must have the same size
-  if ( x_size != y_size) {
+  if (x_size != y_size) {
     throw Elements::Exception() << " Vectors must have "
-                              << "the same size! x size: %d" <<x_size
-                              <<"  y_size : %d"<< y_size;
+                                << "the same size! x size: %d" << x_size << "  y_size : %d" << y_size;
   }
 
   std::vector<std::pair<double, double>> vector_pair;
@@ -68,10 +67,10 @@ XYDataset XYDataset::factory(const std::vector<double>& x_vector, const std::vec
 
   // Make the pair vector
   transform(x_vector.begin(), x_vector.end(), y_vector.begin(), back_inserter(vector_pair),
-                 [](double a, double b) { return std::make_pair(a, b); });
+            [](double a, double b) { return std::make_pair(a, b); });
 
-  return ( XYDataset(move(vector_pair)) );
+  return (XYDataset(move(vector_pair)));
 }
 
 } /* namespace XYDataset */
-} // end of namespace Euclid
+}  // end of namespace Euclid

--- a/XYDataset/tests/src/AsciiParser_test.cpp
+++ b/XYDataset/tests/src/AsciiParser_test.cpp
@@ -1,34 +1,34 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file tests/src/AsciiParser_test.cpp
  *
  * @date Apr 16, 2014
  * @author Nicolas Morisset
  */
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 
-#include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include "ElementsKernel/Exception.h"
 #include "ElementsKernel/Temporary.h"
@@ -38,26 +38,26 @@
 using namespace Euclid::XYDataset;
 
 std::string makeDir(std::string name) {
-  boost::filesystem::path d {name};
+  boost::filesystem::path d{name};
   boost::filesystem::create_directories(d);
   return name;
 }
 void removeDir(std::string base_dir) {
-  boost::filesystem::path bd {base_dir};
+  boost::filesystem::path bd{base_dir};
   boost::filesystem::remove_all(bd);
 }
 
 struct AsciiParser_Fixture {
 
   // Do not forget the "/" at the end of the base directory
-  std::string no_file {"nofile.txt"};
-  std::string nolines_file {"nolines_file.txt"};
-  std::string empty_file {"empty_file.txt"};
-  std::string file {"Gext_ACSf435w.txt"};
-  std::string file_nodataset_name {"Nodataset_name_inside_file.txt"};
-  std::string not_a_dataset_file  {"not_a_dataset_file.txt"};
+  std::string       no_file{"nofile.txt"};
+  std::string       nolines_file{"nolines_file.txt"};
+  std::string       empty_file{"empty_file.txt"};
+  std::string       file{"Gext_ACSf435w.txt"};
+  std::string       file_nodataset_name{"Nodataset_name_inside_file.txt"};
+  std::string       not_a_dataset_file{"not_a_dataset_file.txt"};
   Elements::TempDir temp_dir;
-  std::string base_directory = makeDir(temp_dir.path().native()+"/euclid/filter/MER/");
+  std::string       base_directory = makeDir(temp_dir.path().native() + "/euclid/filter/MER/");
 
   AsciiParser_Fixture() {
     // Create files
@@ -92,18 +92,16 @@ struct AsciiParser_Fixture {
     ofnolines_file.close();
 
     std::ofstream ofempty_file(base_directory + empty_file);
-     ofempty_file.close();
- }
+    ofempty_file.close();
+  }
   ~AsciiParser_Fixture() {
     removeDir(base_directory);
   }
-
-
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (AsciiParser_test)
+BOOST_AUTO_TEST_SUITE(AsciiParser_test)
 
 //-----------------------------------------------------------------------------
 // Test the exception of the getParameter function
@@ -117,7 +115,7 @@ BOOST_FIXTURE_TEST_CASE(exception_getParameter_function_test, AsciiParser_Fixtur
 
   AsciiParser parser{};
 
-  BOOST_CHECK_THROW(parser.getParameter(base_directory + no_file,"TEST"), Elements::Exception);
+  BOOST_CHECK_THROW(parser.getParameter(base_directory + no_file, "TEST"), Elements::Exception);
 }
 
 //-----------------------------------------------------------------------------
@@ -131,18 +129,14 @@ BOOST_FIXTURE_TEST_CASE(getParameter_function_test, AsciiParser_Fixture) {
   BOOST_TEST_MESSAGE(" ");
 
   // The dataset is the correct name, result: Keyword value
-  AsciiParser parser {};
+  AsciiParser parser{};
 
-  BOOST_CHECK_EQUAL("TEST_VALUE", parser.getParameter(base_directory + file,"TEST"));
+  BOOST_CHECK_EQUAL("TEST_VALUE", parser.getParameter(base_directory + file, "TEST"));
 
-  BOOST_CHECK_EQUAL("", parser.getParameter(base_directory + file_nodataset_name,"TEST2"));
+  BOOST_CHECK_EQUAL("", parser.getParameter(base_directory + file_nodataset_name, "TEST2"));
 
-  BOOST_CHECK_EQUAL("", parser.getParameter(base_directory + file_nodataset_name,"TEST"));
+  BOOST_CHECK_EQUAL("", parser.getParameter(base_directory + file_nodataset_name, "TEST"));
 }
-
-
-
-
 
 //-----------------------------------------------------------------------------
 // Test the exception of the getName function
@@ -179,7 +173,6 @@ BOOST_FIXTURE_TEST_CASE(getName_function_test, AsciiParser_Fixture) {
 
   dataset_name = parser.getName(base_directory + file_nodataset_name);
   BOOST_CHECK_EQUAL("Nodataset_name_inside_file", dataset_name);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -193,9 +186,8 @@ BOOST_FIXTURE_TEST_CASE(getDataset_function_test, AsciiParser_Fixture) {
   BOOST_TEST_MESSAGE(" ");
 
   AsciiParser parser{};
-  auto xy_ptr = parser.getDataset(base_directory + file);
+  auto        xy_ptr = parser.getDataset(base_directory + file);
   BOOST_CHECK_EQUAL(xy_ptr->size(), 3);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -216,11 +208,8 @@ BOOST_FIXTURE_TEST_CASE(isDatatsetFile_function_test, AsciiParser_Fixture) {
   BOOST_CHECK_EQUAL(parser.isDatasetFile(base_directory + nolines_file), false);
   // File with no line at all
   BOOST_CHECK_EQUAL(parser.isDatasetFile(base_directory + empty_file), false);
-
 }
-
-
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/XYDataset/tests/src/CachedProvider_test.cpp
+++ b/XYDataset/tests/src/CachedProvider_test.cpp
@@ -21,30 +21,26 @@
  *
  */
 
-#include <boost/test/unit_test.hpp>
 #include <ElementsKernel/Exception.h>
 #include <ElementsKernel/Real.h>
 #include <ElementsKernel/Unused.h>
+#include <boost/test/unit_test.hpp>
 
 #include "XYDataset/CachedProvider.h"
 
 using namespace Euclid::XYDataset;
 
-boost::test_tools::predicate_result checkAllClose(const XYDataset& a, const XYDataset &b) {
+boost::test_tools::predicate_result checkAllClose(const XYDataset& a, const XYDataset& b) {
   boost::test_tools::predicate_result res(true);
 
   if (a.size() != b.size()) {
     res = false;
     res.message() << "Different sizes";
-  }
-  else {
+  } else {
     for (auto i = a.begin(), j = b.begin(); i != a.end(); ++i, ++j) {
       if (!Elements::isEqual(i->first, j->first) || !Elements::isEqual(i->second, j->second)) {
         res = false;
-        res.message()
-          << '<' << i->first << ',' << i->second << '>'
-          << " != "
-          << '<' << j->first << ',' << j->second << ">\n";
+        res.message() << '<' << i->first << ',' << i->second << '>' << " != " << '<' << j->first << ',' << j->second << ">\n";
       }
     }
   }
@@ -52,15 +48,14 @@ boost::test_tools::predicate_result checkAllClose(const XYDataset& a, const XYDa
   return res;
 }
 
-
-struct MockProvider: public XYDatasetProvider {
+struct MockProvider : public XYDatasetProvider {
   int m_list_calls = 0;
   int m_data_calls = 0;
 
   std::map<std::string, std::vector<QualifiedName>> m_listing;
-  std::map<QualifiedName, XYDataset> m_dataset;
-  std::vector<double> m_x = {1., 2., 3.};
-  std::vector<double> m_y = {0., 0.5, 0.6};
+  std::map<QualifiedName, XYDataset>                m_dataset;
+  std::vector<double>                               m_x = {1., 2., 3.};
+  std::vector<double>                               m_y = {0., 0.5, 0.6};
 
   virtual ~MockProvider() = default;
 
@@ -91,8 +86,8 @@ struct MockProvider: public XYDatasetProvider {
     return std::unique_ptr<XYDataset>{new XYDataset{i->second}};
   }
 
-  std::string getParameter(ELEMENTS_UNUSED const QualifiedName& qualified_name, const std::string& key_word) override{
-     return key_word;
+  std::string getParameter(ELEMENTS_UNUSED const QualifiedName& qualified_name, const std::string& key_word) override {
+    return key_word;
   }
 };
 
@@ -102,7 +97,7 @@ struct CachedProvider_fixture {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (CachedProvider_test)
+BOOST_AUTO_TEST_SUITE(CachedProvider_test)
 
 //-----------------------------------------------------------------------------
 
@@ -119,37 +114,31 @@ BOOST_FIXTURE_TEST_CASE(listContents_test, CachedProvider_fixture) {
   CachedProvider cache{mock_provider};
 
   auto list_return = cache.listContents("A");
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-    list_return.begin(), list_return.end(), mock_provider->m_listing["A"].begin(), mock_provider->m_listing["A"].end()
-  );
+  BOOST_CHECK_EQUAL_COLLECTIONS(list_return.begin(), list_return.end(), mock_provider->m_listing["A"].begin(),
+                                mock_provider->m_listing["A"].end());
 
   list_return = cache.listContents("B");
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-    list_return.begin(), list_return.end(), mock_provider->m_listing["B"].begin(), mock_provider->m_listing["B"].end()
-  );
+  BOOST_CHECK_EQUAL_COLLECTIONS(list_return.begin(), list_return.end(), mock_provider->m_listing["B"].begin(),
+                                mock_provider->m_listing["B"].end());
 
   list_return = cache.listContents("C");
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-    list_return.begin(), list_return.end(), mock_provider->m_listing["C"].begin(), mock_provider->m_listing["C"].end()
-  );
+  BOOST_CHECK_EQUAL_COLLECTIONS(list_return.begin(), list_return.end(), mock_provider->m_listing["C"].begin(),
+                                mock_provider->m_listing["C"].end());
 
   BOOST_CHECK_EQUAL(mock_provider->m_list_calls, 3);
 
   // Repeat
   list_return = cache.listContents("A");
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-    list_return.begin(), list_return.end(), mock_provider->m_listing["A"].begin(), mock_provider->m_listing["A"].end()
-  );
+  BOOST_CHECK_EQUAL_COLLECTIONS(list_return.begin(), list_return.end(), mock_provider->m_listing["A"].begin(),
+                                mock_provider->m_listing["A"].end());
 
   list_return = cache.listContents("B");
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-    list_return.begin(), list_return.end(), mock_provider->m_listing["B"].begin(), mock_provider->m_listing["B"].end()
-  );
+  BOOST_CHECK_EQUAL_COLLECTIONS(list_return.begin(), list_return.end(), mock_provider->m_listing["B"].begin(),
+                                mock_provider->m_listing["B"].end());
 
   list_return = cache.listContents("C");
-  BOOST_CHECK_EQUAL_COLLECTIONS(
-    list_return.begin(), list_return.end(), mock_provider->m_listing["C"].begin(), mock_provider->m_listing["C"].end()
-  );
+  BOOST_CHECK_EQUAL_COLLECTIONS(list_return.begin(), list_return.end(), mock_provider->m_listing["C"].begin(),
+                                mock_provider->m_listing["C"].end());
 
   BOOST_CHECK_EQUAL(mock_provider->m_list_calls, 3);
 }
@@ -187,6 +176,4 @@ BOOST_FIXTURE_TEST_CASE(getDataSet_test, CachedProvider_fixture) {
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/XYDataset/tests/src/FileSystemProvider_test.cpp
+++ b/XYDataset/tests/src/FileSystemProvider_test.cpp
@@ -1,64 +1,63 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file tests/src/FileSystemProvider_test.cpp
  *
  * @date Apr 16, 2014
  * @author Nicolas Morisset
  */
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 
-#include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include "ElementsKernel/Exception.h"
 #include "ElementsKernel/Temporary.h"
-#include "XYDataset/FileSystemProvider.h"
 #include "XYDataset/AsciiParser.h"
+#include "XYDataset/FileSystemProvider.h"
 #include "XYDataset/QualifiedName.h"
 
 using namespace Euclid::XYDataset;
 
 // Create a directory on disk
 void makeDirectory(const std::string& name) {
-  boost::filesystem::path d {name};
+  boost::filesystem::path d{name};
   boost::filesystem::create_directories(d);
 }
 
 // Remove a directory on disk
 void removeDir(const std::string& base_dir) {
-  boost::filesystem::path bd {base_dir};
+  boost::filesystem::path bd{base_dir};
   boost::filesystem::remove_all(bd);
 }
 
 struct FileSystemProvider_Fixture {
 
-  std::string group { "filter/MER" };
+  std::string group{"filter/MER"};
   // Do not forget the "/" at the end of the base directory
   Elements::TempDir temp_dir;
-  std::string base_directory { temp_dir.path().native()+"/euclid/" };
-  std::string mer_directory    = base_directory + "filter/MER";
-  std::string cosmos_directory = base_directory + "filter/COSMOS";
-
+  std::string       base_directory{temp_dir.path().native() + "/euclid/"};
+  std::string       mer_directory    = base_directory + "filter/MER";
+  std::string       cosmos_directory = base_directory + "filter/COSMOS";
 
   FileSystemProvider_Fixture() {
 
@@ -84,21 +83,18 @@ struct FileSystemProvider_Fixture {
     dotfile_mer << ".......\n";
     dotfile_mer << ".......\n";
     dotfile_mer.close();
-
   }
 
   ~FileSystemProvider_Fixture() {
-   removeDir(base_directory);
+    removeDir(base_directory);
   }
 
-  std::unique_ptr<FileParser> fp { new AsciiParser{} };
-
+  std::unique_ptr<FileParser> fp{new AsciiParser{}};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (FileSystemProvider_test)
-
+BOOST_AUTO_TEST_SUITE(FileSystemProvider_test)
 
 //-----------------------------------------------------------------------------
 // Test the empty name
@@ -110,15 +106,16 @@ BOOST_FIXTURE_TEST_CASE(empty_datasetname_test, FileSystemProvider_Fixture) {
   BOOST_TEST_MESSAGE("--> Testing the empty dataset name, .DS_Store file must be ignored");
   BOOST_TEST_MESSAGE(" ");
 
-  FileSystemProvider fsp {temp_dir.path().native()+"/euclid/", std::move(fp)};
+  FileSystemProvider fsp{temp_dir.path().native() + "/euclid/", std::move(fp)};
 
   // Even with two slashes in the group it must work
-  group = "filter/MER/";
+  group                                    = "filter/MER/";
   std::vector<QualifiedName> result_vector = fsp.listContents(group);
   BOOST_CHECK_EQUAL(2, result_vector.size());
-  BOOST_CHECK(std::find(result_vector.begin(), result_vector.end(), QualifiedName{{"filter","MER"},"Dataset_name_for_file1"})!=result_vector.end());
-  BOOST_CHECK(std::find(result_vector.begin(), result_vector.end(), QualifiedName{{"filter","MER"},"file2"})!=result_vector.end());
-
+  BOOST_CHECK(std::find(result_vector.begin(), result_vector.end(), QualifiedName{{"filter", "MER"}, "Dataset_name_for_file1"}) !=
+              result_vector.end());
+  BOOST_CHECK(std::find(result_vector.begin(), result_vector.end(), QualifiedName{{"filter", "MER"}, "file2"}) !=
+              result_vector.end());
 }
 
 //-----------------------------------------------------------------------------
@@ -132,28 +129,25 @@ BOOST_FIXTURE_TEST_CASE(exceptions_test, FileSystemProvider_Fixture) {
   BOOST_TEST_MESSAGE(" ");
 
   // Path is not valid
-  base_directory = temp_dir.path().native()+"/PATH_DOES_NOT_EXIST";
-  BOOST_CHECK_THROW( FileSystemProvider fsp (base_directory, std::move(fp)),
-                     Elements::Exception);
+  base_directory = temp_dir.path().native() + "/PATH_DOES_NOT_EXIST";
+  BOOST_CHECK_THROW(FileSystemProvider fsp(base_directory, std::move(fp)), Elements::Exception);
 
   // Path to a file which is not valid
   base_directory = base_directory + "filter/MER/Gext_ACSf435w.txt";
-  BOOST_CHECK_THROW( FileSystemProvider fsp (base_directory, std::move(fp)),
-                     Elements::Exception);
+  BOOST_CHECK_THROW(FileSystemProvider fsp(base_directory, std::move(fp)), Elements::Exception);
 
   // Fill up a new file with dataset name already existing
   // We must have only unique qualify name
-  std::ofstream file3_mer(temp_dir.path().native()+"/euclid/filter/MER/file3.txt");
+  std::ofstream file3_mer(temp_dir.path().native() + "/euclid/filter/MER/file3.txt");
   file3_mer << "\n";
   file3_mer << "# Dataset_name_for_file1\n";
   file3_mer << "0.1111 1.0000 \n";
   file3_mer.close();
 
-  BOOST_CHECK_THROW( FileSystemProvider fsp (base_directory, std::move(fp)),
-                     Elements::Exception);
+  BOOST_CHECK_THROW(FileSystemProvider fsp(base_directory, std::move(fp)), Elements::Exception);
 
   // Remove file3 to avoid exception in the next test
-  removeDir(temp_dir.path().native()+"/euclid/filter/MER/file3.txt");
+  removeDir(temp_dir.path().native() + "/euclid/filter/MER/file3.txt");
 }
 
 //-----------------------------------------------------------------------------
@@ -166,20 +160,21 @@ BOOST_FIXTURE_TEST_CASE(listContent_test, FileSystemProvider_Fixture) {
   BOOST_TEST_MESSAGE("--> Testing the listContents function");
   BOOST_TEST_MESSAGE(" ");
 
-  FileSystemProvider fsp {temp_dir.path().native()+"/euclid/", std::move(fp)};
+  FileSystemProvider fsp{temp_dir.path().native() + "/euclid/", std::move(fp)};
 
   // Even with two slashes in the group it must work
-  group = "filter/MER//";
+  group                                    = "filter/MER//";
   std::vector<QualifiedName> result_vector = fsp.listContents(group);
   BOOST_CHECK_EQUAL(2, result_vector.size());
-  BOOST_CHECK(std::find(result_vector.begin(), result_vector.end(), QualifiedName{{"filter","MER"},"Dataset_name_for_file1"})!=result_vector.end());
-  BOOST_CHECK(std::find(result_vector.begin(), result_vector.end(), QualifiedName{{"filter","MER"},"file2"})!=result_vector.end());
+  BOOST_CHECK(std::find(result_vector.begin(), result_vector.end(), QualifiedName{{"filter", "MER"}, "Dataset_name_for_file1"}) !=
+              result_vector.end());
+  BOOST_CHECK(std::find(result_vector.begin(), result_vector.end(), QualifiedName{{"filter", "MER"}, "file2"}) !=
+              result_vector.end());
 
   // With this group the vector must be empty
-  group = "MER";
+  group                                     = "MER";
   std::vector<QualifiedName> result_vector2 = fsp.listContents(group);
   BOOST_CHECK_EQUAL(0, result_vector2.size());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -192,20 +187,19 @@ BOOST_FIXTURE_TEST_CASE(getDataset_test, FileSystemProvider_Fixture) {
   BOOST_TEST_MESSAGE("--> Testing the getDataset function");
   BOOST_TEST_MESSAGE(" ");
 
-  FileSystemProvider fsp {temp_dir.path().native()+"/euclid/", std::move(fp)};
+  FileSystemProvider fsp{temp_dir.path().native() + "/euclid/", std::move(fp)};
 
   // Check that a pointer must be returned (and not the nullptr)
-  QualifiedName identifier {{"filter","MER"},"Dataset_name_for_file1"};
+  QualifiedName                                 identifier{{"filter", "MER"}, "Dataset_name_for_file1"};
   std::unique_ptr<Euclid::XYDataset::XYDataset> dataset_ptr = fsp.getDataset(identifier);
 
   BOOST_CHECK(dataset_ptr);
 
   // Check a nullptr must be returned
-  identifier = QualifiedName{{"filter"},"DOES_NOT_EXIST"};
+  identifier  = QualifiedName{{"filter"}, "DOES_NOT_EXIST"};
   dataset_ptr = fsp.getDataset(identifier);
 
   BOOST_CHECK(!dataset_ptr);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -222,18 +216,17 @@ BOOST_FIXTURE_TEST_CASE(empty_order_file_listContents_test, FileSystemProvider_F
   // Empty order.txt file
   order_mer.close();
 
-  FileSystemProvider fsp {temp_dir.path().native()+"/euclid/", std::move(fp)};
+  FileSystemProvider fsp{temp_dir.path().native() + "/euclid/", std::move(fp)};
 
   // Even with two slashes in the group it must work
-  group = "filter/MER//";
+  group                                    = "filter/MER//";
   std::vector<QualifiedName> result_vector = fsp.listContents(group);
-  for(auto& elt : result_vector){
-    std::cout<<elt.datasetName()<<std::endl;
+  for (auto& elt : result_vector) {
+    std::cout << elt.datasetName() << std::endl;
   }
   BOOST_CHECK_EQUAL(2, result_vector.size());
   BOOST_CHECK_EQUAL(result_vector[0].datasetName(), "Dataset_name_for_file1");
   BOOST_CHECK_EQUAL(result_vector[1].datasetName(), "file2");
-
 }
 
 //-----------------------------------------------------------------------------
@@ -250,23 +243,22 @@ BOOST_FIXTURE_TEST_CASE(ordering_listContents_test, FileSystemProvider_Fixture) 
   // Empty order.txt file
   order_mer << "file2.txt\n";
   order_mer << "file1.txt\n";
-  order_mer << "file3.txt\n"; // This file should have no effect to the result
+  order_mer << "file3.txt\n";  // This file should have no effect to the result
   order_mer.close();
 
-  FileSystemProvider fsp {temp_dir.path().native()+"/euclid/", std::move(fp)};
+  FileSystemProvider fsp{temp_dir.path().native() + "/euclid/", std::move(fp)};
 
   // Even with two slashes in the group it must work
-  group = "filter/MER//";
+  group                                    = "filter/MER//";
   std::vector<QualifiedName> result_vector = fsp.listContents(group);
-  for(auto& elt : result_vector){
-    std::cout<<elt.datasetName()<<std::endl;
+  for (auto& elt : result_vector) {
+    std::cout << elt.datasetName() << std::endl;
   }
   BOOST_CHECK_EQUAL(2, result_vector.size());
   BOOST_CHECK_EQUAL(result_vector[0].datasetName(), "file2");
   BOOST_CHECK_EQUAL(result_vector[1].datasetName(), "Dataset_name_for_file1");
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/XYDataset/tests/src/FitsParser_test.cpp
+++ b/XYDataset/tests/src/FitsParser_test.cpp
@@ -1,77 +1,72 @@
 /*
- * Copyright (C) 2012-2020 Euclid Science Ground Segment    
- *  
+ * Copyright (C) 2012-2020 Euclid Science Ground Segment
+ *
  * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free 
- * Software Foundation; either version 3.0 of the License, or (at your option)  
- * any later version.  
- *  
- * This library is distributed in the hope that it will be useful, but WITHOUT 
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  
- * details.  
- *  
- * You should have received a copy of the GNU Lesser General Public License 
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA  
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
- 
- /**
+
+/**
  * @file tests/src/FitsParser_test.cpp
  *
  * @date May 19, 2014
  * @author Nicolas Morisset
  */
 
-#include <iostream>
 #include <fstream>
-#include <string>
+#include <iostream>
 #include <memory>
+#include <string>
 
-#include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include "ElementsKernel/Exception.h"
 #include "ElementsKernel/Temporary.h"
-#include <CCfits/CCfits>
 #include "XYDataset/FitsParser.h"
 #include "XYDataset/XYDataset.h"
+#include <CCfits/CCfits>
 
 using namespace Euclid::XYDataset;
 
-
 CCfits::Table* addTable(CCfits::FITS& fits) {
-  std::vector<std::string> names {"X","Y"};
-  std::vector<std::string> types {"D","D"};
-  CCfits::Table* table_hdu = fits.addTable("extension", 2, names, types);
-  std::vector<double> x_values {3.4f, 2.1e-3f};
+  std::vector<std::string> names{"X", "Y"};
+  std::vector<std::string> types{"D", "D"};
+  CCfits::Table*           table_hdu = fits.addTable("extension", 2, names, types);
+  std::vector<double>      x_values{3.4f, 2.1e-3f};
   table_hdu->column(1).write(x_values, 1);
-  std::vector<double> y_values {3.4, 2.1e-13};
+  std::vector<double> y_values{3.4, 2.1e-13};
   table_hdu->column(2).write(y_values, 1);
-  table_hdu->addKey("dataset", "TEST_NAME","Dataset name");
+  table_hdu->addKey("dataset", "TEST_NAME", "Dataset name");
   return table_hdu;
 }
 
 struct FitsParser_Fixture {
   Elements::TempDir temp_dir;
-  std::string fits_file        = temp_dir.path().native()+"/FitsParser_test.fits";
-  std::string fits_nodata_file = temp_dir.path().native()+"/FitsParser_nodata_test.fits";
-
+  std::string       fits_file        = temp_dir.path().native() + "/FitsParser_test.fits";
+  std::string       fits_nodata_file = temp_dir.path().native() + "/FitsParser_nodata_test.fits";
 
   FitsParser_Fixture() {
-    std::unique_ptr<CCfits::FITS> fits { new CCfits::FITS("!"+fits_file, CCfits::RWmode::Write) };
+    std::unique_ptr<CCfits::FITS> fits{new CCfits::FITS("!" + fits_file, CCfits::RWmode::Write)};
     addTable(*fits);
-    std::unique_ptr<CCfits::FITS> fits_nodata { new CCfits::FITS("!"+fits_nodata_file, CCfits::RWmode::Write) };
- }
-  ~FitsParser_Fixture() {
-
+    std::unique_ptr<CCfits::FITS> fits_nodata{new CCfits::FITS("!" + fits_nodata_file, CCfits::RWmode::Write)};
   }
-
+  ~FitsParser_Fixture() {}
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (FitsParser_test)
+BOOST_AUTO_TEST_SUITE(FitsParser_test)
 //-----------------------------------------------------------------------------
 // Test the exception of the getParameter function
 //-----------------------------------------------------------------------------
@@ -84,7 +79,7 @@ BOOST_FIXTURE_TEST_CASE(exception_getParameter_function_test, FitsParser_Fixture
 
   FitsParser parser{};
 
-  BOOST_CHECK_THROW(parser.getParameter("File_does_not_exist.fits","DATASET"), Elements::Exception);
+  BOOST_CHECK_THROW(parser.getParameter("File_does_not_exist.fits", "DATASET"), Elements::Exception);
 }
 
 //-----------------------------------------------------------------------------
@@ -98,14 +93,12 @@ BOOST_FIXTURE_TEST_CASE(getParameter_function_test, FitsParser_Fixture) {
   BOOST_TEST_MESSAGE(" ");
 
   // The dataset is the correct name, result: Keyword value
-  FitsParser fits_parser {"DATASET"};
+  FitsParser fits_parser{"DATASET"};
 
-  BOOST_CHECK_EQUAL("TEST_NAME", fits_parser.getParameter(fits_file,"DATASET"));
+  BOOST_CHECK_EQUAL("TEST_NAME", fits_parser.getParameter(fits_file, "DATASET"));
 
-  BOOST_CHECK_EQUAL("", fits_parser.getParameter(fits_file,"NOT_EXISTING"));
+  BOOST_CHECK_EQUAL("", fits_parser.getParameter(fits_file, "NOT_EXISTING"));
 }
-
-
 
 //-----------------------------------------------------------------------------
 // Test the exception of the getName function
@@ -133,7 +126,7 @@ BOOST_FIXTURE_TEST_CASE(getName_function_test, FitsParser_Fixture) {
   BOOST_TEST_MESSAGE(" ");
 
   // The dataset is the correct name, result: Keyword value
-  FitsParser fits_parser {"DATASET"};
+  FitsParser fits_parser{"DATASET"};
 
   BOOST_CHECK_EQUAL("TEST_NAME", fits_parser.getName(fits_file));
 
@@ -142,9 +135,6 @@ BOOST_FIXTURE_TEST_CASE(getName_function_test, FitsParser_Fixture) {
 
   BOOST_CHECK_EQUAL("FitsParser_test", fits_parser.getName(fits_file));
 }
-
-
-
 
 //-----------------------------------------------------------------------------
 // Test the getDataset function
@@ -156,15 +146,14 @@ BOOST_FIXTURE_TEST_CASE(getDataset_function_test, FitsParser_Fixture) {
   BOOST_TEST_MESSAGE("--> Testing the getDataset function");
   BOOST_TEST_MESSAGE(" ");
 
-  FitsParser fits_parser {"TEST_NAME"};
-  auto xy_ptr = fits_parser.getDataset(fits_file);
+  FitsParser fits_parser{"TEST_NAME"};
+  auto       xy_ptr = fits_parser.getDataset(fits_file);
   BOOST_CHECK_EQUAL(xy_ptr->size(), 2);
 
   // Catch exception if FITS file incorrect
-  FitsParser fits_parser_nodata { };
+  FitsParser fits_parser_nodata{};
 
   BOOST_CHECK_THROW(fits_parser_nodata.getDataset(fits_nodata_file), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -179,14 +168,10 @@ BOOST_FIXTURE_TEST_CASE(isDatatsetFile_function_test, FitsParser_Fixture) {
   BOOST_TEST_MESSAGE("--> Testing the isDatatsetFile function");
   BOOST_TEST_MESSAGE(" ");
 
-  FitsParser fits_parser {"TEST_NAME"};
+  FitsParser fits_parser{"TEST_NAME"};
 
   BOOST_CHECK_EQUAL(fits_parser.isDatasetFile(fits_file), true);
   BOOST_CHECK_EQUAL(fits_parser.isDatasetFile(fits_nodata_file), false);
-
 }
 
-
-BOOST_AUTO_TEST_SUITE_END ()
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/XYDataset/tests/src/QualifiedName_test.cpp
+++ b/XYDataset/tests/src/QualifiedName_test.cpp
@@ -16,22 +16,22 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/QualifiedName_test.cpp
  * @date May 19, 2014
  * @author Nikolaos Apostolakos
  */
 
-#include <string>
-#include <set>
 #include <boost/test/unit_test.hpp>
+#include <set>
+#include <string>
 
 #include "ElementsKernel/Exception.h"
 #include "XYDataset/QualifiedName.h"
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (QualifiedName_test)
+BOOST_AUTO_TEST_SUITE(QualifiedName_test)
 
 //-----------------------------------------------------------------------------
 // Check that invalid constructor arguments throw exceptions
@@ -39,11 +39,10 @@ BOOST_AUTO_TEST_SUITE (QualifiedName_test)
 
 BOOST_AUTO_TEST_CASE(constructorExceptions_test) {
 
-  BOOST_CHECK_THROW((Euclid::XYDataset::QualifiedName{{"","g"}, "b"}),Elements::Exception);
+  BOOST_CHECK_THROW((Euclid::XYDataset::QualifiedName{{"", "g"}, "b"}), Elements::Exception);
   BOOST_CHECK_THROW((Euclid::XYDataset::QualifiedName{{"asd/sad", "g"}, "b"}), Elements::Exception);
-  BOOST_CHECK_THROW((Euclid::XYDataset::QualifiedName{{"a","g"}, ""}), Elements::Exception);
-  BOOST_CHECK_THROW((Euclid::XYDataset::QualifiedName{{"a","g"}, "bdf/sdf"}), Elements::Exception);
-
+  BOOST_CHECK_THROW((Euclid::XYDataset::QualifiedName{{"a", "g"}, ""}), Elements::Exception);
+  BOOST_CHECK_THROW((Euclid::XYDataset::QualifiedName{{"a", "g"}, "bdf/sdf"}), Elements::Exception);
 }
 
 //-----------------------------------------------------------------------------
@@ -55,30 +54,29 @@ BOOST_AUTO_TEST_CASE(nameMethods_test) {
   // Given
   std::string group1 = "TestGroup1";
   std::string group2 = "TestGroup2";
-  std::string name = "TestName";
+  std::string name   = "TestName";
 
   // When
-  Euclid::XYDataset::QualifiedName qualifiedName1 {{group1,group2}, name};
-  auto groups1 = qualifiedName1.groups();
-  Euclid::XYDataset::QualifiedName qualifiedName2 {{group1}, name};
-  auto groups2 = qualifiedName2.groups();
-  Euclid::XYDataset::QualifiedName qualifiedName3 {{}, name};
-  auto groups3 = qualifiedName3.groups();
+  Euclid::XYDataset::QualifiedName qualifiedName1{{group1, group2}, name};
+  auto                             groups1 = qualifiedName1.groups();
+  Euclid::XYDataset::QualifiedName qualifiedName2{{group1}, name};
+  auto                             groups2 = qualifiedName2.groups();
+  Euclid::XYDataset::QualifiedName qualifiedName3{{}, name};
+  auto                             groups3 = qualifiedName3.groups();
 
   // Then
   BOOST_CHECK_EQUAL(groups1.size(), 2);
   BOOST_CHECK_EQUAL(groups1[0], group1);
   BOOST_CHECK_EQUAL(groups1[1], group2);
   BOOST_CHECK_EQUAL(qualifiedName1.datasetName(), name);
-  BOOST_CHECK_EQUAL(qualifiedName1.qualifiedName(), group1+"/"+group2+"/"+name);
+  BOOST_CHECK_EQUAL(qualifiedName1.qualifiedName(), group1 + "/" + group2 + "/" + name);
   BOOST_CHECK_EQUAL(groups2.size(), 1);
   BOOST_CHECK_EQUAL(groups2[0], group1);
   BOOST_CHECK_EQUAL(qualifiedName2.datasetName(), name);
-  BOOST_CHECK_EQUAL(qualifiedName2.qualifiedName(), group1+"/"+name);
+  BOOST_CHECK_EQUAL(qualifiedName2.qualifiedName(), group1 + "/" + name);
   BOOST_CHECK_EQUAL(groups3.size(), 0);
   BOOST_CHECK_EQUAL(qualifiedName3.datasetName(), name);
   BOOST_CHECK_EQUAL(qualifiedName3.qualifiedName(), name);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -88,15 +86,15 @@ BOOST_AUTO_TEST_CASE(nameMethods_test) {
 BOOST_AUTO_TEST_CASE(belongsInGroup_test) {
 
   // Given
-  Euclid::XYDataset::QualifiedName qualified_name {"group1/group2/group3/name"};
+  Euclid::XYDataset::QualifiedName qualified_name{"group1/group2/group3/name"};
 
   // When
-  Euclid::XYDataset::QualifiedName group1 {"group1"};
-  Euclid::XYDataset::QualifiedName group1_group2 {"group1/group2"};
-  Euclid::XYDataset::QualifiedName group1_group2_group3 {"group1/group2/group3"};
-  Euclid::XYDataset::QualifiedName wrong_group_1 {"wrong_group"};
-  Euclid::XYDataset::QualifiedName wrong_group_2 {"group1group2"};
-  Euclid::XYDataset::QualifiedName wrong_group_3 {"group1/group4/group3"};
+  Euclid::XYDataset::QualifiedName group1{"group1"};
+  Euclid::XYDataset::QualifiedName group1_group2{"group1/group2"};
+  Euclid::XYDataset::QualifiedName group1_group2_group3{"group1/group2/group3"};
+  Euclid::XYDataset::QualifiedName wrong_group_1{"wrong_group"};
+  Euclid::XYDataset::QualifiedName wrong_group_2{"group1group2"};
+  Euclid::XYDataset::QualifiedName wrong_group_3{"group1/group4/group3"};
 
   // Then
   BOOST_CHECK(qualified_name.belongsInGroup(group1));
@@ -106,7 +104,6 @@ BOOST_AUTO_TEST_CASE(belongsInGroup_test) {
   BOOST_CHECK(!qualified_name.belongsInGroup(wrong_group_2));
   BOOST_CHECK(!qualified_name.belongsInGroup(wrong_group_3));
   BOOST_CHECK(!qualified_name.belongsInGroup(qualified_name));
-
 }
 
 //-----------------------------------------------------------------------------
@@ -116,29 +113,29 @@ BOOST_AUTO_TEST_CASE(belongsInGroup_test) {
 BOOST_AUTO_TEST_CASE(hashMethod_test) {
 
   // Given
-  Euclid::XYDataset::QualifiedName qualifiedName1 {{"group1","group2"}, "name"};
-  Euclid::XYDataset::QualifiedName qualifiedName2 {{"group1","group2"}, "name"};
+  Euclid::XYDataset::QualifiedName qualifiedName1{{"group1", "group2"}, "name"};
+  Euclid::XYDataset::QualifiedName qualifiedName2{{"group1", "group2"}, "name"};
 
   // Then
   BOOST_CHECK_EQUAL(qualifiedName1.hash(), qualifiedName2.hash());
 
   // Given
-  qualifiedName1 = Euclid::XYDataset::QualifiedName {{"group1","group2"}, "name"};
-  qualifiedName2 = Euclid::XYDataset::QualifiedName {{"group1","group2"}, "name2"};
+  qualifiedName1 = Euclid::XYDataset::QualifiedName{{"group1", "group2"}, "name"};
+  qualifiedName2 = Euclid::XYDataset::QualifiedName{{"group1", "group2"}, "name2"};
 
   // Then
   BOOST_CHECK_NE(qualifiedName1.hash(), qualifiedName2.hash());
 
   // Given
-  qualifiedName1 = Euclid::XYDataset::QualifiedName {{"group1","group2"}, "name"};
-  qualifiedName2 = Euclid::XYDataset::QualifiedName {{"group1","grou2"}, "name"};
+  qualifiedName1 = Euclid::XYDataset::QualifiedName{{"group1", "group2"}, "name"};
+  qualifiedName2 = Euclid::XYDataset::QualifiedName{{"group1", "grou2"}, "name"};
 
   // Then
   BOOST_CHECK_NE(qualifiedName1.hash(), qualifiedName2.hash());
 
   // Given
-  qualifiedName1 = Euclid::XYDataset::QualifiedName {{"group1","group2"}, "name"};
-  qualifiedName2 = Euclid::XYDataset::QualifiedName {{"group1","group2"}, "name2"};
+  qualifiedName1 = Euclid::XYDataset::QualifiedName{{"group1", "group2"}, "name"};
+  qualifiedName2 = Euclid::XYDataset::QualifiedName{{"group1", "group2"}, "name2"};
 
   // Then
   BOOST_CHECK_NE(qualifiedName1.hash(), qualifiedName2.hash());
@@ -157,17 +154,17 @@ BOOST_AUTO_TEST_CASE(hashMethod_test) {
 BOOST_AUTO_TEST_CASE(comparison_test) {
 
   // Given
-  Euclid::XYDataset::QualifiedName qualifiedName1 {{"group1","group2"}, "name"};
-  Euclid::XYDataset::QualifiedName qualifiedName2 {{"group1","group2"}, "name"};
+  Euclid::XYDataset::QualifiedName qualifiedName1{{"group1", "group2"}, "name"};
+  Euclid::XYDataset::QualifiedName qualifiedName2{{"group1", "group2"}, "name"};
 
   // Then
   BOOST_CHECK(!(qualifiedName1 < qualifiedName2));
   BOOST_CHECK(!(qualifiedName2 < qualifiedName1));
 
   // Given
-  qualifiedName1 = Euclid::XYDataset::QualifiedName {{"agroup"}, "aname"};
-  qualifiedName2 = Euclid::XYDataset::QualifiedName {{"bgroup"}, "aname"};
-  Euclid::XYDataset::QualifiedName qualifiedName3 {{"bgroup"}, "bname"};
+  qualifiedName1 = Euclid::XYDataset::QualifiedName{{"agroup"}, "aname"};
+  qualifiedName2 = Euclid::XYDataset::QualifiedName{{"bgroup"}, "aname"};
+  Euclid::XYDataset::QualifiedName qualifiedName3{{"bgroup"}, "bname"};
 
   // Then
   BOOST_CHECK((qualifiedName1 < qualifiedName2) ^ (qualifiedName2 < qualifiedName1));
@@ -181,24 +178,22 @@ BOOST_AUTO_TEST_CASE(comparison_test) {
 
 BOOST_AUTO_TEST_CASE(equality_test) {
 
-
   // Given
-  Euclid::XYDataset::QualifiedName qualifiedName1 {{"group1","group2"}, "name"};
-  Euclid::XYDataset::QualifiedName qualifiedName2 {{"group1","group2"}, "name"};
+  Euclid::XYDataset::QualifiedName qualifiedName1{{"group1", "group2"}, "name"};
+  Euclid::XYDataset::QualifiedName qualifiedName2{{"group1", "group2"}, "name"};
 
   // Then
   BOOST_CHECK(qualifiedName1 == qualifiedName2);
 
   // Given
-  qualifiedName1 = Euclid::XYDataset::QualifiedName {{"agroup"}, "aname"};
-  qualifiedName2 = Euclid::XYDataset::QualifiedName {{"bgroup"}, "aname"};
-  Euclid::XYDataset::QualifiedName qualifiedName3 {{"bgroup"}, "bname"};
+  qualifiedName1 = Euclid::XYDataset::QualifiedName{{"agroup"}, "aname"};
+  qualifiedName2 = Euclid::XYDataset::QualifiedName{{"bgroup"}, "aname"};
+  Euclid::XYDataset::QualifiedName qualifiedName3{{"bgroup"}, "bname"};
 
   // Then
   BOOST_CHECK(!(qualifiedName1 == qualifiedName2));
   BOOST_CHECK(!(qualifiedName2 == qualifiedName3));
   BOOST_CHECK(!(qualifiedName1 == qualifiedName3));
-
 }
 
 //-----------------------------------------------------------------------------
@@ -208,12 +203,12 @@ BOOST_AUTO_TEST_CASE(equality_test) {
 BOOST_AUTO_TEST_CASE(alphabeticalOrdering_test) {
 
   // Given
-  Euclid::XYDataset::QualifiedName qualifiedName1 {{"SDSS"}, "g"};
-  Euclid::XYDataset::QualifiedName qualifiedName2 {{"COSMOS"}, "g"};
-  Euclid::XYDataset::QualifiedName qualifiedName3 {{"COSMOS"}, "z"};
+  Euclid::XYDataset::QualifiedName qualifiedName1{{"SDSS"}, "g"};
+  Euclid::XYDataset::QualifiedName qualifiedName2{{"COSMOS"}, "g"};
+  Euclid::XYDataset::QualifiedName qualifiedName3{{"COSMOS"}, "z"};
 
   // When
-  std::set<Euclid::XYDataset::QualifiedName, Euclid::XYDataset::QualifiedName::AlphabeticalComparator> filterSet {};
+  std::set<Euclid::XYDataset::QualifiedName, Euclid::XYDataset::QualifiedName::AlphabeticalComparator> filterSet{};
   filterSet.insert(qualifiedName1);
   filterSet.insert(qualifiedName2);
   filterSet.insert(qualifiedName3);
@@ -228,7 +223,6 @@ BOOST_AUTO_TEST_CASE(alphabeticalOrdering_test) {
   BOOST_CHECK((*iterator) == qualifiedName3);
   ++iterator;
   BOOST_CHECK((*iterator) == qualifiedName1);
-
 }
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()

--- a/XYDataset/tests/src/XYDataset_test.cpp
+++ b/XYDataset/tests/src/XYDataset_test.cpp
@@ -16,33 +16,32 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
- /**
+/**
  * @file tests/src/XYDataset_test.cpp
  *
  * @date Apr 9, 2014
  * @author Nicolas Morisset
  */
 
-#include <iostream>
 #include <boost/test/unit_test.hpp>
+#include <iostream>
 
 #include "ElementsKernel/Exception.h"
 #include "XYDataset/XYDataset.h"
-
 
 namespace Euclid {
 namespace XYDataset {
 
 struct XYDataset_Fixture {
-  std::vector<double> vector1 {1., 2., 3., 4., 5.};
-  std::vector<double> vector2 {1.1, 2.2, 3.3, 4.4, 5.5};
-  std::vector<double> vector3 {1.1, 2.2, 3.3};
-  std::vector<std::pair<double,double>> vector_pair { {1,1}, {2,2}, {3,3} };
+  std::vector<double>                    vector1{1., 2., 3., 4., 5.};
+  std::vector<double>                    vector2{1.1, 2.2, 3.3, 4.4, 5.5};
+  std::vector<double>                    vector3{1.1, 2.2, 3.3};
+  std::vector<std::pair<double, double>> vector_pair{{1, 1}, {2, 2}, {3, 3}};
 };
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE (XYDataset_test)
+BOOST_AUTO_TEST_SUITE(XYDataset_test)
 
 //-----------------------------------------------------------------------------
 // Test the move constructor
@@ -58,7 +57,6 @@ BOOST_FIXTURE_TEST_CASE(MoveConstructor_test, XYDataset_Fixture) {
   auto xy_move(std::move(xydataset));
 
   BOOST_CHECK(3 == xy_move.size());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -74,7 +72,6 @@ BOOST_FIXTURE_TEST_CASE(Constructor1_test, XYDataset_Fixture) {
   auto xydataset = Euclid::XYDataset::XYDataset::factory(vector_pair);
 
   BOOST_CHECK(3 == xydataset.size());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -90,7 +87,6 @@ BOOST_FIXTURE_TEST_CASE(Constructor2_test, XYDataset_Fixture) {
   auto xydataset = Euclid::XYDataset::XYDataset::factory(vector1, vector2);
 
   BOOST_CHECK(5 == xydataset.size());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -105,7 +101,6 @@ BOOST_FIXTURE_TEST_CASE(factory_test, XYDataset_Fixture) {
 
   auto xydataset = Euclid::XYDataset::XYDataset::factory(vector1, vector2);
   BOOST_CHECK(5 == xydataset.size());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -119,7 +114,6 @@ BOOST_FIXTURE_TEST_CASE(exception_test, XYDataset_Fixture) {
   BOOST_TEST_MESSAGE(" ");
 
   BOOST_CHECK_THROW(Euclid::XYDataset::XYDataset::factory(vector1, vector3), Elements::Exception);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -133,25 +127,24 @@ BOOST_FIXTURE_TEST_CASE(const_iterator_test, XYDataset_Fixture) {
   BOOST_TEST_MESSAGE(" ");
 
   auto xydataset = Euclid::XYDataset::XYDataset::factory(vector1, vector2);
-  auto it = xydataset.begin();
+  auto it        = xydataset.begin();
 
-// The XYDataset specification guarantees that the iterator will iterate over
-// the exact same double representations in the memory (which is a stricter
-// guarantee than just the same real number representation). To allow testing
-// the float-equal warning must be dissabled.
-// WARNING: In the following lines the double literals are NOT representing the
-// real values (1, 1.1, etc) but the double representation of these values as
-// converted by the compiler. The test guarantees that the XYDataset does not
-// perform any arithmetics with them.
-  BOOST_CHECK(1   == it->first);
+  // The XYDataset specification guarantees that the iterator will iterate over
+  // the exact same double representations in the memory (which is a stricter
+  // guarantee than just the same real number representation). To allow testing
+  // the float-equal warning must be dissabled.
+  // WARNING: In the following lines the double literals are NOT representing the
+  // real values (1, 1.1, etc) but the double representation of these values as
+  // converted by the compiler. The test guarantees that the XYDataset does not
+  // perform any arithmetics with them.
+  BOOST_CHECK(1 == it->first);
   BOOST_CHECK(1.1 == it->second);
   ++it;
-  BOOST_CHECK(2   == it->first);
+  BOOST_CHECK(2 == it->first);
   BOOST_CHECK(2.2 == it->second);
   it = --xydataset.end();
-  BOOST_CHECK(5   == it->first);
+  BOOST_CHECK(5 == it->first);
   BOOST_CHECK(5.5 == it->second);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -164,28 +157,27 @@ BOOST_FIXTURE_TEST_CASE(front_back_test, XYDataset_Fixture) {
   BOOST_TEST_MESSAGE("--> Testing the front, back functions");
   BOOST_TEST_MESSAGE(" ");
 
-  auto xydataset = Euclid::XYDataset::XYDataset::factory(vector1, vector2);
-  auto& front = xydataset.front();
-  auto& back = xydataset.back();
+  auto  xydataset = Euclid::XYDataset::XYDataset::factory(vector1, vector2);
+  auto& front     = xydataset.front();
+  auto& back      = xydataset.back();
 
-// The XYDataset specification guarantees that the iterator will iterate over
-// the exact same double representations in the memory (which is a stricter
-// guarantee than just the same real number representation). To allow testing
-// the float-equal warning must be dissabled.
-// WARNING: In the following lines the double literals are NOT representing the
-// real values (1, 1.1, etc) but the double representation of these values as
-// converted by the compiler. The test guarantees that the XYDataset does not
-// perform any arithmetics with them.
-  BOOST_CHECK(1   == front.first);
+  // The XYDataset specification guarantees that the iterator will iterate over
+  // the exact same double representations in the memory (which is a stricter
+  // guarantee than just the same real number representation). To allow testing
+  // the float-equal warning must be dissabled.
+  // WARNING: In the following lines the double literals are NOT representing the
+  // real values (1, 1.1, etc) but the double representation of these values as
+  // converted by the compiler. The test guarantees that the XYDataset does not
+  // perform any arithmetics with them.
+  BOOST_CHECK(1 == front.first);
   BOOST_CHECK(1.1 == front.second);
-  BOOST_CHECK(5   == back.first);
+  BOOST_CHECK(5 == back.first);
   BOOST_CHECK(5.5 == back.second);
-
 }
 
 //-----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE_END ()
+BOOST_AUTO_TEST_SUITE_END()
 
-}
-} // end of namespace Euclid
+}  // namespace XYDataset
+}  // end of namespace Euclid


### PR DESCRIPTION
`.clang-format` copied from Elements, but tweaked a bit:

```diff
12c12
< AllowShortBlocksOnASingleLine: true
---
> AllowShortBlocksOnASingleLine: false
14c14
< AllowShortFunctionsOnASingleLine: Inline
---
> AllowShortFunctionsOnASingleLine: Empty
```

I agree with Hubert  it is nice to have a tool do the formatting the same way for everybody.