### PR TITLE
Fix: Use integral of the linear interpolation for the CDF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,7 @@ indent_size = 4
 
 [Makefile]
 indent_style = tab
+
+# Do not apply inside build directories
+[/build.*/**]
+max_line_length = unset

--- a/MathUtils/CMakeLists.txt
+++ b/MathUtils/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(GMock)
 #===== Libraries ===============================================================
 
 elements_add_library(MathUtils
-                      src/lib/function/*.cpp src/lib/interpolation/*.cpp
+                      src/lib/function/*.cpp src/lib/helpers/*.cpp src/lib/interpolation/*.cpp
                       src/lib/numericalIntegration/*.cpp src/lib/numericalDifferentiation/*.cpp
                       src/lib/PDF/*.cpp
                      LINK_LIBRARIES NdArray XYDataset
@@ -30,6 +30,9 @@ endif()
 
 elements_add_unit_test(function_all_tests tests/src/function/*_test.cpp
                        LINK_LIBRARIES MathUtils XYDataset TYPE Boost)
+
+elements_add_unit_test(helpers_all_tests tests/src/helpers/*_test.cpp
+                       LINK_LIBRARIES MathUtils TYPE Boost)
 
 elements_add_unit_test(interpolation_all_tests tests/src/interpolation/*_test.cpp
                        LINK_LIBRARIES MathUtils XYDataset TYPE Boost)

--- a/MathUtils/MathUtils/PDF/_impl/NdSampler.icpp
+++ b/MathUtils/MathUtils/PDF/_impl/NdSampler.icpp
@@ -1,8 +1,8 @@
 #ifdef NDSAMPLER_IMPL
 
 #include "ElementsKernel/Real.h"
-#include "MathUtils/PDF/Cumulative.h"
 #include "MathUtils/function/function_tools.h"
+#include "MathUtils/helpers/InverseCumulative.h"
 #include "MathUtils/interpolation/interpolation.h"
 #include "NdArray/Operations.h"
 #include <cmath>
@@ -23,18 +23,9 @@ public:
   virtual ~NdSampler() = default;
 
   NdSampler(std::vector<double> knots, const NdArray::NdArray<double>& grid)
-      : m_knots(std::move(knots)), m_cumulative(grid.size()) {
+      : m_inv_cumulative(std::move(knots), std::move(std::vector<double>(grid.begin(), grid.end()))) {
     if (grid.shape().size() != 1) {
       throw Elements::Exception() << "Grid with " << grid.shape().size() << " axes passed to a 1D sampler";
-    }
-    if (grid.shape()[0] != m_knots.size()) {
-      throw Elements::Exception() << "Grid and knots dimensionality do not match: " << grid.shape()[0] << " != " << m_knots.size();
-    }
-    // Integrate using the trapezoidal method
-    m_cumulative[0] = grid.at(0);
-    for (std::size_t i = 1; i < grid.size(); ++i) {
-      m_cumulative[i] = (m_knots[i] - m_knots[i - 1]) * (grid.at(i) + grid.at(i - 1)) / 2.;
-      m_cumulative[i] += m_cumulative[i - 1];
     }
   }
 
@@ -50,13 +41,12 @@ public:
                                   << output.shape()[0] << ", " << output.shape()[1] << ")";
     }
     // The std::nextafter is required so the interval is closed
-    std::uniform_real_distribution<> uniform(m_cumulative.front(),
-                                             std::nextafter(m_cumulative.back(), std::numeric_limits<double>::max()));
+    std::uniform_real_distribution<> uniform(0, std::nextafter(1, std::numeric_limits<double>::max()));
     // Draw samples
     auto this_n = output.shape()[1] - 1;
     for (std::size_t i = 0; i < ndraws; ++i) {
       auto p               = uniform(rng);
-      output.at(i, this_n) = simple_interpolation(p, m_cumulative, m_knots, true);
+      output.at(i, this_n) = m_inv_cumulative(p);
     }
   }
 
@@ -68,7 +58,7 @@ public:
   }
 
 private:
-  std::vector<double> m_knots, m_cumulative;
+  const InverseCumulative m_inv_cumulative;
 };
 
 /**
@@ -180,21 +170,15 @@ void NdSampler<N>::draw(std::size_t ndraws, Generator& rng, NdArray::NdArray<dou
 
   // For each sample
   for (std::size_t draw = 0; draw < ndraws; ++draw) {
-    std::vector<double> pdf(m_knots.size()), cumulative(m_knots.size());
+    std::vector<double> pdf(m_knots.size());
     auto                subsample = output.slice(draw);
-    // First pass, evaluate the function
+    // Evaluate the PDF
     for (std::size_t i = 0; i < m_knots.size(); ++i) {
       pdf[i] = _CallHelper<_make_index_sequence<N - 1>>::call(*m_interpolation, m_knots[i], subsample, this_n + 1);
     }
-    // Second pass, evaluate the integral
-    for (std::size_t i = 1; i < m_knots.size(); ++i) {
-      auto dx       = m_knots[i] - m_knots[i - 1];
-      cumulative[i] = dx * (pdf[i] + pdf[i - 1]) / 2.;
-      cumulative[i] += cumulative[i - 1];
-    }
-    // Generate a random value from the uniform distribution [min_pN, max_pN]
-    auto p                  = uniform(rng) * (cumulative.back() - cumulative.front()) + cumulative.front();
-    output.at(draw, this_n) = simple_interpolation(p, cumulative, m_knots, true);
+    auto p                  = uniform(rng);
+    InverseCumulative inv_cumulative(m_knots, std::move(pdf));
+    output.at(draw, this_n) = inv_cumulative(p);
   }
 }
 

--- a/MathUtils/MathUtils/helpers/InverseCumulative.h
+++ b/MathUtils/MathUtils/helpers/InverseCumulative.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef MATHUTILS_INV_CUMULATIVE_H
+#define MATHUTILS_INV_CUMULATIVE_H
+
+#include "ElementsKernel/Exception.h"
+#include <vector>
+
+namespace Euclid {
+namespace MathUtils {
+
+class InverseCumulative {
+public:
+  InverseCumulative(std::vector<double> knots, std::vector<double> pdf);
+
+  double operator()(double p) const;
+
+private:
+  std::vector<double> m_knots, m_pdf, m_cdf;
+  double              m_min, m_range;
+};
+
+}  // namespace MathUtils
+}  // namespace Euclid
+
+#endif  // MATHUTILS_INV_CUMULATIVE_H

--- a/MathUtils/MathUtils/helpers/Solvers.h
+++ b/MathUtils/MathUtils/helpers/Solvers.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef MATHUTILS_SOLVERS_H
+#define MATHUTILS_SOLVERS_H
+
+#include "ElementsKernel/Exception.h"
+#include <tuple>
+
+namespace Euclid {
+namespace MathUtils {
+
+/**
+ * Solve x for y = a * x^2 + b * x + c
+ * @return
+ *  A pair with the two (or one) possible solution
+ * @throw Elements::Exception
+ *  If a == b == 0. (can not be solved)
+ */
+std::pair<double, double> solveSquare(double a, double b, double c, double y);
+
+}  // namespace MathUtils
+}  // namespace Euclid
+
+#endif  // MATHUTILS_SOLVERS_H

