### PR TITLE
Fix off-by-one error in FitsReader::hasMoreRows

### DIFF
--- a/Table/src/lib/FitsReader.cpp
+++ b/Table/src/lib/FitsReader.cpp
@@ -163,7 +163,7 @@ void FitsReader::skip(long rows) {
 
 bool FitsReader::hasMoreRows() {
   readColumnInfo();
-  return m_current_row < m_total_rows;
+  return m_current_row <= m_total_rows;
 }
 
 std::size_t FitsReader::rowsLeft() {

--- a/Table/tests/src/FitsReader_test.cpp
+++ b/Table/tests/src/FitsReader_test.cpp
@@ -251,5 +251,25 @@ BOOST_FIXTURE_TEST_CASE(ReadSuccess, FitsReader_Fixture) {
 }
 
 //-----------------------------------------------------------------------------
+// Regression test for an off-by-one bug in hasMoreRows
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(ReadInChunks_test, FitsReader_Fixture) {
+  FitsReader reader{*table_hdu};
+  BOOST_CHECK(reader.hasMoreRows());
+  BOOST_CHECK_EQUAL(reader.rowsLeft(), 2);
+
+  auto rows = reader.read(1);
+  BOOST_CHECK_EQUAL(rows.size(), 1);
+  BOOST_CHECK(reader.hasMoreRows());
+  BOOST_CHECK_EQUAL(reader.rowsLeft(), 1);
+
+  rows = reader.read(1);
+  BOOST_CHECK_EQUAL(rows.size(), 1);
+  BOOST_CHECK(!reader.hasMoreRows());
+  BOOST_CHECK_EQUAL(reader.rowsLeft(), 0);
+}
+
+//-----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Rows start at 1, and `m_current_row`, and points to the next-to-be-read. The condition in `hasMoreRows` should be less or equal than the number of sources, not strictly less.