### PR TITLE
Implement interpolation without using Piecewise

### DIFF
--- a/MathUtils/MathUtils/function/Piecewise.h
+++ b/MathUtils/MathUtils/function/Piecewise.h
@@ -36,6 +36,32 @@ namespace Euclid {
 namespace MathUtils {
 
 /**
+ * @class PiecewiseBase
+ *
+ * @brief Represents a piecewise function
+ *
+ * @details
+ * A Piecewise function is defined by multiple sub functions, each applied to an
+ * interval defined by the piecewise knots. Outside of the knots range the
+ * Piecewise evaluates zero.
+ */
+class ELEMENTS_API PiecewiseBase : public Integrable {
+public:
+  virtual ~PiecewiseBase() = default;
+
+  /// Returns the knots of the piecewise function
+  const std::vector<double>& getKnots() const {
+    return m_knots;
+  }
+
+protected:
+  explicit PiecewiseBase(std::vector<double> knots) : m_knots(std::move(knots)) {}
+
+  /// A vector where the knots are kept
+  std::vector<double> m_knots;
+};
+
+/**
  * @class Piecewise
  *
  * @brief Represents a piecewise function
@@ -45,7 +71,7 @@ namespace MathUtils {
  * interval defined by the piecewise knots. Outside of the knots range the
  * Piecewise evaluates zero.
  */
-class ELEMENTS_API Piecewise : public Integrable {
+class ELEMENTS_API Piecewise : public PiecewiseBase {
 
 public:
   /**
@@ -68,9 +94,6 @@ public:
   /// Default destructor
   virtual ~Piecewise() = default;
 
-  /// Returns the knots of the piecewise function
-  const std::vector<double>& getKnots() const;
-
   /// Returns the functions in the ranges between the knots
   const std::vector<std::unique_ptr<Function>>& getFunctions() const;
 
@@ -92,8 +115,6 @@ public:
   double integrate(const double x1, const double x2) const override;
 
 private:
-  /// A vector where the knots are kept
-  std::vector<double> m_knots;
   /// A vector where the sub-functions are kept
   std::vector<std::unique_ptr<Function>> m_functions;
 };

--- a/MathUtils/src/lib/function/Piecewise.cpp
+++ b/MathUtils/src/lib/function/Piecewise.cpp
@@ -31,7 +31,7 @@ namespace Euclid {
 namespace MathUtils {
 
 Piecewise::Piecewise(std::vector<double> knots, std::vector<std::shared_ptr<Function>> functions)
-    : m_knots{std::move(knots)} {
+    : PiecewiseBase(std::move(knots)) {
   if (m_knots.size() - functions.size() != 1) {
     throw Elements::Exception() << "Invalid number of knots(" << m_knots.size() << ")-functions(" << m_functions.size()
                                 << ")";
@@ -50,7 +50,7 @@ Piecewise::Piecewise(std::vector<double> knots, std::vector<std::shared_ptr<Func
 }
 
 Piecewise::Piecewise(std::vector<double> knots, std::vector<std::unique_ptr<Function>> functions)
-    : m_knots{std::move(knots)}, m_functions{std::move(functions)} {
+    : PiecewiseBase(std::move(knots)), m_functions{std::move(functions)} {
   if (m_knots.size() - m_functions.size() != 1) {
     throw Elements::Exception() << "Invalid number of knots(" << m_knots.size() << ")-functions(" << m_functions.size()
                                 << ")";
@@ -61,10 +61,6 @@ Piecewise::Piecewise(std::vector<double> knots, std::vector<std::unique_ptr<Func
       throw Elements::Exception("knots must be increasing");
     }
   }
-}
-
-const std::vector<double>& Piecewise::getKnots() const {
-  return m_knots;
 }
 
 const std::vector<std::unique_ptr<Function>>& Piecewise::getFunctions() const {

--- a/MathUtils/src/lib/interpolation/linear.cpp
+++ b/MathUtils/src/lib/interpolation/linear.cpp
@@ -23,17 +23,17 @@
  */
 
 #include "ElementsKernel/Exception.h"
-#include "MathUtils/function/Integrable.h"
+#include "MathUtils/function/Piecewise.h"
 #include "MathUtils/interpolation/interpolation.h"
 #include <limits>
 
 namespace Euclid {
 namespace MathUtils {
 
-class LinearInterpolator final : public Integrable {
+class LinearInterpolator final : public PiecewiseBase {
 public:
   LinearInterpolator(std::vector<double> knots, std::vector<double> coef0, std::vector<double> coef1)
-      : m_knots(std::move(knots)), m_coef0(std::move(coef0)), m_coef1(std::move(coef1)){};
+      : PiecewiseBase(std::move(knots)), m_coef0(std::move(coef0)), m_coef1(std::move(coef1)){};
 
   virtual ~LinearInterpolator() = default;
 
@@ -92,7 +92,7 @@ public:
   }
 
 private:
-  const std::vector<double> m_knots, m_coef0, m_coef1;
+  const std::vector<double> m_coef0, m_coef1;
 
   double antiderivative(int i, double x) const {
     return m_coef0[i] * x + m_coef1[i] * x * x / 2;

--- a/MathUtils/src/lib/interpolation/spline.cpp
+++ b/MathUtils/src/lib/interpolation/spline.cpp
@@ -23,18 +23,18 @@
  */
 
 #include "ElementsKernel/Exception.h"
-#include "MathUtils/function/Integrable.h"
+#include "MathUtils/function/Piecewise.h"
 #include "MathUtils/interpolation/interpolation.h"
 #include <limits>
 
 namespace Euclid {
 namespace MathUtils {
 
-class CubicInterpolator final : public Integrable {
+class CubicInterpolator final : public PiecewiseBase {
 public:
   CubicInterpolator(std::vector<double> knots, std::vector<double> coef0, std::vector<double> coef1,
                     std::vector<double> coef2, std::vector<double> coef3)
-      : m_knots(std::move(knots))
+      : PiecewiseBase(std::move(knots))
       , m_coef0(std::move(coef0))
       , m_coef1(std::move(coef1))
       , m_coef2(std::move(coef2))
@@ -97,7 +97,7 @@ public:
   }
 
 private:
-  std::vector<double> m_knots, m_coef0, m_coef1, m_coef2, m_coef3;
+  std::vector<double> m_coef0, m_coef1, m_coef2, m_coef3;
 
   double antiderivative(int i, double x) const {
     double x2 = x * x;

--- a/MathUtils/tests/src/interpolation/Linear_test.cpp
+++ b/MathUtils/tests/src/interpolation/Linear_test.cpp
@@ -22,7 +22,7 @@
  * @author Nikolaos Apostolakos
  */
 
-#include "MathUtils/function/Function.h"
+#include "MathUtils/function/function_tools.h"
 #include "MathUtils/interpolation/interpolation.h"
 #include <boost/test/unit_test.hpp>
 #include <memory>
@@ -171,6 +171,21 @@ BOOST_FIXTURE_TEST_CASE(LinearStep, Linear_Fixture) {
   BOOST_CHECK_CLOSE(value2, 2., close_tolerance);
   BOOST_CHECK_CLOSE(value3, 3.5, close_tolerance);
   BOOST_CHECK_CLOSE(value4, 4., close_tolerance);
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(Linear_Integration, Linear_Fixture) {
+  // Given
+  std::vector<double> x{-1., 0., 1., 2., 8., 10.};
+  std::vector<double> y{4., 3., 1., 2., 2., 20.};
+
+  // When
+  auto linear = Euclid::MathUtils::interpolate(x, y, Euclid::MathUtils::InterpolationType::LINEAR, true);
+
+  // Then
+  BOOST_CHECK_CLOSE(Euclid::MathUtils::integrate(*linear, -1., 10.), 41., close_tolerance);
+  BOOST_CHECK_CLOSE(Euclid::MathUtils::integrate(*linear, 0.5, 4.), 6.25, close_tolerance);
 }
 
 //-----------------------------------------------------------------------------

--- a/MathUtils/tests/src/interpolation/Spline_test.cpp
+++ b/MathUtils/tests/src/interpolation/Spline_test.cpp
@@ -22,7 +22,7 @@
  * @author Nikolaos Apostolakos
  */
 
-#include "MathUtils/function/Piecewise.h"
+#include "MathUtils/function/function_tools.h"
 #include "MathUtils/interpolation/interpolation.h"
 #include "MathUtils/numericalDifferentiation/FiniteDifference.h"
 #include <boost/test/unit_test.hpp>
@@ -33,7 +33,7 @@ using namespace Euclid::MathUtils;
 struct Spline_Fixture {
   const double eps = std::sqrt(std::numeric_limits<double>::epsilon());
   const double close_tolerance{1.2E-2};
-  const double small_tolerance{1E-12};
+  const double small_tolerance{1E-10};
 
   std::vector<double> x, y;
 
@@ -81,16 +81,14 @@ BOOST_FIXTURE_TEST_CASE(fx, Spline_Fixture) {
 // the splines to each side match with the original value
 //-----------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(Spline_fx, Spline_Fixture) {
-  auto  cubic_f      = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
-  auto  cubic_pieces = dynamic_cast<Piecewise*>(cubic_f.get());
-  auto& splines      = cubic_pieces->getFunctions();
+  auto cubic_f = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
 
-  for (size_t i = 0; i < splines.size() - 1; ++i) {
-    auto  x0        = x[i + 1];
-    auto& left      = splines[i];
-    auto& right     = splines[i + 1];
-    auto  left_val  = (*left)(x0);
-    auto  right_val = (*right)(x0);
+  for (size_t i = 0; i < x.size() - 1; ++i) {
+    auto x0        = x[i + 1];
+    auto left      = x0 - std::numeric_limits<double>::epsilon();
+    auto right     = x0 + std::numeric_limits<double>::epsilon();
+    auto left_val  = (*cubic_f)(left);
+    auto right_val = (*cubic_f)(right);
 
     if (std::abs(left_val) <= eps || std::abs(right_val) <= eps) {
       BOOST_CHECK_SMALL(left_val, small_tolerance);
@@ -107,17 +105,15 @@ BOOST_FIXTURE_TEST_CASE(Spline_fx, Spline_Fixture) {
 // Similarly, the first derivative of the splines to each side must match
 //-----------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(Spline_dfx, Spline_Fixture) {
-  auto  cubic_f      = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
-  auto  cubic_pieces = dynamic_cast<Piecewise*>(cubic_f.get());
-  auto& splines      = cubic_pieces->getFunctions();
+  auto cubic_f = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
 
-  for (size_t i = 0; i < splines.size() - 1; ++i) {
-    auto  x0    = x[i + 1];
-    auto& left  = splines[i];
-    auto& right = splines[i + 1];
+  for (size_t i = 0; i < x.size() - 1; ++i) {
+    auto x0    = x[i + 1];
+    auto left  = x0 - std::numeric_limits<double>::epsilon();
+    auto right = x0 + std::numeric_limits<double>::epsilon();
 
-    auto left_dy  = derivative(*left, x0);
-    auto right_dy = derivative(*right, x0);
+    auto left_dy  = derivative(*cubic_f, left);
+    auto right_dy = derivative(*cubic_f, right);
 
     if (std::abs(left_dy) <= eps || std::abs(right_dy) <= eps) {
       BOOST_CHECK_SMALL(left_dy, small_tolerance);
@@ -133,17 +129,15 @@ BOOST_FIXTURE_TEST_CASE(Spline_dfx, Spline_Fixture) {
 // also the second derivative of the splines to each side must match
 //-----------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(Spline_ddfx, Spline_Fixture) {
-  auto  cubic_f      = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
-  auto  cubic_pieces = dynamic_cast<Piecewise*>(cubic_f.get());
-  auto& splines      = cubic_pieces->getFunctions();
+  auto cubic_f = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
 
-  for (size_t i = 0; i < splines.size() - 1; ++i) {
-    auto  x0    = x[i + 1];
-    auto& left  = splines[i];
-    auto& right = splines[i + 1];
+  for (size_t i = 0; i < x.size() - 1; ++i) {
+    auto x0    = x[i + 1];
+    auto left  = x0 - std::numeric_limits<double>::epsilon();
+    auto right = x0 + std::numeric_limits<double>::epsilon();
 
-    auto left_ddy  = derivative2nd(*left, x0);
-    auto right_ddy = derivative2nd(*right, x0);
+    auto left_ddy  = derivative2nd(*cubic_f, left);
+    auto right_ddy = derivative2nd(*cubic_f, right);
 
     if (std::abs(left_ddy) <= eps || std::abs(right_ddy) <= eps) {
       BOOST_CHECK_SMALL(left_ddy, small_tolerance);
@@ -155,25 +149,7 @@ BOOST_FIXTURE_TEST_CASE(Spline_ddfx, Spline_Fixture) {
 }
 
 //-----------------------------------------------------------------------------
-// Second derivative at the endpoints should be 0
-//-----------------------------------------------------------------------------
-BOOST_FIXTURE_TEST_CASE(Spline_ddfx_endpoint, Spline_Fixture) {
-  auto  cubic_f      = interpolate(x, y, InterpolationType::CUBIC_SPLINE);
-  auto  cubic_pieces = dynamic_cast<Piecewise*>(cubic_f.get());
-  auto& splines      = cubic_pieces->getFunctions();
-
-  auto& left  = splines.front();
-  auto& right = splines.back();
-
-  auto left_ddy  = derivative2nd(*left, x.front());
-  auto right_ddy = derivative2nd(*right, x.back());
-
-  BOOST_CHECK_SMALL(left_ddy, 1e-4);
-  BOOST_CHECK_SMALL(right_ddy, 1e-4);
-}
-
-//-----------------------------------------------------------------------------
-// Same, but with extrapolation
+// Second derivative at the endpoints should be 0 when extrapolating
 //-----------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(Spline_extrapolation, Spline_Fixture) {
   auto cubic_f = interpolate(x, y, InterpolationType::CUBIC_SPLINE, true);
@@ -195,8 +171,8 @@ BOOST_FIXTURE_TEST_CASE(Spline_1DataPoint, Spline_Fixture) {
   std::vector<double> y_test_value{42.};
 
   // When
-  auto linear =
-      Euclid::MathUtils::interpolate(x_test_value, y_test_value, Euclid::MathUtils::InterpolationType::CUBIC_SPLINE, true);
+  auto   linear = Euclid::MathUtils::interpolate(x_test_value, y_test_value,
+                                                 Euclid::MathUtils::InterpolationType::CUBIC_SPLINE, true);
   double value1 = (*linear)(-2.);
   double value2 = (*linear)(-1.);
   double value3 = (*linear)(-.5);
@@ -221,16 +197,28 @@ BOOST_FIXTURE_TEST_CASE(Spline_1DataPoint_NoExtrapolate, Spline_Fixture) {
   std::vector<double> y_test_value{42.};
 
   // When
-  auto linear =
-      Euclid::MathUtils::interpolate(x_test_value, y_test_value, Euclid::MathUtils::InterpolationType::CUBIC_SPLINE, false);
-  double value1 = (*linear)(-2.);
-  double value2 = (*linear)(2.);
-  double value3 = (*linear)(5.);
+  auto   cubic  = Euclid::MathUtils::interpolate(x_test_value, y_test_value,
+                                                 Euclid::MathUtils::InterpolationType::CUBIC_SPLINE, false);
+  double value1 = (*cubic)(-2.);
+  double value2 = (*cubic)(2.);
+  double value3 = (*cubic)(5.);
 
   // Then
   BOOST_CHECK_EQUAL(value1, 0.);
   BOOST_CHECK_CLOSE(value2, 42., close_tolerance);
   BOOST_CHECK_EQUAL(value3, 0.);
+}
+
+//-----------------------------------------------------------------------------
+// Integrate
+//-----------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_CASE(Spline_Integrate, Spline_Fixture) {
+  // When
+  auto cubic = Euclid::MathUtils::interpolate(x, y, Euclid::MathUtils::InterpolationType::CUBIC_SPLINE, true);
+
+  // Then
+  BOOST_CHECK_CLOSE(Euclid::MathUtils::integrate(*cubic, 0.0, 1.0), 0.459697592, close_tolerance);
+  BOOST_CHECK_CLOSE(Euclid::MathUtils::integrate(*cubic, 1.5, 3.5), 1.007193412, close_tolerance);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Avoids lots of indirection, keeps memory more packed (good for cache), and avoids allocating/releasing a myriad of intermediate functions.

For `PhosphorosBuildReferenceSample`, this improves from 600 sources/second, to 1863 sources/second (~3x).
Other Phosphoros executables may benefit too.