--- a/MathUtils/src/lib/PDF/Cumulative.cpp
+++ b/MathUtils/src/lib/PDF/Cumulative.cpp
@@ -24,10 +24,7 @@
 
 #include "MathUtils/PDF/Cumulative.h"
 #include "ElementsKernel/Exception.h"
-#include "MathUtils/helpers/Solvers.h"
 #include "XYDataset/XYDataset.h"
-#include <cassert>
-#include <cmath>
 #include <cstdlib>  // for size_t
 
 namespace Euclid {
@@ -188,40 +185,6 @@ std::pair<double, double> Cumulative::findCenteredInterval(double rate) const {
   double max_x = findValue(max_rate, TrayPosition::begin);
 
   return std::make_pair(min_x, max_x);
-}
-
-double inverseCumulative(const std::vector<double>& knots, const std::vector<double>& cdf, double p) {
-  assert(p >= cdf.front() && p <= cdf.back());
-
-  // Find segment
-  std::size_t i = std::lower_bound(cdf.begin(), cdf.end(), p) - cdf.begin();
-  if (i >= cdf.size())
-    --i;
-
-  // "Derive" the segment of the cdf to get the pdf
-  const double p0 = 0., p1 = cdf[i + 1] - cdf[i];
-  const double x0 = knots[i], x1 = knots[i + 1];
-
-  // If both extremes are 0, then the interval has 0 probability.
-  // If both extremes are the same, this is probably a discontinuity.
-  // In those cases, return the lower bound, which might be at least defined (or has a probability of exactly p).
-  if (p1 <= 0 || x1 == x0)
-    return x0;
-
-  // Linear interpolation of the pdf
-  double a = (x1 - x0) / (p1 - p0);
-  double b = x0 - a * p0;
-
-  // The integration of the linear equation (for dx) is
-  // y = a*x + b => y = a*x^2/2 + bx + c
-  // We need to solve for x, since y is known (the target cumulative probability)
-  double s0, s1;
-  std::tie(s0, s1) = solveSquare(a / 2., b, 0., p);
-
-  if (s0 >= x0 && s0 <= x1) {
-    return s0;
-  }
-  return s1;
 }
 
 }  // namespace MathUtils

