### PR TITLE
Sampling required fixes for interpolation

### DIFF
--- a/MathUtils/MathUtils/interpolation/interpolation.h
+++ b/MathUtils/MathUtils/interpolation/interpolation.h
@@ -89,7 +89,8 @@ using Coordinates = std::array<std::reference_wrapper<const std::vector<double>>
  * @tparam N
  *  Dimensionality
  * @param grid
- *  Array containing the knots for each grid dimension
+ *  Array containing the knots for each grid dimension. Note that the order must follow the same as the axes!
+ *  the first coordinates corresponds to the axis 0, the second coordinates to the axis 1, and so on.
  * @param values
  *  Values at each grid point. Its shape must match the grid coordinates
  * @param type

--- a/MathUtils/src/lib/function/Piecewise.cpp
+++ b/MathUtils/src/lib/function/Piecewise.cpp
@@ -41,8 +41,8 @@ Piecewise::Piecewise(std::vector<double> knots, std::vector<std::shared_ptr<Func
 
   auto knotsIter = m_knots.begin();
   while (++knotsIter != m_knots.end()) {
-    if (*knotsIter <= *(knotsIter - 1)) {
-      throw Elements::Exception("knots must be strictly increasing");
+    if (*knotsIter < *(knotsIter - 1)) {
+      throw Elements::Exception("knots must be increasing");
     }
   }
 }

--- a/MathUtils/src/lib/interpolation/interpolation.cpp
+++ b/MathUtils/src/lib/interpolation/interpolation.cpp
@@ -65,10 +65,6 @@ std::unique_ptr<Function> interpolate(const std::vector<double>& x, const std::v
       if (y[i] == y[i - 1]) {
         logger.warn() << "Ignoring duplicate pair (" << x[i] << ", " << y[i] << ") during interpolation";
         continue;
-      } else {
-        throw InterpolationException() << "Interpolation of step functions is not "
-                                       << "supported. Entries: (" << x[i] << ", " << y[i] << ") and (" << x[i - 1] << ", "
-                                       << y[i - 1] << ")";
       }
     }
     if (x[i] < x[i - 1]) {

--- a/MathUtils/tests/src/interpolation/Linear_test.cpp
+++ b/MathUtils/tests/src/interpolation/Linear_test.cpp
@@ -130,5 +130,28 @@ BOOST_FIXTURE_TEST_CASE(Linear1DataPoint, Linear_Fixture) {
 }
 
 //-----------------------------------------------------------------------------
+// Step function
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(LinearStep, Linear_Fixture) {
+  // Given
+  std::vector<double> x{1., 2., 2., 4.};
+  std::vector<double> y{1., 2., 3., 4.};
+
+  // When
+  auto   linear = Euclid::MathUtils::interpolate(x, y, Euclid::MathUtils::InterpolationType::LINEAR, true);
+  double value1 = (*linear)(1);
+  double value2 = (*linear)(2);
+  double value3 = (*linear)(3);
+  double value4 = (*linear)(4);
+
+  // Then
+  BOOST_CHECK_CLOSE(value1, 1., close_tolerance);
+  BOOST_CHECK_CLOSE(value2, 2., close_tolerance);
+  BOOST_CHECK_CLOSE(value3, 3.5, close_tolerance);
+  BOOST_CHECK_CLOSE(value4, 4., close_tolerance);
+}
+
+//-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/MathUtils/tests/src/interpolation/NDimensional_test.cpp
+++ b/MathUtils/tests/src/interpolation/NDimensional_test.cpp
@@ -43,17 +43,16 @@ struct Fixture1D {
 from scipy.interpolate import interpn
 import numpy as np
 
-def value_func_2d(x, y):
-    return 2 * x + 3 * y
-x = np.arange(0, 3)
-y = np.arange(0, 3)
-points = (x, y)
-values = value_func_2d(*np.meshgrid(*points))
+def value_func_2d(x0, x1):
+    return 2 * x0 + 3 * x1
+x0 = np.arange(0, 3)
+x1 = np.arange(0, 3)
+values = value_func_2d(*np.meshgrid(x0, x1, indexing='ij'))
  */
 struct Fixture2D {
-  std::vector<double> x{0, 1, 2};
-  std::vector<double> y{0, 1, 2};
-  NdArray<double>     values{{3, 3}, {0, 2, 4, 3, 5, 7, 6, 8, 10}};
+  std::vector<double> x0{0, 1, 2};
+  std::vector<double> x1{0, 1, 2};
+  NdArray<double>     values{{3, 3}, {0, 3, 6, 2, 5, 8, 4, 7, 10}};
 };
 
 //-----------------------------------------------------------------------------
@@ -61,51 +60,71 @@ struct Fixture2D {
 from scipy.interpolate import interpn
 import numpy as np
 
-def value_func_3d(x, y, z):
-    return 5 * x + 8 * y - z
-x = np.arange(0, 3)
-y = np.arange(0, 3)
-z = np.arange(0, 3)
-points = (x, y, z)
-values = value_func_3d(*np.meshgrid(*points))
+def value_func_3d(x0, x1, x2):
+    return 5 * x0 + 8 * x1 - x2
+x0 = np.arange(0, 3)
+x1 = np.arange(0, 3)
+x2 = np.arange(0, 3)
+values = value_func_3d(*np.meshgrid(x0, x1, x2, indexing='ij'))
  */
 struct Fixture3D {
-  std::vector<double> x{0, 1, 2};
-  std::vector<double> y{0, 1, 2};
-  std::vector<double> z{0, 1, 2};
+  std::vector<double> x0{0, 1, 2};
+  std::vector<double> x1{0, 1, 2};
+  std::vector<double> x2{0, 1, 2};
   NdArray<double>     values{{3, 3, 3},
-                         {0, -1, -2, 5, 4, 3, 10, 9, 8, 8, 7, 6, 13, 12, 11, 18, 17, 16, 16, 15, 14, 21, 20, 19, 26, 25, 24}};
+                         {0, -1, -2, 8, 7, 6, 16, 15, 14, 5, 4, 3, 13, 12, 11, 21, 20, 19, 10, 9, 8, 18, 17, 16, 26, 25, 24}};
 };
 
 //-----------------------------------------------------------------------------
-/** Ok, I am stopping here :D
+/**
+ * Ok, I am stopping here :D
  *
 from scipy.interpolate import interpn
 import numpy as np
 
-def value_func_4d(x, y, z, w):
-    return 5 * x + 8 * y - z * w
-x = np.arange(0, 3)
-y = np.arange(0, 3)
-z = np.arange(0, 3)
-w = np.linspace(0, 5, 5)
-points = (x, y, z, w)
-values = value_func_4d(*np.meshgrid(*points))
+def value_func_4d(x0, x1, x2, x3):
+    return 5 * x0 + 8 * x1 - x2 * x3
+x0 = np.arange(0, 3)
+x1 = np.arange(0, 3)
+x2 = np.arange(0, 3)
+x3 = np.linspace(0, 5, 5)
+values = value_func_4d(*np.meshgrid(x0, x1, x2, x3, indexing='ij'))
  */
 struct Fixture4D {
-  std::vector<double> x{0, 1, 2};
-  std::vector<double> y{0, 1, 2};
-  std::vector<double> z{0, 1, 2};
-  std::vector<double> w{0., 1.25, 2.5, 3.75, 5.};
-  NdArray<double>     values{{3, 3, 3, 5}, {0.,  0.,  0.,  0.,  0.,  0.,  -1.25, -2.5, -3.75, -5., 0.,  -2.5, -5., -7.5, -10.,
-                                        5.,  5.,  5.,  5.,  5.,  5.,  3.75,  2.5,  1.25,  0.,  5.,  2.5,  0.,  -2.5, -5.,
-                                        10., 10., 10., 10., 10., 10., 8.75,  7.5,  6.25,  5.,  10., 7.5,  5.,  2.5,  0.,
+  std::vector<double> x0{0, 1, 2};
+  std::vector<double> x1{0, 1, 2};
+  std::vector<double> x2{0, 1, 2};
+  std::vector<double> x3{0., 1.25, 2.5, 3.75, 5.};
+  NdArray<double>     values{{3, 3, 3, 5}, {//
+                                        0.,  0.,  0.,  0.,  0.,  0.,  -1.25, -2.5, -3.75, -5., 0.,  -2.5, -5., -7.5, -10.,
                                         8.,  8.,  8.,  8.,  8.,  8.,  6.75,  5.5,  4.25,  3.,  8.,  5.5,  3.,  0.5,  -2.,
-                                        13., 13., 13., 13., 13., 13., 11.75, 10.5, 9.25,  8.,  13., 10.5, 8.,  5.5,  3.,
-                                        18., 18., 18., 18., 18., 18., 16.75, 15.5, 14.25, 13., 18., 15.5, 13., 10.5, 8.,
                                         16., 16., 16., 16., 16., 16., 14.75, 13.5, 12.25, 11., 16., 13.5, 11., 8.5,  6.,
+                                        5.,  5.,  5.,  5.,  5.,  5.,  3.75,  2.5,  1.25,  0.,  5.,  2.5,  0.,  -2.5, -5.,
+                                        13., 13., 13., 13., 13., 13., 11.75, 10.5, 9.25,  8.,  13., 10.5, 8.,  5.5,  3.,
                                         21., 21., 21., 21., 21., 21., 19.75, 18.5, 17.25, 16., 21., 18.5, 16., 13.5, 11.,
+                                        10., 10., 10., 10., 10., 10., 8.75,  7.5,  6.25,  5.,  10., 7.5,  5.,  2.5,  0.,
+                                        18., 18., 18., 18., 18., 18., 16.75, 15.5, 14.25, 13., 18., 15.5, 13., 10.5, 8.,
                                         26., 26., 26., 26., 26., 26., 24.75, 23.5, 22.25, 21., 26., 23.5, 21., 18.5, 16.}};
+};
+
+//-----------------------------------------------------------------------------
+
+/**
+ * A 2D rectangular grid
+from scipy.interpolate import interpn
+import numpy as np
+
+def value_func_2d(x0, x1):
+    return 2 * x0 + 3 * x1
+x0 = np.arange(0, 5)
+x1 = np.arange(0, 3)
+values = value_func_2d(*np.meshgrid(x0, x1, indexing='ij'))
+ */
+struct FixtureRectangle2D {
+  std::vector<double> x0{0, 1, 2, 3, 4};
+  std::vector<double> x1{0, 1, 2};
+  // Note that y corresponds to the axis 0!
+  NdArray<double> values{{5, 3}, {0, 3, 6, 2, 5, 8, 4, 7, 10, 6, 9, 12, 8, 11, 14}};
 };
 
 //-----------------------------------------------------------------------------
@@ -133,7 +152,7 @@ BOOST_FIXTURE_TEST_CASE(Interp1D, Fixture1D) {
 
 BOOST_FIXTURE_TEST_CASE(Interp1DExtrapolate, Fixture1D) {
   auto func = interpn<1>({x}, values, InterpolationType::LINEAR, true);
-  // interpn(x, values, [-10.], bounds_error=False, fill_value=None
+  // interpn(x, values, [-10.], bounds_error=False, fill_value=None)
   BOOST_CHECK_CLOSE((*func)(1.45), 2.9, close_tolerance);
   BOOST_CHECK_CLOSE((*func)(-10), -20., close_tolerance);
   BOOST_CHECK_CLOSE((*func)(10), 20., close_tolerance);
@@ -148,19 +167,20 @@ BOOST_FIXTURE_TEST_CASE(Interp1DExtrapolate, Fixture1D) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Interp2D, Fixture2D) {
-  auto func = interpn<2>({x, y}, values, InterpolationType::LINEAR, false);
+  auto func = interpn<2>({x0, x1}, values, InterpolationType::LINEAR, false);
   BOOST_CHECK(func);
-  // interpn(points, values, [0.4, 0.5])
-  BOOST_CHECK_CLOSE((*func)(0.4, 0.5), 2.2, close_tolerance);
-  BOOST_CHECK_CLOSE((*func)(1.8, 0.6), 6.6, close_tolerance);
+  // interpn((x0,x1), values, [0.5, 0.4])
+  BOOST_CHECK_CLOSE((*func)(0.5, 0.4), 2.2, close_tolerance);
+  BOOST_CHECK_CLOSE((*func)(0.4, 0.5), 2.3, close_tolerance);
+  BOOST_CHECK_CLOSE((*func)(1.8, 0.6), 5.4, close_tolerance);
   BOOST_CHECK_EQUAL((*func)(-10, 1.5), 0.0);
   BOOST_CHECK_EQUAL((*func)(1.9, 5.5), 0.0);
 
   auto copy = func->clone();
   func.reset(nullptr);
   BOOST_CHECK(copy);
-  BOOST_CHECK_CLOSE((*copy)(0.4, 0.5), 2.2, close_tolerance);
-  BOOST_CHECK_CLOSE((*copy)(1.8, 0.6), 6.6, close_tolerance);
+  BOOST_CHECK_CLOSE((*copy)(0.4, 0.5), 2.3, close_tolerance);
+  BOOST_CHECK_CLOSE((*copy)(1.8, 0.6), 5.4, close_tolerance);
   BOOST_CHECK_EQUAL((*copy)(-10, 1.5), 0.0);
   BOOST_CHECK_EQUAL((*copy)(1.9, 5.5), 0.0);
 }
@@ -168,28 +188,28 @@ BOOST_FIXTURE_TEST_CASE(Interp2D, Fixture2D) {
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Interp2DExtrapolate, Fixture2D) {
-  auto func = interpn<2>({x, y}, values, InterpolationType::LINEAR, true);
-  BOOST_CHECK_CLOSE((*func)(0.4, 0.5), 2.2, close_tolerance);
-  // interpn(points, values, [-10., 1.5], bounds_error=False, fill_value=None)
-  BOOST_CHECK_CLOSE((*func)(-10, 1.5), -27., close_tolerance);
-  BOOST_CHECK_CLOSE((*func)(1.9, 5.5), 16.7, close_tolerance);
+  auto func = interpn<2>({x0, x1}, values, InterpolationType::LINEAR, true);
+  BOOST_CHECK_CLOSE((*func)(0.4, 0.5), 2.3, close_tolerance);
+  // interpn((x0,x1), values, [-10., 1.5], bounds_error=False, fill_value=None)
+  BOOST_CHECK_CLOSE((*func)(-10, 1.5), -15.5, close_tolerance);
+  BOOST_CHECK_CLOSE((*func)(1.9, 5.5), 20.3, close_tolerance);
 
   auto copy = func->clone();
   func.reset(nullptr);
-  BOOST_CHECK_CLOSE((*copy)(-10, 1.5), -27., close_tolerance);
-  BOOST_CHECK_CLOSE((*copy)(1.9, 5.5), 16.7, close_tolerance);
+  BOOST_CHECK_CLOSE((*copy)(-10, 1.5), -15.5, close_tolerance);
+  BOOST_CHECK_CLOSE((*copy)(1.9, 5.5), 20.3, close_tolerance);
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Interp3D, Fixture3D) {
-  auto func = interpn<3>({x, y, z}, values, InterpolationType::LINEAR, false);
+  auto func = interpn<3>({x0, x1, x2}, values, InterpolationType::LINEAR, false);
   BOOST_CHECK(func);
-  // interpn(points, values, [0.4, 0.5, 1.1])
-  BOOST_CHECK_CLOSE((*func)(0.4, 0.5, 1.1), 4.6, close_tolerance);
-  BOOST_CHECK_CLOSE((*func)(1.3, 0.8, 0.0), 14.4, close_tolerance);
+  // interpn((x0,x1,x2), values, [0.4, 0.5, 1.1])
+  BOOST_CHECK_CLOSE((*func)(0.4, 0.5, 1.1), 4.9, close_tolerance);
+  BOOST_CHECK_CLOSE((*func)(1.3, 0.8, 0.0), 12.9, close_tolerance);
   BOOST_CHECK_CLOSE((*func)(0.0, 0.0, 0.1), -0.1, close_tolerance);
-  BOOST_CHECK_CLOSE((*func)(0.0, 0.1, 0.1), 0.4, close_tolerance);
+  BOOST_CHECK_CLOSE((*func)(0.0, 0.1, 0.1), 0.7, close_tolerance);
   // No extrapolation
   BOOST_CHECK_CLOSE((*func)(-1.0, 0.1, 0.1), 0.0, close_tolerance);
   BOOST_CHECK_CLOSE((*func)(10.0, 0.1, 0.1), 0.0, close_tolerance);
@@ -201,42 +221,53 @@ BOOST_FIXTURE_TEST_CASE(Interp3D, Fixture3D) {
   auto copy = func->clone();
   func.reset(nullptr);
   BOOST_CHECK(copy);
-  BOOST_CHECK_CLOSE((*copy)(0.4, 0.5, 1.1), 4.6, close_tolerance);
+  BOOST_CHECK_CLOSE((*copy)(0.4, 0.5, 1.1), 4.9, close_tolerance);
   BOOST_CHECK_CLOSE((*copy)(1.1, 10.1, 0.1), 0.0, close_tolerance);
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Interp3DExtrapolate, Fixture3D) {
-  auto func = interpn<3>({x, y, z}, values, InterpolationType::LINEAR, true);
+  auto func = interpn<3>({x0, x1, x2}, values, InterpolationType::LINEAR, true);
 
-  BOOST_CHECK_CLOSE((*func)(0.4, 0.5, 1.1), 4.6, close_tolerance);
-  // interpn(points, values, [-1.0, 0.1, 0.1], bounds_error=False, fill_value=None)
-  BOOST_CHECK_CLOSE((*func)(-1.0, 0.1, 0.1), -7.6, close_tolerance);
-  BOOST_CHECK_CLOSE((*func)(10.0, 0.1, 0.1), 80.4, close_tolerance);
-  BOOST_CHECK_CLOSE((*func)(1.1, -0.1, 0.1), 8.2, close_tolerance);
-  BOOST_CHECK_CLOSE((*func)(1.1, 10.1, 0.1), 59.2, close_tolerance);
-  BOOST_CHECK_CLOSE((*func)(1.1, 0.1, 10.1), -0.8, close_tolerance);
-  BOOST_CHECK_CLOSE((*func)(1.1, 0.1, -0.8), 10.1, close_tolerance);
+  BOOST_CHECK_CLOSE((*func)(0.4, 0.5, 1.1), 4.9, close_tolerance);
+  // interpn((x0,x1,x2), values, [-1.0, 0.1, 0.1], bounds_error=False, fill_value=None)
+  BOOST_CHECK_CLOSE((*func)(-1.0, 0.1, 0.1), -4.3, close_tolerance);
+  BOOST_CHECK_CLOSE((*func)(10.0, 0.1, 0.1), 50.7, close_tolerance);
+  BOOST_CHECK_CLOSE((*func)(1.1, -0.1, 0.1), 4.6, close_tolerance);
+  BOOST_CHECK_CLOSE((*func)(1.1, 10.1, 0.1), 86.2, close_tolerance);
+  BOOST_CHECK_CLOSE((*func)(1.1, 0.1, 10.1), -3.8, close_tolerance);
+  BOOST_CHECK_CLOSE((*func)(1.1, 0.1, -0.8), 7.1, close_tolerance);
 
   auto copy = func->clone();
   func.reset(nullptr);
-  BOOST_CHECK_CLOSE((*copy)(1.1, 0.1, -0.8), 10.1, close_tolerance);
+  BOOST_CHECK_CLOSE((*copy)(1.1, 0.1, -0.8), 7.1, close_tolerance);
 }
 
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Interp4D, Fixture4D) {
-  auto func = interpn<4>({x, y, z, w}, values, InterpolationType::LINEAR, true);
-  // interpn(points, values, [0.5, 0.5, 0.5, 0.5], bounds_error=False, fill_value=None)
+  auto func = interpn<4>({x0, x1, x2, x3}, values, InterpolationType::LINEAR, true);
+  // interpn((x0,x1,x2,x3), values, [0.5, 0.5, 0.5, 0.5], bounds_error=False, fill_value=None)
   BOOST_CHECK_CLOSE((*func)(0.5, 0.5, 0.5, 0.5), 6.25, close_tolerance);
-  BOOST_CHECK_CLOSE((*func)(0.0, 0.1, 1.6, 4.5), -6.7, close_tolerance);
-  BOOST_CHECK_CLOSE((*func)(0.0, -0.1, 2.6, 5.5), -14.8, close_tolerance);
+  BOOST_CHECK_CLOSE((*func)(0.0, 0.1, 1.6, 4.5), -6.4, close_tolerance);
+  BOOST_CHECK_CLOSE((*func)(0.0, -0.1, 2.6, 5.5), -15.1, close_tolerance);
 
   auto copy = func->clone();
   func.reset(nullptr);
   BOOST_CHECK_CLOSE((*copy)(0.5, 0.5, 0.5, 0.5), 6.25, close_tolerance);
-  BOOST_CHECK_CLOSE((*copy)(0.0, -0.1, 2.6, 5.5), -14.8, close_tolerance);
+  BOOST_CHECK_CLOSE((*copy)(0.0, -0.1, 2.6, 5.5), -15.1, close_tolerance);
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(InterpRectable2D, FixtureRectangle2D) {
+  auto func = interpn<2>({x0, x1}, values, InterpolationType::LINEAR, false);
+  // interpn((x0,x1), values, [0.4, 0.5])
+  BOOST_CHECK_CLOSE((*func)(0.4, 0.5), 2.3, close_tolerance);
+  BOOST_CHECK_CLOSE((*func)(4., 2.), 14., close_tolerance);
+  // This extrapolates!
+  BOOST_CHECK_CLOSE((*func)(2., 4.), 0., close_tolerance);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Well, only one really: a cumulative distribution might be a step function (think of several initial or trailing knots with 0 prob, they will be a step on the cumulative).

The other is more a fix on the tests of the n-dimensional interpolation function. The implementation itself is OK, but it can be confusing the order in which the axis knots must be passed down, and in which order the grid must be.

To limit the confusion I have modified the tests to use `x0,x1,...` so it is clearer they correspond to the axis 0, axis 1, of the grid (n-dimensional array). 