### PR TITLE
Stop using internal Boost header

### DIFF
--- a/Table/src/lib/AsciiReader.cpp
+++ b/Table/src/lib/AsciiReader.cpp
@@ -32,7 +32,12 @@
 using boost::regex;
 using boost::regex_match;
 #include <boost/algorithm/string.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 107300
+#include <boost/io/quoted.hpp>
+#else
 #include <boost/io/detail/quoted_manip.hpp>
+#endif
 
 #include "ElementsKernel/Exception.h"
 #include "Table/AsciiReader.h"

--- a/Table/src/lib/AsciiWriterHelper.cpp
+++ b/Table/src/lib/AsciiWriterHelper.cpp
@@ -25,7 +25,6 @@
 #include <algorithm>
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
-#include <boost/io/detail/quoted_manip.hpp>
 #include "ElementsKernel/Exception.h"
 #include "AsciiWriterHelper.h"
 

--- a/Table/src/lib/AsciiWriterHelper.h
+++ b/Table/src/lib/AsciiWriterHelper.h
@@ -27,7 +27,12 @@
 
 #include <vector>
 #include <typeindex>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 107300
+#include <boost/io/quoted.hpp>
+#else
 #include <boost/io/detail/quoted_manip.hpp>
+#endif
 
 #include "ElementsKernel/Export.h"
 


### PR DESCRIPTION
Use the public header, not the "detail" one.

The new public header was added in Boost 1.73.0 and the old one was removed in Boost 1.74.0

See https://github.com/boostorg/io/commit/76ee3467734f84f30cdf9c2d593839962a475e9c
and https://github.com/boostorg/io/commit/e276f63390a225df3af442889258078f9be27cdb
and https://github.com/boostorg/io/commit/cfe2e98267a38a8df3b9b4d37c67413070e0e4af