--- a/MathUtils/src/lib/helpers/InverseCumulative.cpp
+++ b/MathUtils/src/lib/helpers/InverseCumulative.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "MathUtils/helpers/InverseCumulative.h"
+#include "MathUtils/helpers/Solvers.h"
+#include <algorithm>
+#include <cassert>
+
+namespace Euclid {
+namespace MathUtils {
+
+InverseCumulative::InverseCumulative(std::vector<double> knots, std::vector<double> pdf)
+    : m_knots(std::move(knots)), m_pdf(std::move(pdf)), m_cdf(m_pdf.size()) {
+  if (m_knots.size() != m_knots.size()) {
+    throw Elements::Exception() << "PDF and knots dimensionality do not match: " << m_knots.size() << " != " << knots.size();
+  }
+
+  m_cdf[0] = m_pdf[0];
+  for (std::size_t i = 1; i < m_cdf.size(); ++i) {
+    m_cdf[i] = (m_knots[i] - m_knots[i - 1]) * (m_pdf[i] + m_pdf[i - 1]) / 2.;
+    m_cdf[i] += m_cdf[i - 1];
+  }
+  m_min   = m_cdf.front();
+  m_range = m_cdf.back() - m_min;
+}
+
+double InverseCumulative::operator()(double p) const {
+  if (p < 0. || p > 1.) {
+    throw Elements::Exception() << "Cumulative::findInterpolatedValue : p parameter must be in the range [0,1]";
+  }
+
+  const double unnormed_p = p * m_range + m_min;
+
+  // Find segment
+  if (unnormed_p <= m_cdf.front())
+    return m_knots.front();
+  if (unnormed_p >= m_cdf.back())
+    return m_knots.back();
+
+  std::size_t i = std::upper_bound(m_cdf.begin(), m_cdf.end(), unnormed_p) - m_cdf.begin() - 1;
+
+  const double x0 = m_knots[i], x1 = m_knots[i + 1];
+  const double cdf0 = m_cdf[i], cdf1 = m_cdf[i + 1];
+  const double p0 = m_pdf[i], p1 = m_pdf[i + 1];
+
+  // If p0 == p1 we are on a uniform area
+  if (p0 == p1) {
+    return (x1 - x0) * p + x0;
+  }
+
+  // If both cdf are the same, then the interval has 0 probability.
+  // If both x are the same, this is probably a discontinuity.
+  // In those cases, return the lower bound, which might be at least defined (or has a probability of exactly p).
+  if (x1 == x0 || cdf0 == cdf1 || cdf0 >= unnormed_p) {
+    return x0;
+  }
+
+  // Since we assume a linear interpolation, we know that
+  // p0 = a * x0 + b
+  // p1 = a * x1 + b
+  // So we can solve for a and b
+  const double a = (p1 - p0) / (x1 - x0);
+  const double b = p0 - a * x0;
+
+  assert(std::abs(a * x0 + b - p0) < 1e-8);
+  assert(std::abs(a * x1 + b - p1) < 1e-8);
+
+  // The CDF is the integral, so we also know that
+  // cdf0 = a/2 * x0^2 + b * x0 + c
+  // cdf1 = a/2 * x1^2 + b * x1 + c
+  // We already know a and b, so it is easy to solve for c
+  const double c = cdf0 - (a / 2.) * (x0 * x0) - b * x0;
+
+  // Double check that the equation passes through the CDF at the limits
+  assert(std::abs((a / 2.) * (x0 * x0) + b * x0 + c - cdf0) < 1e-8);
+  assert(std::abs((a / 2) * (x1 * x1) + b * x1 + c - cdf1) < 1e-8);
+
+  // We have the equation, so we now need to solve x for p
+  double s0, s1;
+  std::tie(s0, s1) = solveSquare(a / 2, b, c, unnormed_p);
+
+  // Pick the possible result that lies within [x0, x1]
+  if (s0 >= x0 - 1e-8 && s0 <= x1 + 1e-8) {
+    return s0;
+  }
+  assert(s1 >= x0 - 1e-8 && s1 <= x1 + 1e-8);
+  return s1;
+}
+
+}  // namespace MathUtils
+}  // namespace Euclid

