### PR TITLE
Add support for GridCellManager no default constructible

### DIFF
--- a/GridContainer/CMakeLists.txt
+++ b/GridContainer/CMakeLists.txt
@@ -38,5 +38,8 @@ elements_add_unit_test(GridCellManagerTraits_test tests/src/GridCellManagerTrait
 elements_add_unit_test(GridContainer_test tests/src/GridContainer_test.cpp
                        LINK_LIBRARIES GridContainer TYPE Boost)
 
+elements_add_unit_test(GridContainerNoDefaultConstructor_test tests/src/GridContainerNoDefaultConstructor_test.cpp
+                       LINK_LIBRARIES GridContainer TYPE Boost)
+
 elements_add_unit_test(serialize_test tests/src/serialize_test.cpp
                        LINK_LIBRARIES GridContainer TYPE Boost)

--- a/GridContainer/GridContainer/GridCellManagerTraits.h
+++ b/GridContainer/GridContainer/GridCellManagerTraits.h
@@ -114,7 +114,9 @@ template <typename T>
 struct GridCellManagerTraits<std::vector<T>> {
 
   /// The type of the data kept by the GridCellManager
-  typedef T data_type;
+  typedef T  data_type;
+  typedef T& reference_type;
+  typedef T* pointer_type;
 
   /// The iterator type which is used to iterate through the data kept in the
   /// cell manager

--- a/GridContainer/GridContainer/_impl/GridContainer.icpp
+++ b/GridContainer/GridContainer/_impl/GridContainer.icpp
@@ -29,22 +29,47 @@ namespace Euclid {
 namespace GridContainer {
 
 template <typename GridCellManager, typename... AxesTypes>
-GridContainer<GridCellManager, AxesTypes...>::GridContainer(GridAxis<AxesTypes>... axes) : m_axes{std::move(axes)...} {}
+GridContainer<GridCellManager, AxesTypes...>::GridContainer(GridAxis<AxesTypes>... axes) : m_axes{std::move(axes)...} {
+  m_cell_manager =
+      GridCellManagerTraits<GridCellManager>::factory(GridConstructionHelper<AxesTypes...>::getAxisIndexFactor(
+          m_axes, TemplateLoopCounter<sizeof...(AxesTypes) - 1>{}));
+}
 
 template <typename GridCellManager, typename... AxesTypes>
 GridContainer<GridCellManager, AxesTypes...>::GridContainer(std::tuple<GridAxis<AxesTypes>...> axes_tuple)
-    : m_axes{std::move(axes_tuple)} {}
+    : m_axes{std::move(axes_tuple)} {
+  m_cell_manager =
+      GridCellManagerTraits<GridCellManager>::factory(GridConstructionHelper<AxesTypes...>::getAxisIndexFactor(
+          m_axes, TemplateLoopCounter<sizeof...(AxesTypes) - 1>{}));
+}
+
+template <typename GridCellManager, typename... AxesTypes>
+template <typename... Args>
+GridContainer<GridCellManager, AxesTypes...>::GridContainer(std::tuple<GridAxis<AxesTypes>...> axes_tuple,
+                                                            Args&&... args)
+    : m_axes{std::move(axes_tuple)} {
+  m_cell_manager = GridCellManagerTraits<GridCellManager>::factory(
+      GridConstructionHelper<AxesTypes...>::getAxisIndexFactor(m_axes, TemplateLoopCounter<sizeof...(AxesTypes) - 1>{}),
+      std::forward<Args>(args)...);
+}
 
 template <typename... AxesTypes>
-std::tuple<GridAxis<AxesTypes>...> fixAxis(const std::tuple<GridAxis<AxesTypes>...>& original, size_t axis, size_t index) {
+std::tuple<GridAxis<AxesTypes>...> fixAxis(const std::tuple<GridAxis<AxesTypes>...>& original, size_t axis,
+                                           size_t index) {
   std::tuple<GridAxis<AxesTypes>...> result{original};
   GridConstructionHelper<AxesTypes...>::template findAndFixAxis(result, axis, index, TemplateLoopCounter<0>{});
   return result;
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-GridContainer<GridCellManager, AxesTypes...>::GridContainer(const GridContainer<GridCellManager, AxesTypes...>& other, size_t axis,
-                                                            size_t index)
+GridContainer<GridCellManager, AxesTypes...>::GridContainer()
+    : m_cell_manager{
+          GridCellManagerTraits<GridCellManager>::factory(GridConstructionHelper<AxesTypes...>::getAxisIndexFactor(
+              m_axes, TemplateLoopCounter<sizeof...(AxesTypes) - 1>{}))} {}
+
+template <typename GridCellManager, typename... AxesTypes>
+GridContainer<GridCellManager, AxesTypes...>::GridContainer(const GridContainer<GridCellManager, AxesTypes...>& other,
+                                                            size_t axis, size_t index)
     : m_axes{other.m_axes}
     , m_axes_fixed{fixAxis(other.m_axes, axis, index)}
     , m_fixed_indices{other.m_fixed_indices}
@@ -120,8 +145,8 @@ size_t GridContainer<GridCellManager, AxesTypes...>::size() const {
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-auto GridContainer<GridCellManager, AxesTypes...>::operator()(decltype(std::declval<GridAxis<AxesTypes>>().size())... indices) const
-    -> const cell_type& {
+auto GridContainer<GridCellManager, AxesTypes...>::operator()(
+    decltype(std::declval<GridAxis<AxesTypes>>().size())... indices) const -> const reference_type {
   size_t total_index = m_index_helper.totalIndex(indices...);
   // If we have fixed axes we need to move the index accordingly
   for (auto& pair : m_fixed_indices) {
@@ -131,14 +156,19 @@ auto GridContainer<GridCellManager, AxesTypes...>::operator()(decltype(std::decl
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-auto GridContainer<GridCellManager, AxesTypes...>::operator()(decltype(std::declval<GridAxis<AxesTypes>>().size())... indices)
-    -> cell_type& {
-  return const_cast<cell_type&>(static_cast<const GridContainer&>(*this)(indices...));
+auto GridContainer<GridCellManager, AxesTypes...>::operator()(
+    decltype(std::declval<GridAxis<AxesTypes>>().size())... indices) -> reference_type {
+  size_t total_index = m_index_helper.totalIndex(indices...);
+  // If we have fixed axes we need to move the index accordingly
+  for (auto& pair : m_fixed_indices) {
+    total_index += pair.second * m_index_helper.m_axes_index_factors[pair.first];
+  }
+  return (*m_cell_manager)[total_index];
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-auto GridContainer<GridCellManager, AxesTypes...>::at(decltype(std::declval<GridAxis<AxesTypes>>().size())... indices) const
-    -> const cell_type& {
+auto GridContainer<GridCellManager, AxesTypes...>::at(
+    decltype(std::declval<GridAxis<AxesTypes>>().size())... indices) const -> const cell_type& {
   // First make a check that all the fixed axes are zero
   m_index_helper.checkAllFixedAreZero(m_fixed_indices, indices...);
   size_t total_index = m_index_helper.totalIndexChecked(indices...);
@@ -183,7 +213,8 @@ struct InfimumHelper<0> {
   using Index = std::size_t;
 
   template <typename... AxesType>
-  static std::tuple<std::size_t> getIndex(const std::tuple<AxesType...>& coords, const std::tuple<GridAxis<AxesType>...>& axes) {
+  static std::tuple<std::size_t> getIndex(const std::tuple<AxesType...>&           coords,
+                                          const std::tuple<GridAxis<AxesType>...>& axes) {
     auto i0 = std::get<0>(axes).infimum(std::get<0>(coords));
     return std::make_tuple(i0);
   }
@@ -210,7 +241,8 @@ auto GridContainer<GridCellManager, AxesTypes...>::infimum(const std::tuple<Axes
 
 template <typename GridCellManager, typename... AxesTypes>
 template <int I>
-GridContainer<GridCellManager, AxesTypes...> GridContainer<GridCellManager, AxesTypes...>::fixAxisByIndex(size_t index) {
+GridContainer<GridCellManager, AxesTypes...>
+GridContainer<GridCellManager, AxesTypes...>::fixAxisByIndex(size_t index) {
   if (index >= getOriginalAxis<I>().size()) {
     throw Elements::Exception() << "Index (" << index << ") out of axis " << getOriginalAxis<I>().name() << " size ("
                                 << getOriginalAxis<I>().size() << ")";

--- a/GridContainer/GridContainer/_impl/GridContainerToTable.icpp
+++ b/GridContainer/GridContainer/_impl/GridContainerToTable.icpp
@@ -122,7 +122,7 @@ Table::Table gridContainerToTable(const GridContainer<GridCellManager, AxesTypes
   using Helper   = GridToFitsHelper<std::tuple_size<typename GridType::AxesTuple>::value, GridCellManager, AxesTypes...>;
 
   std::vector<Table::ColumnDescription> columns;
-  Helper::addColumnDescriptions(GridContainer<GridCellManager, AxesTypes...>{grid.getAxesTuple()}, columns);
+  Helper::addColumnDescriptions(grid, columns);
 
   GridCellToTable<typename GridType::cell_type> cell_trais;
   cell_trais.addColumnDescriptions(*grid.begin(), columns);

--- a/GridContainer/GridContainer/_impl/GridIterator.icpp
+++ b/GridContainer/GridContainer/_impl/GridIterator.icpp
@@ -30,22 +30,23 @@ namespace Euclid {
 namespace GridContainer {
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
-GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::iter(const GridContainer<GridCellManager, AxesTypes...>& owner,
-                                                                   const cell_manager_iter_type&                       data_iter)
+template <typename CellType, typename PointerType, typename ReferenceType>
+GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::iter(
+    const GridContainer<GridCellManager, AxesTypes...>& owner, const cell_manager_iter_type& data_iter)
     : m_owner(owner), m_data_iter{data_iter} {}
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
-auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator=(const iter& other) -> iter& {
+template <typename CellType, typename PointerType, typename ReferenceType>
+auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::operator=(
+    const iter& other) -> iter& {
   m_data_iter     = other.m_data_iter;
   m_fixed_indices = other.m_fixed_indices;
   return *this;
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
-auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator++() -> iter& {
+template <typename CellType, typename PointerType, typename ReferenceType>
+auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::operator++() -> iter& {
   ++m_data_iter;
   if (!m_fixed_indices.empty()) {
     for (auto& fixed_index_pair : m_fixed_indices) {
@@ -64,68 +65,76 @@ auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator++() 
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
-auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator*() -> CellType& {
+template <typename CellType, typename PointerType, typename ReferenceType>
+auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::operator*()
+    -> ReferenceType {
   return *m_data_iter;
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
-auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator*() const -> typename std::add_const<CellType>::type& {
+template <typename CellType, typename PointerType, typename ReferenceType>
+auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::operator*() const ->
+    typename std::add_const<ReferenceType>::type {
   return *m_data_iter;
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
-auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator->() -> CellType* {
-  return &(*m_data_iter);
+template <typename CellType, typename PointerType, typename ReferenceType>
+auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::operator->()
+    -> PointerType {
+  return m_data_iter.operator->();
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
-auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator->() const -> typename std::add_const<CellType>::type* {
-  return &(*m_data_iter);
+template <typename CellType, typename PointerType, typename ReferenceType>
+auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::operator->() const ->
+    typename std::add_const<PointerType>::type {
+  return m_data_iter.operator->();
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
-bool GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator==(const iter& other) const {
+template <typename CellType, typename PointerType, typename ReferenceType>
+bool GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::operator==(
+    const iter& other) const {
   return m_data_iter == other.m_data_iter;
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
-bool GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::operator!=(const iter& other) const {
+template <typename CellType, typename PointerType, typename ReferenceType>
+bool GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::operator!=(
+    const iter& other) const {
   return m_data_iter != other.m_data_iter;
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
+template <typename CellType, typename PointerType, typename ReferenceType>
 template <int I>
-size_t GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::axisIndex() const {
+size_t GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::axisIndex() const {
   size_t index = m_data_iter - GridCellManagerTraits<GridCellManager>::begin(*(m_owner.m_cell_manager));
   return m_owner.m_index_helper.axisIndex(I, index);
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
+template <typename CellType, typename PointerType, typename ReferenceType>
 template <int I>
-auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::axisValue() const -> const axis_type<I>& {
+auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::axisValue() const
+    -> const axis_type<I>& {
   size_t index = axisIndex<I>();
   return std::get<I>(m_owner.m_axes)[index];
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
+template <typename CellType, typename PointerType, typename ReferenceType>
 template <int I>
-auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::fixAxisByIndex(size_t index) -> iter& {
+auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::fixAxisByIndex(
+    size_t index) -> iter& {
   auto fixed_index = m_fixed_indices.find(I);
   if (fixed_index != m_fixed_indices.end() && fixed_index->second != index) {
     throw Elements::Exception() << "Axis " << m_owner.getOriginalAxis<I>().name() << " is already fixed";
   }
   if (index >= m_owner.getOriginalAxis<I>().size()) {
-    throw Elements::Exception() << "Index (" << index << ") out of axis " << m_owner.getOriginalAxis<I>().name() << " size ("
-                                << m_owner.getOriginalAxis<I>().size() << ")";
+    throw Elements::Exception() << "Index (" << index << ") out of axis " << m_owner.getOriginalAxis<I>().name()
+                                << " size (" << m_owner.getOriginalAxis<I>().size() << ")";
   }
   m_fixed_indices[I] = index;
   forwardToIndex(I, index);
@@ -133,27 +142,31 @@ auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::fixAxisByInde
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
+template <typename CellType, typename PointerType, typename ReferenceType>
 template <int I>
-auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::fixAxisByValue(const axis_type<I>& value) -> iter& {
+auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::fixAxisByValue(
+    const axis_type<I>& value) -> iter& {
   auto& axis       = m_owner.getOriginalAxis<I>();
   auto  found_axis = std::find(axis.begin(), axis.end(), value);
   if (found_axis == axis.end()) {
-    throw Elements::Exception() << "Failed to fix axis " << m_owner.getOriginalAxis<I>().name() << " (given value not found)";
+    throw Elements::Exception() << "Failed to fix axis " << m_owner.getOriginalAxis<I>().name()
+                                << " (given value not found)";
   }
   size_t index = found_axis - axis.begin();
   return fixAxisByIndex<I>(index);
 }
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
-void GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::forwardToIndex(size_t axis, size_t fixed_index) {
+template <typename CellType, typename PointerType, typename ReferenceType>
+void GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::forwardToIndex(
+    size_t axis, size_t fixed_index) {
   size_t current_size  = m_data_iter - GridCellManagerTraits<GridCellManager>::begin(*(m_owner.m_cell_manager));
   size_t current_index = m_owner.m_index_helper.axisIndex(axis, current_size);
   if (fixed_index != current_index) {
     size_t axis_factor = m_owner.m_index_helper.m_axes_index_factors[axis];
-    size_t distance    = (fixed_index > current_index) ? fixed_index - current_index
-                                                    : m_owner.m_index_helper.m_axes_sizes[axis] + fixed_index - current_index;
+    size_t distance    = (fixed_index > current_index)
+                             ? fixed_index - current_index
+                             : m_owner.m_index_helper.m_axes_sizes[axis] + fixed_index - current_index;
     m_data_iter += distance * axis_factor;
   }
 }
@@ -168,9 +181,10 @@ template <typename IterFrom, typename IterTo>
 static void fixSameAxes(IterFrom&, IterTo&, const TemplateLoopCounter<-1>&) {}
 
 template <typename GridCellManager, typename... AxesTypes>
-template <typename CellType>
+template <typename CellType, typename PointerType, typename ReferenceType>
 template <typename OtherIter>
-auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType>::fixAllAxes(const OtherIter& other) -> iter& {
+auto GridContainer<GridCellManager, AxesTypes...>::iter<CellType, PointerType, ReferenceType>::fixAllAxes(
+    const OtherIter& other) -> iter& {
   fixSameAxes(other, *this, TemplateLoopCounter<sizeof...(AxesTypes) - 1>{});
   return *this;
 }

--- a/GridContainer/tests/src/GridContainerNoDefaultConstructor_test.cpp
+++ b/GridContainer/tests/src/GridContainerNoDefaultConstructor_test.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "AlexandriaKernel/memory_tools.h"
+#include "GridContainer/GridContainer.h"
+#include <boost/test/unit_test.hpp>
+#include <numeric>
+
+/**
+ * No default constructible container.
+ * It allocates as a single vector a grid of arrays of doubles.
+ */
+struct Container {
+  /**
+   * Iterator that strides over the underlying vector, so +1 actually steps n positions
+   */
+  struct StrideIterator {
+    StrideIterator(std::vector<double>::iterator start, int stride) : m_i(start), m_stride(stride) {}
+
+    bool operator!=(const StrideIterator& other) const {
+      return m_i != other.m_i;
+    }
+
+    bool operator>(const StrideIterator& other) const {
+      return m_i > other.m_i;
+    }
+
+    StrideIterator& operator++() {
+      m_i += m_stride;
+      return *this;
+    }
+
+    StrideIterator& operator+=(int diff) {
+      m_i += diff;
+      return *this;
+    }
+
+    ptrdiff_t operator-(const StrideIterator& other) const {
+      return (m_i - other.m_i) / m_stride;
+    }
+
+    double& operator*() {
+      return *m_i;
+    }
+
+  private:
+    std::vector<double>::iterator m_i;
+    int                           m_stride;
+  };
+
+  Container(size_t size, int nested_values) : m_values(size * nested_values), m_cell_size(nested_values) {}
+  ~Container() = default;
+
+  Container(const Container&) = delete;
+
+  double& operator[](int i) {
+    return m_values[i * m_cell_size];
+  }
+
+  std::vector<double> m_values;
+  int                 m_cell_size;
+};
+
+/**
+ * GridCellManagerTraits specialization
+ */
+namespace Euclid {
+namespace GridContainer {
+template <>
+struct GridCellManagerTraits<Container> {
+  typedef double                    data_type;
+  typedef double&                   reference_type;
+  typedef double*                   pointer_type;
+  typedef Container::StrideIterator iterator;
+
+  static std::unique_ptr<Container> factory(size_t size, size_t nested_values) {
+    return Euclid::make_unique<Container>(size, nested_values);
+  }
+
+  static iterator begin(Container& c) {
+    return {c.m_values.begin(), c.m_cell_size};
+  }
+
+  static iterator end(Container& c) {
+    return {c.m_values.end(), c.m_cell_size};
+  }
+};
+
+}  // namespace GridContainer
+}  // namespace Euclid
+
+struct GridContainerNoDefaultConstructibleFixture {
+  typedef Euclid::GridContainer::GridContainer<Container, int, int, int, int> GridContainerType;
+  typedef Euclid::GridContainer::GridAxis<int>                                IntAxis;
+  IntAxis                                                                     axis1{"Axis 1", {1, 2, 3, 4, 5}};
+  IntAxis                                                                     axis2{"Axis 2", {1, 2, 3}};
+  IntAxis                                                                     axis3{"Axis 3", {1, 2, 3, 4, 5, 6}};
+  IntAxis                                                                     axis4{"Axis 4", {1, 2}};
+  std::tuple<IntAxis, IntAxis, IntAxis, IntAxis>                              axes_tuple{axis1, axis2, axis3, axis4};
+  const size_t total_size = axis1.size() * axis2.size() * axis3.size() * axis4.size();
+  const int    cell_size  = 8;
+};
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(GridContainerNoDefaultConstructor_test)
+
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(Construction, GridContainerNoDefaultConstructibleFixture) {
+  static_assert(!std::is_default_constructible<Container>::value, "Container must be no default constructible");
+  GridContainerType result_grid(std::make_tuple(axis1, axis2, axis3, axis4), cell_size);
+  BOOST_CHECK_EQUAL(result_grid.size(), total_size);
+  BOOST_CHECK_EQUAL(result_grid.getCellManager().m_values.size(), total_size * cell_size);
+
+  std::vector<double> zeros(cell_size);
+  for (auto& v : result_grid) {
+    BOOST_CHECK_EQUAL_COLLECTIONS(&v, &v + cell_size, zeros.begin(), zeros.end());
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(Assign, GridContainerNoDefaultConstructibleFixture) {
+  GridContainerType result_grid(std::make_tuple(axis1, axis2, axis3, axis4), cell_size);
+  double            cell = 0;
+  for (auto& v : result_grid) {
+    double value = 0.;
+    for (double* ptr = &v; ptr < &v + cell_size; ++ptr) {
+      *ptr = cell * 100 + value;
+      value += 1.;
+    }
+    cell += 1.;
+  }
+
+  // First cell
+  std::vector<double> cell0(cell_size);
+  std::iota(cell0.begin(), cell0.end(), 0.);
+  double* v = &result_grid(0, 0, 0, 0);
+  BOOST_CHECK_EQUAL_COLLECTIONS(v, v + cell_size, cell0.begin(), cell0.end());
+
+  // 52th cell
+  // 0 * 6 * 3 * 5 + 3 * 3 * 5 + 1 * 5 + 2 = 52
+  std::vector<double> cell52(cell_size);
+  std::iota(cell52.begin(), cell52.end(), 52. * 100.);
+  v = &result_grid(2, 1, 3, 0);
+  BOOST_CHECK_EQUAL_COLLECTIONS(v, v + cell_size, cell52.begin(), cell52.end());
+
+  // 179th cell
+  // 1 * 6 * 3 * 5 + 5 * 3 * 5 + 2 * 5 + 4 = 179
+  std::vector<double> cell179(cell_size);
+  std::iota(cell179.begin(), cell179.end(), 179. * 100.);
+  v = &result_grid(4, 2, 5, 1);
+  BOOST_CHECK_EQUAL_COLLECTIONS(v, v + cell_size, cell179.begin(), cell179.end());
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//-----------------------------------------------------------------------------

--- a/GridContainer/tests/src/GridContainer_test.cpp
+++ b/GridContainer/tests/src/GridContainer_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -78,7 +78,7 @@ BOOST_FIXTURE_TEST_CASE(GridAxisConstructor, GridContainer_Fixture) {
 // Test construction with GridAxis tuple
 //-----------------------------------------------------------------------------
 
-BOOST_FIXTURE_TEST_CASE(GridAxisTupleonstructor, GridContainer_Fixture) {
+BOOST_FIXTURE_TEST_CASE(GridAxisTupleConstructor, GridContainer_Fixture) {
 
   // When
   GridContainerType result_grid{axes_tuple};

--- a/SourceCatalog/SourceCatalog/SourceAttributes/Photometry.h
+++ b/SourceCatalog/SourceCatalog/SourceAttributes/Photometry.h
@@ -80,8 +80,7 @@ public:
     using typename std::iterator<std::forward_iterator_tag, value_t>::reference;
     using typename std::iterator<std::forward_iterator_tag, value_t>::pointer;
 
-    using filters_iter_t = typename std::conditional<Const, std::vector<std::string>::const_iterator,
-                                                     std::vector<std::string>::iterator>::type;
+    using filters_iter_t = typename std::vector<std::string>::const_iterator;
     using values_iter_t  = typename std::conditional<Const, std::vector<FluxErrorPair>::const_iterator,
                                                     std::vector<FluxErrorPair>::iterator>::type;
 


### PR DESCRIPTION
Required step for optimizing the photometry grid (i.e., single allocation of the grid, instead of N allocations for N vectors)