### PR TITLE
Add Semaphore

### DIFF
--- a/AlexandriaKernel/AlexandriaKernel/Semaphore.h
+++ b/AlexandriaKernel/AlexandriaKernel/Semaphore.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _ALEXANDRIAKERNEL_SEMAPHORE_H
+#define _ALEXANDRIAKERNEL_SEMAPHORE_H
+
+#include <chrono>
+#include <memory>
+
+namespace Euclid {
+
+/**
+ * @class Semaphore
+ * Counting semaphore, based on the C++20 API, so it can be eventually swapped
+ */
+class Semaphore {
+public:
+  /**
+   * Constructor
+   * @param i
+   *    The internal counter will be initialized to i
+   */
+  explicit Semaphore(unsigned int i);
+
+  /**
+   * Destructor
+   */
+  ~Semaphore();
+
+  /**
+   * Increment the counter. Does not block.
+   */
+  void release();
+
+  /**
+   * Decrement the counter. Blocks if it was already 0 until some other thread calls release()
+   */
+  void acquire();
+
+  /**
+   * Try decrementing the counter.
+   * @return false if the counter can not be decremented (already at 0)
+   */
+  bool try_acquire();
+
+  /**
+   * Try decrementing the counter with an *absolute timeout*
+   * @param abs_time
+   *    If the counter can not be decremented, the call will block until this time point
+   *    is reached. If it was in the past, it will return immediately.
+   * @return
+   *    false if the counter can not be decremented within the time window
+   */
+  bool try_acquire_until(const std::chrono::system_clock::time_point& abs_time);
+
+  /**
+   * @copybrief try_acquire_until
+   * @tparam Clock
+   * @tparam Duration
+   * @param abs_time
+   * @return
+   *    false if the counter can not be decremented within the time window
+   */
+  template <class Clock, class Duration>
+  bool try_acquire_until(const std::chrono::time_point<Clock, Duration>& abs_time) {
+    return try_acquire_until(std::chrono::system_clock::now() + (Clock::now() - abs_time));
+  }
+
+  /**
+   * Try decrementing the counter with a *relative timeout*
+   * @tparam Rep
+   * @tparam Ratio
+   * @param rel_time
+   *    If the counter can not be decremented, the call will block for this duration.
+   * @return
+   *    false if the counter can not be decremented within the time window
+   */
+  template <class Rep, class Ratio>
+  bool try_acquire_for(const std::chrono::duration<Rep, Ratio>& rel_time) {
+    return try_acquire_until(std::chrono::system_clock::now() + rel_time);
+  }
+
+private:
+  class SemaphoreImpl;
+  std::unique_ptr<SemaphoreImpl> m_impl;
+};
+
+}  // namespace Euclid
+
+#endif  // _ALEXANDRIAKERNEL_SEMAPHORE_H