--- a/MathUtils/src/lib/helpers/Solvers.cpp
+++ b/MathUtils/src/lib/helpers/Solvers.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "MathUtils/helpers/Solvers.h"
+#include <cmath>
+
+namespace Euclid {
+namespace MathUtils {
+
+std::pair<double, double> solveSquare(double a, double b, double c, double y) {
+  if (a != 0.) {
+    double exprb = b / (2 * a);
+    exprb *= exprb;
+    double sr = std::sqrt((y - c) / a + exprb);
+    return std::make_pair(-sr - b / (2 * a), sr - b / (2 * a));
+  } else if (b != 0.) {
+    return std::make_pair((y - c) / b, (y - c) / b);
+  }
+  throw Elements::Exception() << "Can not solve y = 0x^2 + 0x + c";
+}
+
+}  // namespace MathUtils
+}  // namespace Euclid

--- a/MathUtils/tests/src/helpers/Solvers_test.cpp
+++ b/MathUtils/tests/src/helpers/Solvers_test.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "MathUtils/helpers/Solvers.h"
+#include <boost/test/unit_test.hpp>
+#include <cmath>
+
+static constexpr double tolerance = 1e-40;
+
+using namespace Euclid::MathUtils;
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Solvers_test)
+
+//-----------------------------------------------------------------------------
+
+// y = 2x^2 + 4^x + 5
+BOOST_AUTO_TEST_CASE(SolveSquare_test) {
+  double x0, x1;
+
+  std::tie(x0, x1) = solveSquare(2, 4, 5, 75);
+  BOOST_CHECK_CLOSE(x0, -7, tolerance);
+  BOOST_CHECK_CLOSE(x1, 5, tolerance);
+
+  std::tie(x0, x1) = solveSquare(2, 4, 5, 8);
+  BOOST_CHECK_CLOSE(x0, -2.58113883008419, tolerance);
+  BOOST_CHECK_CLOSE(x1, 0.58113883008418976, tolerance);
+
+  std::tie(x0, x1) = solveSquare(2, 4, 5, -8);
+  BOOST_CHECK(std::isnan(x0));
+  BOOST_CHECK(std::isnan(x1));
+}
+
+//-----------------------------------------------------------------------------
+
+// y = 9^x - 7
+BOOST_AUTO_TEST_CASE(SolveLinear_test) {
+  double x0, x1;
+
+  std::tie(x0, x1) = solveSquare(0, 9, -7, 100);
+  BOOST_CHECK_CLOSE(x0, 11.88888888888889, tolerance);
+  BOOST_CHECK_CLOSE(x1, x0, tolerance);
+
+  std::tie(x0, x1) = solveSquare(0, 9, -7, 0);
+  BOOST_CHECK_CLOSE(x0, 0.7777777777777778, tolerance);
+  BOOST_CHECK_CLOSE(x1, x0, tolerance);
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(Unsolvable_test) {
+  BOOST_CHECK_THROW(solveSquare(0, 0, 1, 100), Elements::Exception);
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//-----------------------------------------------------------------------------


### PR DESCRIPTION
This was a bug present in #52 which is only evident when the grid has a very low resolution.
Since it was using a linear interpolation of the CDF, that effectively is an uniform in each bin. We know the PDF is itself linearly
interpolated, so the original idea from @FDubath was to use the analytical integral, which is quadratic.

This plot shows very clearly the issue that arises when the PDF has a low resolution.

![develop](https://user-images.githubusercontent.com/1410577/117975704-3ccf8580-b32f-11eb-890c-5525b84f5dae.png)

This pull request fixes the problem:

![fix](https://user-images.githubusercontent.com/1410577/117975745-4b1da180-b32f-11eb-9aa3-87a3fe7092f2.png)
