### PR TITLE
Add missing include for `std::max`

### DIFF
--- a/SOM/src/lib/NeihbourhoodFunc.cpp
+++ b/SOM/src/lib/NeihbourhoodFunc.cpp
@@ -18,6 +18,7 @@
 
 #include "SOM/NeighborhoodFunc.h"
 #include <cmath>
+#include <algorithm> // std::max
 
 namespace Euclid {
 namespace SOM {


### PR DESCRIPTION
Building fails on macos because of this