--- a/AlexandriaKernel/CMakeLists.txt
+++ b/AlexandriaKernel/CMakeLists.txt
@@ -62,6 +62,9 @@ elements_add_unit_test(AlexandriaKernel_ThreadPool_test tests/src/ThreadPool_tes
 elements_add_unit_test(Tuple_test tests/src/Tuple_test.cpp
         LINK_LIBRARIES AlexandriaKernel
         TYPE Boost)
+elements_add_unit_test(Semaphore_test tests/src/Semaphore_test.cpp
+        LINK_LIBRARIES AlexandriaKernel
+        TYPE Boost)
 
 #===============================================================================
 # Declare the Python programs here

--- a/AlexandriaKernel/src/lib/Semaphore.cpp
+++ b/AlexandriaKernel/src/lib/Semaphore.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "AlexandriaKernel/Semaphore.h"
+#include "SemaphorePosix.icpp"
+
+namespace Euclid {
+
+Semaphore::Semaphore(unsigned int i) : m_impl(new SemaphoreImpl(i)) {}
+
+Semaphore::~Semaphore() {}
+
+void Semaphore::release() {
+  m_impl->post();
+}
+
+void Semaphore::acquire() {
+  m_impl->wait();
+}
+
+bool Semaphore::try_acquire() {
+  return m_impl->try_acquire();
+}
+
+bool Semaphore::try_acquire_until(const std::chrono::system_clock::time_point& abs_time) {
+  return m_impl->try_acquire_until(abs_time);
+}
+
+}  // namespace Euclid

--- a/AlexandriaKernel/src/lib/SemaphorePosix.icpp
+++ b/AlexandriaKernel/src/lib/SemaphorePosix.icpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <cerrno>
+#include <semaphore.h>
+#include <system_error>
+
+namespace Euclid {
+class Semaphore::SemaphoreImpl {
+public:
+  explicit SemaphoreImpl(unsigned int i) {
+    if (sem_init(&m_semaphore, 0, i) < 0) {
+      throw std::system_error(errno, std::system_category());
+    }
+  }
+
+  ~SemaphoreImpl() {
+    sem_destroy(&m_semaphore);
+  }
+
+  void post() {
+    if (sem_post(&m_semaphore) < 0) {
+      throw std::system_error(errno, std::system_category());
+    }
+  }
+
+  void wait() {
+    if (sem_wait(&m_semaphore) != 0) {
+      throw std::system_error(errno, std::system_category());
+    }
+  }
+
+  bool try_acquire() {
+    if (sem_trywait(&m_semaphore) == 0) {
+      return true;
+    }
+    if (errno == EAGAIN) {
+      return false;
+    }
+    throw std::system_error(errno, std::system_category());
+  }
+
+  bool try_acquire_until(std::chrono::system_clock::time_point abs_time) {
+    using std::chrono::time_point_cast;
+    auto seconds = time_point_cast<std::chrono::seconds>(abs_time);
+    auto nseconds =
+        time_point_cast<std::chrono::nanoseconds>(abs_time) - time_point_cast<std::chrono::nanoseconds>(seconds);
+
+    struct timespec timeout;
+    timeout.tv_sec  = seconds.time_since_epoch().count();
+    timeout.tv_nsec = nseconds.count();
+    if (sem_timedwait(&m_semaphore, &timeout) == 0) {
+      return true;
+    }
+    if (errno == ETIMEDOUT) {
+      return false;
+    }
+    throw std::system_error(errno, std::system_category());
+  }
+
+private:
+  sem_t m_semaphore;
+};
+}  // namespace Euclid

--- a/AlexandriaKernel/tests/src/Semaphore_test.cpp
+++ b/AlexandriaKernel/tests/src/Semaphore_test.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "AlexandriaKernel/Semaphore.h"
+#include <boost/test/unit_test.hpp>
+
+using Euclid::Semaphore;
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Semaphore_test)
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(AcquireRelease_test) {
+  Semaphore sem(10);
+  for (int i = 0; i < 9; ++i) {
+    sem.acquire();
+  }
+  sem.release();
+  sem.acquire();
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(TryAcquire_test) {
+  Semaphore sem(10);
+  for (int i = 0; i < 10; ++i) {
+    sem.acquire();
+  }
+  BOOST_CHECK(!sem.try_acquire());
+  sem.release();
+  BOOST_CHECK(sem.try_acquire());
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(TimedAcquire_test) {
+  Semaphore sem(10);
+  for (int i = 0; i < 10; ++i) {
+    sem.acquire();
+  }
+
+  // No slot available
+  auto before = std::chrono::steady_clock::now();
+  BOOST_CHECK(!sem.try_acquire_for(std::chrono::seconds(2)));
+  auto after      = std::chrono::steady_clock::now();
+  auto waited_for = after - before;
+  BOOST_CHECK_GE(std::chrono::duration_cast<std::chrono::seconds>(waited_for).count(), 2);
+
+  // One available
+  sem.release();
+  before = std::chrono::steady_clock::now();
+  BOOST_CHECK(sem.try_acquire_for(std::chrono::seconds(2)));
+  after      = std::chrono::steady_clock::now();
+  waited_for = after - before;
+  BOOST_CHECK_LT(std::chrono::duration_cast<std::chrono::seconds>(waited_for).count(), 2);
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//-----------------------------------------------------------------------------


### PR DESCRIPTION
Semaphores were added in C++20, so we are a bit far from being able to use them.
This is basically an identical API wrapping the POSIX semaphore API.