### PR TITLE
Fix include for boost 1.73

### DIFF
--- a/Table/src/lib/AsciiReader.cpp
+++ b/Table/src/lib/AsciiReader.cpp
@@ -32,7 +32,12 @@
 using boost::regex;
 using boost::regex_match;
 #include <boost/algorithm/string.hpp>
+
+#if BOOST_VERSION < 107300
 #include <boost/io/detail/quoted_manip.hpp>
+#else
+#include <boost/io/quoted.hpp>
+#endif
 
 #include "ElementsKernel/Exception.h"
 #include "Table/AsciiReader.h"

--- a/Table/src/lib/AsciiWriterHelper.cpp
+++ b/Table/src/lib/AsciiWriterHelper.cpp
@@ -25,9 +25,14 @@
 #include "AsciiWriterHelper.h"
 #include "ElementsKernel/Exception.h"
 #include <algorithm>
-#include <boost/io/detail/quoted_manip.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
+
+#if BOOST_VERSION < 107300
+#include <boost/io/detail/quoted_manip.hpp>
+#else
+#include <boost/io/quoted.hpp>
+#endif
 
 namespace Euclid {
 namespace Table {

--- a/Table/src/lib/AsciiWriterHelper.h
+++ b/Table/src/lib/AsciiWriterHelper.h
@@ -25,13 +25,11 @@
 #ifndef TABLE_ASCIIWRITERHELPER_H
 #define TABLE_ASCIIWRITERHELPER_H
 
-#include <boost/io/detail/quoted_manip.hpp>
 #include <sstream>
 #include <typeindex>
 #include <vector>
 
 #include "ElementsKernel/Export.h"
-
 #include "Table/Table.h"
 
 namespace Euclid {


### PR DESCRIPTION
`boost/io/detail/quoted_manip.hpp` has been moved to `boost/io/quoted.hpp`