### PR TITLE
Fixes for s390x and armv7

### DIFF
--- a/NdArray/NdArray/io/_impl/NpyCommon.h
+++ b/NdArray/NdArray/io/_impl/NpyCommon.h
@@ -236,7 +236,7 @@ inline void readNpyHeader(std::istream& input, std::string& dtype, std::vector<s
   if (fortran_order)
     throw Elements::Exception() << "Fortran order not supported";
 
-  if (big_endian && (BYTE_ORDER != BIG_ENDIAN))
+  if ((big_endian && (BYTE_ORDER != BIG_ENDIAN)) || (!big_endian && (BYTE_ORDER != LITTLE_ENDIAN)))
     throw Elements::Exception() << "Only native endianness supported for reading";
 }
 

--- a/NdArray/NdArray/io/_impl/NpyCommon.h
+++ b/NdArray/NdArray/io/_impl/NpyCommon.h
@@ -294,13 +294,14 @@ void writeNpyHeader(std::ostream& out, std::vector<size_t> shape, const std::vec
   little_uint32_t header_len = header_str.size();
 
   // Pad header with spaces so the header block is 64 bytes aligned
-  size_t total_length = sizeof(NPY_MAGIC) + sizeof(NPY_VERSION) + sizeof(header_len) + header_len - 1;  // Keep 1 for \n
+  size_t total_length = sizeof(NPY_MAGIC) + sizeof(NPY_VERSION) + sizeof(header_len) + header_len + 1;  // Keep 1 for \n
   size_t padding      = 64 - total_length % 64;
   if (padding) {
-    header << std::string(padding, '\x20') << '\n';
-    header_str = header.str();
-    header_len = header_str.size();
+    header << std::string(padding, '\x20');
   }
+  header << '\n';
+  header_str = header.str();
+  header_len = header_str.size();
 
   // Magic and version
   out.write(NPY_MAGIC, sizeof(NPY_MAGIC));

--- a/NdArray/NdArray/io/_impl/NpyMmap.icpp
+++ b/NdArray/NdArray/io/_impl/NpyMmap.icpp
@@ -67,6 +67,8 @@ NdArray<T> createMmapNpy(const boost::filesystem::path& path, const std::vector<
   auto header_str  = header.str();
   auto header_size = header_str.size();
 
+  assert(header_size % 64 == 0);
+
   // Compute file expected size
   size_t n_elements = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<size_t>());
   if (!attrs.empty())

--- a/NdArray/tests/src/Npy_test.cpp
+++ b/NdArray/tests/src/Npy_test.cpp
@@ -160,11 +160,19 @@ BOOST_AUTO_TEST_CASE(Npy_badtype_test) {
 BOOST_AUTO_TEST_CASE(Npy_badendian_test) {
   Elements::TempFile file(std::string("npy_testpy_endian_%%.npy"));
 
+#if BYTE_ORDER == LITTLE_ENDIAN
   constexpr const char* PYCODE = R"EDOCYP(
 import sys
 import numpy as np
 np.save(sys.argv[1], np.arange(100, 400, dtype='>i8'))
 )EDOCYP";
+#else
+  constexpr const char* PYCODE = R"EDOCYP(
+import sys
+import numpy as np
+np.save(sys.argv[1], np.arange(100, 400, dtype='<i8'))
+)EDOCYP";
+#endif
 
   runPython(PYCODE, file.path());
 


### PR DESCRIPTION
There are two bugs on the NdArray code that are triggered only on non x86 architectures.

1. I forgot to add a check for reading little endian files on big endian architectures.
2. The padding for alignment of the npy header was wrongly calculated. It must be aligned to 64 bytes, but due to a miscalculation, there was an offset. x86 doesn't particular care, and neither does s390x, but armv7 does, and failed with a `SIGBUS` error when trying to access a memory-mapped  array.