### PR TITLE
SOM: Remove the templated ND parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,4 +11,4 @@ set(CXX_SUGGEST_OVERRIDE ON
     FORCE)
 
 # Declare project name and version
-elements_project(Alexandria 2.23.1 USE Elements 6.0.1)
+elements_project(Alexandria 2.24.0 USE Elements 6.0.1)

--- a/GridContainer/GridContainer/GridCellManagerVectorOfVectors.h
+++ b/GridContainer/GridContainer/GridCellManagerVectorOfVectors.h
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2022 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef GRIDCONTAINER_GRIDCELLMANAGERVECTOROFVECTORS_H
+#define GRIDCONTAINER_GRIDCELLMANAGERVECTOROFVECTORS_H
+
+#include "AlexandriaKernel/memory_tools.h"
+#include "GridContainer/GridCellManagerTraits.h"
+#include <vector>
+
+namespace Euclid {
+namespace GridContainer {
+
+template <typename T>
+struct VectorValueProxy;
+
+/**
+ * It allocates a conceptual vector of vectors container as a single
+ * vector traversed in strides.
+ */
+template <typename T>
+struct GridCellManagerVectorOfVectors {
+
+  /**
+   * Iterator that strides over the underlying vector, so +1 actually steps n positions
+   */
+  struct StrideIterator {
+    StrideIterator(typename std::vector<T>::iterator start, int stride) : m_i(start), m_stride(stride) {}
+
+    bool operator!=(const StrideIterator& other) const {
+      return m_i != other.m_i;
+    }
+
+    bool operator>(const StrideIterator& other) const {
+      return m_i > other.m_i;
+    }
+
+    StrideIterator& operator++() {
+      m_i += m_stride;
+      return *this;
+    }
+
+    StrideIterator& operator+=(int diff) {
+      m_i += diff;
+      return *this;
+    }
+
+    ptrdiff_t operator-(const StrideIterator& other) const {
+      return (m_i - other.m_i) / m_stride;
+    }
+
+    VectorValueProxy<T> operator*() {
+      return {m_i, m_i + m_stride};
+    }
+
+    VectorValueProxy<T> operator->() {
+      return {m_i, m_i + m_stride};
+    }
+
+  private:
+    typename std::vector<T>::iterator m_i;
+    int                               m_stride;
+  };
+
+  /**
+   * Constructor
+   * @param size
+   *    Number of cells
+   * @param nested_values
+   *    Number of values per cell
+   */
+  GridCellManagerVectorOfVectors(size_t size, int nested_values)
+      : m_values(size * nested_values), m_cell_size(nested_values) {}
+
+  /**
+   * Destructor
+   */
+  ~GridCellManagerVectorOfVectors() = default;
+
+  /**
+   * Non-copyable to avoid expensive copies by mistake
+   */
+  GridCellManagerVectorOfVectors(const GridCellManagerVectorOfVectors&) = delete;
+
+  /**
+   * Movable
+   */
+  GridCellManagerVectorOfVectors(GridCellManagerVectorOfVectors&&) = default;
+
+  /**
+   * Access cell
+   * @param i
+   *    Cell index
+   * @return
+   *    A reference to the first value on the cell i
+   */
+  VectorValueProxy<T> operator[](int i) {
+    auto iter = m_values.begin() + i * m_cell_size;
+    return {iter, iter + m_cell_size};
+  }
+
+  size_t getCellSize() const {
+    return m_cell_size;
+  }
+
+  size_t getTotalSize() const {
+    return m_values.size();
+  }
+
+private:
+  std::vector<T> m_values;
+  int            m_cell_size;
+
+  friend struct GridCellManagerTraits<GridCellManagerVectorOfVectors>;
+};
+
+template <typename T>
+struct VectorValueProxy {
+  using iterator       = typename std::vector<T>::iterator;
+  using const_iterator = typename std::vector<T>::const_iterator;
+
+  iterator begin() {
+    return m_begin;
+  }
+
+  iterator end() {
+    return m_end;
+  }
+
+  const_iterator begin() const {
+    return m_begin;
+  }
+
+  const_iterator end() const {
+    return m_end;
+  }
+
+  std::size_t size() const {
+    return m_end - m_begin;
+  }
+
+  VectorValueProxy* operator->() const {
+    return const_cast<VectorValueProxy*>(this);
+  }
+
+  VectorValueProxy& operator=(const VectorValueProxy& other) {
+    std::copy(other.begin(), other.end(), begin());
+    return *this;
+  }
+
+  bool operator==(const VectorValueProxy& other) const {
+    return std::equal(m_begin, m_end, other.m_begin, other.m_end);
+  }
+
+  bool operator!=(const VectorValueProxy& other) const {
+    return !std::equal(m_begin, m_end, other.m_begin, other.m_end);
+  }
+
+  operator std::vector<T>() const {
+    return {begin(), end()};
+  }
+
+  T& operator[](const size_t i) {
+    return *(m_begin + i);
+  }
+
+  const T& operator[](const size_t i) const {
+    return *(m_begin + i);
+  }
+
+private:
+  VectorValueProxy(typename std::vector<T>::iterator begin, typename std::vector<T>::iterator end)
+      : m_begin(begin), m_end(end){};
+
+  typename std::vector<T>::iterator m_begin, m_end;
+
+  friend struct GridCellManagerVectorOfVectors<T>;
+};
+
+/**
+ * GridCellManagerTraits specialization
+ */
+template <typename T>
+struct GridCellManagerTraits<GridCellManagerVectorOfVectors<T>> {
+  typedef std::vector<double>                                        data_type;
+  typedef VectorValueProxy<T>                                        reference_type;
+  typedef VectorValueProxy<T>                                        pointer_type;
+  typedef typename GridCellManagerVectorOfVectors<T>::StrideIterator iterator;
+
+  static std::unique_ptr<GridCellManagerVectorOfVectors<T>> factory(size_t size, size_t nested_values) {
+    return Euclid::make_unique<GridCellManagerVectorOfVectors<T>>(size, nested_values);
+  }
+
+  static iterator begin(GridCellManagerVectorOfVectors<T>& c) {
+    return {c.m_values.begin(), c.m_cell_size};
+  }
+
+  static iterator end(GridCellManagerVectorOfVectors<T>& c) {
+    return {c.m_values.end(), c.m_cell_size};
+  }
+};
+}  // namespace GridContainer
+}  // namespace Euclid
+
+#endif  // GRIDCONTAINER_GRIDCELLMANAGERVECTOROFVECTORS_H

--- a/GridContainer/GridContainer/GridCellManagerVectorOfVectors.h
+++ b/GridContainer/GridContainer/GridCellManagerVectorOfVectors.h
@@ -21,6 +21,7 @@
 
 #include "AlexandriaKernel/memory_tools.h"
 #include "GridContainer/GridCellManagerTraits.h"
+#include <cstddef>
 #include <vector>
 
 namespace Euclid {
@@ -164,11 +165,11 @@ struct VectorValueProxy {
   }
 
   bool operator==(const VectorValueProxy& other) const {
-    return std::equal(m_begin, m_end, other.m_begin, other.m_end);
+    return size() == other.size() && std::equal(m_begin, m_end, other.m_begin);
   }
 
   bool operator!=(const VectorValueProxy& other) const {
-    return !std::equal(m_begin, m_end, other.m_begin, other.m_end);
+    return size() != other.size() || !std::equal(m_begin, m_end, other.m_begin);
   }
 
   operator std::vector<T>() const {
@@ -184,8 +185,8 @@ struct VectorValueProxy {
   }
 
 private:
-  VectorValueProxy(typename std::vector<T>::iterator begin, typename std::vector<T>::iterator end)
-      : m_begin(begin), m_end(end){};
+  VectorValueProxy(typename std::vector<T>::iterator begin_, typename std::vector<T>::iterator end_)
+      : m_begin(begin_), m_end(end_){};
 
   typename std::vector<T>::iterator m_begin, m_end;
 

--- a/GridContainer/GridContainer/serialization/GridCellManagerVectorOfVectors.h
+++ b/GridContainer/GridContainer/serialization/GridCellManagerVectorOfVectors.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef GRIDCONTAINER_SERIALIZATION_GRIDCONTAINER_H
+#define GRIDCONTAINER_SERIALIZATION_GRIDCONTAINER_H
+
+#include "GridContainer/GridCellManagerVectorOfVectors.h"
+#include <boost/serialization/array_wrapper.hpp>
+#include <boost/serialization/collection_traits.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/serialization.hpp>
+
+namespace boost {
+namespace serialization {
+
+template <class Archive, typename T>
+void save(Archive& ar, const Euclid::GridContainer::VectorValueProxy<T>& value_proxy, const unsigned int) {
+  size_t count = value_proxy.size();
+  ar << BOOST_SERIALIZATION_NVP(count);
+  if (count > 0) {
+    ar << make_array<const T, size_t>(static_cast<const T*>(&value_proxy[0]), count);
+  }
+}
+
+template <class Archive, typename T>
+void load(Archive& ar, Euclid::GridContainer::VectorValueProxy<T>& value_proxy, const unsigned int) {
+  size_t count;
+  ar >> BOOST_SERIALIZATION_NVP(count);
+  assert(count == value_proxy.size());
+  T* ptr = &value_proxy[0];
+  while (count-- > 0) {
+    ar >> boost::serialization::make_nvp("item", *ptr++);
+  }
+}
+
+template <class Archive, typename T>
+void serialize(Archive& ar, Euclid::GridContainer::VectorValueProxy<T>& value_proxy, const unsigned int version) {
+  split_free(ar, value_proxy, version);
+}
+
+}  // namespace serialization
+}  // namespace boost
+
+BOOST_SERIALIZATION_COLLECTION_TRAITS(Euclid::GridContainer::VectorValueProxy)
+
+#endif  // GRIDCONTAINER_SERIALIZATION_GRIDCONTAINER_H

--- a/GridContainer/GridContainer/serialization/GridCellManagerVectorOfVectors.h
+++ b/GridContainer/GridContainer/serialization/GridCellManagerVectorOfVectors.h
@@ -20,7 +20,7 @@
 #define GRIDCONTAINER_SERIALIZATION_GRIDCONTAINER_H
 
 #include "GridContainer/GridCellManagerVectorOfVectors.h"
-#include <boost/serialization/array_wrapper.hpp>
+#include <boost/serialization/array.hpp>
 #include <boost/serialization/collection_traits.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/serialization.hpp>
@@ -33,7 +33,7 @@ void save(Archive& ar, const Euclid::GridContainer::VectorValueProxy<T>& value_p
   size_t count = value_proxy.size();
   ar << BOOST_SERIALIZATION_NVP(count);
   if (count > 0) {
-    ar << make_array<const T, size_t>(static_cast<const T*>(&value_proxy[0]), count);
+    ar << make_array<const T>(static_cast<const T*>(&value_proxy[0]), count);
   }
 }
 

--- a/GridContainer/tests/src/GridContainerNoDefaultConstructor_test.cpp
+++ b/GridContainer/tests/src/GridContainerNoDefaultConstructor_test.cpp
@@ -17,103 +17,25 @@
  */
 
 #include "AlexandriaKernel/memory_tools.h"
+#include "GridContainer/GridCellManagerVectorOfVectors.h"
 #include "GridContainer/GridContainer.h"
 #include <boost/test/unit_test.hpp>
 #include <numeric>
 
-/**
- * No default constructible container.
- * It allocates as a single vector a grid of arrays of doubles.
- */
-struct Container {
-  /**
-   * Iterator that strides over the underlying vector, so +1 actually steps n positions
-   */
-  struct StrideIterator {
-    StrideIterator(std::vector<double>::iterator start, int stride) : m_i(start), m_stride(stride) {}
-
-    bool operator!=(const StrideIterator& other) const {
-      return m_i != other.m_i;
-    }
-
-    bool operator>(const StrideIterator& other) const {
-      return m_i > other.m_i;
-    }
-
-    StrideIterator& operator++() {
-      m_i += m_stride;
-      return *this;
-    }
-
-    StrideIterator& operator+=(int diff) {
-      m_i += diff;
-      return *this;
-    }
-
-    ptrdiff_t operator-(const StrideIterator& other) const {
-      return (m_i - other.m_i) / m_stride;
-    }
-
-    double& operator*() {
-      return *m_i;
-    }
-
-  private:
-    std::vector<double>::iterator m_i;
-    int                           m_stride;
-  };
-
-  Container(size_t size, int nested_values) : m_values(size * nested_values), m_cell_size(nested_values) {}
-  ~Container() = default;
-
-  Container(const Container&) = delete;
-
-  double& operator[](int i) {
-    return m_values[i * m_cell_size];
-  }
-
-  std::vector<double> m_values;
-  int                 m_cell_size;
-};
-
-/**
- * GridCellManagerTraits specialization
- */
-namespace Euclid {
-namespace GridContainer {
-template <>
-struct GridCellManagerTraits<Container> {
-  typedef double                    data_type;
-  typedef double&                   reference_type;
-  typedef double*                   pointer_type;
-  typedef Container::StrideIterator iterator;
-
-  static std::unique_ptr<Container> factory(size_t size, size_t nested_values) {
-    return Euclid::make_unique<Container>(size, nested_values);
-  }
-
-  static iterator begin(Container& c) {
-    return {c.m_values.begin(), c.m_cell_size};
-  }
-
-  static iterator end(Container& c) {
-    return {c.m_values.end(), c.m_cell_size};
-  }
-};
-
-}  // namespace GridContainer
-}  // namespace Euclid
+using Euclid::GridContainer::GridAxis;
+using Euclid::GridContainer::GridCellManagerVectorOfVectors;
+using Euclid::GridContainer::GridContainer;
 
 struct GridContainerNoDefaultConstructibleFixture {
-  typedef Euclid::GridContainer::GridContainer<Container, int, int, int, int> GridContainerType;
-  typedef Euclid::GridContainer::GridAxis<int>                                IntAxis;
-  IntAxis                                                                     axis1{"Axis 1", {1, 2, 3, 4, 5}};
-  IntAxis                                                                     axis2{"Axis 2", {1, 2, 3}};
-  IntAxis                                                                     axis3{"Axis 3", {1, 2, 3, 4, 5, 6}};
-  IntAxis                                                                     axis4{"Axis 4", {1, 2}};
-  std::tuple<IntAxis, IntAxis, IntAxis, IntAxis>                              axes_tuple{axis1, axis2, axis3, axis4};
-  const size_t total_size = axis1.size() * axis2.size() * axis3.size() * axis4.size();
-  const int    cell_size  = 8;
+  typedef GridContainer<GridCellManagerVectorOfVectors<double>, int, int, int, int> GridContainerType;
+  typedef GridAxis<int>                                                             IntAxis;
+  IntAxis                                                                           axis1{"Axis 1", {1, 2, 3, 4, 5}};
+  IntAxis                                                                           axis2{"Axis 2", {1, 2, 3}};
+  IntAxis                                                                           axis3{"Axis 3", {1, 2, 3, 4, 5, 6}};
+  IntAxis                                                                           axis4{"Axis 4", {1, 2}};
+  std::tuple<IntAxis, IntAxis, IntAxis, IntAxis> axes_tuple{axis1, axis2, axis3, axis4};
+  const size_t                                   grid_size = axis1.size() * axis2.size() * axis3.size() * axis4.size();
+  const int                                      cell_size = 8;
 };
 
 //-----------------------------------------------------------------------------
@@ -123,14 +45,17 @@ BOOST_AUTO_TEST_SUITE(GridContainerNoDefaultConstructor_test)
 //-----------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(Construction, GridContainerNoDefaultConstructibleFixture) {
-  static_assert(!std::is_default_constructible<Container>::value, "Container must be no default constructible");
+  static_assert(!std::is_default_constructible<GridCellManagerVectorOfVectors<double>>::value,
+                "Container must be no default constructible");
   GridContainerType result_grid(std::make_tuple(axis1, axis2, axis3, axis4), cell_size);
-  BOOST_CHECK_EQUAL(result_grid.size(), total_size);
-  BOOST_CHECK_EQUAL(result_grid.getCellManager().m_values.size(), total_size * cell_size);
+  BOOST_CHECK_EQUAL(result_grid.size(), grid_size);
+  BOOST_CHECK_EQUAL(result_grid.getCellManager().getTotalSize(), grid_size * cell_size);
 
   std::vector<double> zeros(cell_size);
-  for (auto& v : result_grid) {
-    BOOST_CHECK_EQUAL_COLLECTIONS(&v, &v + cell_size, zeros.begin(), zeros.end());
+  for (auto cell : result_grid) {
+    for (auto value : cell) {
+      BOOST_CHECK_EQUAL(value, 0);
+    }
   }
 }
 
@@ -138,35 +63,35 @@ BOOST_FIXTURE_TEST_CASE(Construction, GridContainerNoDefaultConstructibleFixture
 
 BOOST_FIXTURE_TEST_CASE(Assign, GridContainerNoDefaultConstructibleFixture) {
   GridContainerType result_grid(std::make_tuple(axis1, axis2, axis3, axis4), cell_size);
-  double            cell = 0;
-  for (auto& v : result_grid) {
-    double value = 0.;
-    for (double* ptr = &v; ptr < &v + cell_size; ++ptr) {
-      *ptr = cell * 100 + value;
-      value += 1.;
+  double            cell_acc = 0;
+  for (auto cell : result_grid) {
+    double acc = 0.;
+    for (auto& value : cell) {
+      value = cell_acc * 100 + acc;
+      acc += 1.;
     }
-    cell += 1.;
+    cell_acc += 1.;
   }
 
   // First cell
   std::vector<double> cell0(cell_size);
   std::iota(cell0.begin(), cell0.end(), 0.);
-  double* v = &result_grid(0, 0, 0, 0);
-  BOOST_CHECK_EQUAL_COLLECTIONS(v, v + cell_size, cell0.begin(), cell0.end());
+  std::vector<double> v = result_grid(0, 0, 0, 0);
+  BOOST_CHECK_EQUAL_COLLECTIONS(v.begin(), v.end(), cell0.begin(), cell0.end());
 
   // 52th cell
   // 0 * 6 * 3 * 5 + 3 * 3 * 5 + 1 * 5 + 2 = 52
   std::vector<double> cell52(cell_size);
   std::iota(cell52.begin(), cell52.end(), 52. * 100.);
-  v = &result_grid(2, 1, 3, 0);
-  BOOST_CHECK_EQUAL_COLLECTIONS(v, v + cell_size, cell52.begin(), cell52.end());
+  v = result_grid(2, 1, 3, 0);
+  BOOST_CHECK_EQUAL_COLLECTIONS(v.begin(), v.end(), cell52.begin(), cell52.end());
 
   // 179th cell
   // 1 * 6 * 3 * 5 + 5 * 3 * 5 + 2 * 5 + 4 = 179
   std::vector<double> cell179(cell_size);
   std::iota(cell179.begin(), cell179.end(), 179. * 100.);
-  v = &result_grid(4, 2, 5, 1);
-  BOOST_CHECK_EQUAL_COLLECTIONS(v, v + cell_size, cell179.begin(), cell179.end());
+  v = result_grid(4, 2, 5, 1);
+  BOOST_CHECK_EQUAL_COLLECTIONS(v.begin(), v.end(), cell179.begin(), cell179.end());
 }
 
 //-----------------------------------------------------------------------------

--- a/SOM/SOM/SOM.h
+++ b/SOM/SOM/SOM.h
@@ -25,6 +25,7 @@
 #ifndef _SOM_SOM_H
 #define _SOM_SOM_H
 
+#include "GridContainer/GridCellManagerVectorOfVectors.h"
 #include "GridContainer/GridContainer.h"
 #include "SOM/Distance.h"
 #include "SOM/InitFunc.h"
@@ -49,9 +50,11 @@ class SOM {
                 "DistFunc must be a subclass of the Distance::Interface");
 
 public:
-  using CellGridType   = GridContainer::GridContainer<std::vector<std::vector<double>>, std::size_t, std::size_t>;
-  using iterator       = typename CellGridType::iterator;
-  using const_iterator = typename CellGridType::const_iterator;
+  using GridCellManager = GridContainer::GridCellManagerVectorOfVectors<double>;
+  using CellGridType    = GridContainer::GridContainer<GridCellManager, std::size_t, std::size_t>;
+  using iterator        = typename CellGridType::iterator;
+  using const_iterator  = typename CellGridType::const_iterator;
+  using reference_type  = typename CellGridType::reference_type;
 
   SOM(std::size_t nd, std::size_t x, std::size_t y, InitFunc::Signature init_func = InitFunc::zero);
 
@@ -63,9 +66,9 @@ public:
    */
   virtual ~SOM() = default;
 
-  std::vector<double>& operator()(std::size_t x, std::size_t y);
+  reference_type operator()(std::size_t x, std::size_t y);
 
-  const std::vector<double>& operator()(std::size_t x, std::size_t y) const;
+  const reference_type operator()(std::size_t x, std::size_t y) const;
 
   const std::pair<std::size_t, std::size_t>& getSize() const;
 

--- a/SOM/SOM/SOM.h
+++ b/SOM/SOM/SOM.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -42,32 +42,34 @@ namespace SOM {
  * @brief
  *
  */
-template <std::size_t ND, typename DistFunc = Distance::L2<ND>>
+template <typename DistFunc = Distance::L2>
 class SOM {
 
-  static_assert(std::is_base_of<Distance::Interface<ND>, DistFunc>::value,
-                "DistFunc must be a subclass of the Distance::Interface<ND>");
+  static_assert(std::is_base_of<Distance::Interface, DistFunc>::value,
+                "DistFunc must be a subclass of the Distance::Interface");
 
 public:
-  using CellGridType   = GridContainer::GridContainer<std::vector<std::array<double, ND>>, std::size_t, std::size_t>;
+  using CellGridType   = GridContainer::GridContainer<std::vector<std::vector<double>>, std::size_t, std::size_t>;
   using iterator       = typename CellGridType::iterator;
   using const_iterator = typename CellGridType::const_iterator;
 
-  SOM(std::size_t x, std::size_t y, InitFunc::Signature init_func = InitFunc::zero);
+  SOM(std::size_t nd, std::size_t x, std::size_t y, InitFunc::Signature init_func = InitFunc::zero);
 
-  SOM(SOM<ND, DistFunc>&&) = default;
-  SOM& operator=(SOM<ND, DistFunc>&&) = default;
+  SOM(SOM<DistFunc>&&) = default;
+  SOM& operator=(SOM<DistFunc>&&) = default;
 
   /**
    * @brief Destructor
    */
   virtual ~SOM() = default;
 
-  std::array<double, ND>& operator()(std::size_t x, std::size_t y);
+  std::vector<double>& operator()(std::size_t x, std::size_t y);
 
-  const std::array<double, ND>& operator()(std::size_t x, std::size_t y) const;
+  const std::vector<double>& operator()(std::size_t x, std::size_t y) const;
 
   const std::pair<std::size_t, std::size_t>& getSize() const;
+
+  std::size_t getDimensions() const;
 
   iterator begin();
 
@@ -81,10 +83,10 @@ public:
 
   const_iterator cend();
 
-  std::tuple<std::size_t, std::size_t, double> findBMU(const std::array<double, ND>& input) const;
+  std::tuple<std::size_t, std::size_t, double> findBMU(const std::vector<double>& input) const;
 
-  std::tuple<std::size_t, std::size_t, double> findBMU(const std::array<double, ND>& input,
-                                                       const std::array<double, ND>& uncertainties) const;
+  std::tuple<std::size_t, std::size_t, double> findBMU(const std::vector<double>& input,
+                                                       const std::vector<double>& uncertainties) const;
 
   template <typename InputType, typename WeightFunc>
   std::tuple<std::size_t, std::size_t, double> findBMU(const InputType& input, WeightFunc weight_func) const;
@@ -94,6 +96,7 @@ public:
                                                        UncertaintyFunc uncertainty_func) const;
 
 private:
+  std::size_t                         m_dimensions;
   CellGridType                        m_cells;
   std::pair<std::size_t, std::size_t> m_size;
 

--- a/SOM/SOM/SOMProjector.h
+++ b/SOM/SOM/SOMProjector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -37,13 +37,13 @@ public:
   template <typename T>
   using ProjectGrid = GridContainer::GridContainer<std::vector<T>, std::size_t, std::size_t>;
 
-  template <typename T, std::size_t ND, typename DistFunc, typename InputIter, typename WeightFunc, typename AdderFunc>
-  static ProjectGrid<T> project(const SOM<ND, DistFunc>& som, InputIter begin, InputIter end, WeightFunc weight_func,
+  template <typename T, typename DistFunc, typename InputIter, typename WeightFunc, typename AdderFunc>
+  static ProjectGrid<T> project(const SOM<DistFunc>& som, InputIter begin, InputIter end, WeightFunc weight_func,
                                 AdderFunc adder_func, const T& init_cell = T{});
 
-  template <typename T, std::size_t ND, typename DistFunc, typename InputIter, typename WeightFunc,
+  template <typename T, typename DistFunc, typename InputIter, typename WeightFunc,
             typename UncertaintyFunc, typename AdderFunc>
-  static ProjectGrid<T> project(const SOM<ND, DistFunc>& som, InputIter begin, InputIter end, WeightFunc weight_func,
+  static ProjectGrid<T> project(const SOM<DistFunc>& som, InputIter begin, InputIter end, WeightFunc weight_func,
                                 UncertaintyFunc uncertainty_func, AdderFunc adder_func, const T& init_cell = T{});
 };
 

--- a/SOM/SOM/SOMTrainer.h
+++ b/SOM/SOM/SOMTrainer.h
@@ -68,7 +68,7 @@ public:
 
         for (std::size_t cell_y = 0; cell_y < size_y; ++cell_y) {
           for (std::size_t cell_x = 0; cell_x < size_x; ++cell_x) {
-            auto& cell = som(cell_x, cell_y);
+            auto cell = som(cell_x, cell_y);
 
             // Compute the factor based on the distance of the BMU and the cell
             auto neighborhood_factor = m_neighborhood_func({bmu_x, bmu_y}, {cell_x, cell_y}, i, iter_no);

--- a/SOM/SOM/SOMTrainer.h
+++ b/SOM/SOM/SOMTrainer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -38,8 +38,8 @@ public:
   SOMTrainer(NeighborhoodFunc::Signature neighborhood_func, LearningRestraintFunc::Signature learning_restraint_func)
       : m_neighborhood_func(neighborhood_func), m_learning_restraint_func(learning_restraint_func) {}
 
-  template <std::size_t ND, typename DistFunc, typename InputIter, typename InputToWeightFunc>
-  void train(SOM<ND, DistFunc>& som, std::size_t iter_no, InputIter begin, InputIter end, InputToWeightFunc weight_func,
+  template <typename DistFunc, typename InputIter, typename InputToWeightFunc>
+  void train(SOM<DistFunc>& som, std::size_t iter_no, InputIter begin, InputIter end, InputToWeightFunc weight_func,
              const SamplingPolicy::Interface<InputIter>& sampling_policy = SamplingPolicy::FullSet<InputIter>{}) {
 
     // We repeat the training for iter_no iterations
@@ -74,7 +74,7 @@ public:
           // Get the weights of the cell and update them
           if (neighborhood_factor != 0) {
             auto& cell_weights = *cell_it;
-            for (std::size_t wi = 0; wi < ND; ++wi) {
+            for (std::size_t wi = 0; wi < som.getDimensions(); ++wi) {
               cell_weights[wi] =
                   cell_weights[wi] + neighborhood_factor * learn_factor * (input_weights[wi] - cell_weights[wi]);
             }

--- a/SOM/SOM/SOMTrainer.h
+++ b/SOM/SOM/SOMTrainer.h
@@ -58,25 +58,26 @@ public:
         auto input_weights = weight_func(*it);
 
         // Find the coordinates of the BMU for the input
-        std::size_t bmu_x;
-        std::size_t bmu_y;
+        std::size_t bmu_x, bmu_y;
         double      nd_distance;
         std::tie(bmu_x, bmu_y, nd_distance) = som.findBMU(*it, weight_func);
 
         // Now go through all the cells and update their values according their coordinates
-        for (auto cell_it = som.begin(); cell_it != som.end(); ++cell_it) {
+        std::size_t size_x, size_y;
+        std::tie(size_x, size_y) = som.getSize();
 
-          // Compute the factor based on the distance of the BMU and the cell
-          auto cell_x              = cell_it.template axisValue<0>();
-          auto cell_y              = cell_it.template axisValue<1>();
-          auto neighborhood_factor = m_neighborhood_func({bmu_x, bmu_y}, {cell_x, cell_y}, i, iter_no);
+        for (std::size_t cell_y = 0; cell_y < size_y; ++cell_y) {
+          for (std::size_t cell_x = 0; cell_x < size_x; ++cell_x) {
+            auto& cell = som(cell_x, cell_y);
 
-          // Get the weights of the cell and update them
-          if (neighborhood_factor != 0) {
-            auto& cell_weights = *cell_it;
-            for (std::size_t wi = 0; wi < som.getDimensions(); ++wi) {
-              cell_weights[wi] =
-                  cell_weights[wi] + neighborhood_factor * learn_factor * (input_weights[wi] - cell_weights[wi]);
+            // Compute the factor based on the distance of the BMU and the cell
+            auto neighborhood_factor = m_neighborhood_func({bmu_x, bmu_y}, {cell_x, cell_y}, i, iter_no);
+
+            // Get the weights of the cell and update them
+            if (neighborhood_factor != 0) {
+              for (std::size_t wi = 0; wi < som.getDimensions(); ++wi) {
+                cell[wi] = cell[wi] + neighborhood_factor * learn_factor * (input_weights[wi] - cell[wi]);
+              }
             }
           }
         }

--- a/SOM/SOM/UMatrix.h
+++ b/SOM/SOM/UMatrix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -34,8 +34,8 @@ using UMatrix = GridContainer::GridContainer<std::vector<double>, std::size_t, s
 
 enum class UMatrixType { MIN, MAX, MEAN };
 
-template <std::size_t ND, typename DistFunc = Distance::L2<ND>>
-UMatrix computeUMatrix(const SOM<ND, DistFunc>& som, UMatrixType type = UMatrixType::MEAN);
+template <typename DistFunc = Distance::L2>
+UMatrix computeUMatrix(const SOM<DistFunc>& som, UMatrixType type = UMatrixType::MEAN);
 
 }  // namespace SOM
 }  // namespace Euclid

--- a/SOM/SOM/_impl/SOM.icpp
+++ b/SOM/SOM/_impl/SOM.icpp
@@ -28,11 +28,12 @@ namespace SOM {
 
 template <typename DistFunc>
 SOM<DistFunc>::SOM(std::size_t dimensions, std::size_t x, std::size_t y, InitFunc::Signature init_func)
-    : m_dimensions(dimensions), m_cells(ImplTools::indexAxis("X", x), ImplTools::indexAxis("Y", y)), m_size(x, y) {
+    : m_dimensions(dimensions)
+    , m_cells({ImplTools::indexAxis("X", x), ImplTools::indexAxis("Y", y)}, m_dimensions)
+    , m_size(x, y) {
 
   // Initialize all the grid cells using the given function
-  for (auto& array : m_cells) {
-    array.resize(m_dimensions);
+  for (auto array : m_cells) {
     for (auto& w : array) {
       w = init_func();
     }
@@ -51,12 +52,12 @@ std::size_t SOM<DistFunc>::getDimensions() const {
 }
 
 template <typename DistFunc>
-typename std::vector<double>& SOM<DistFunc>::operator()(std::size_t x, std::size_t y) {
+auto SOM<DistFunc>::operator()(std::size_t x, std::size_t y) -> reference_type {
   return m_cells(x, y);
 }
 
 template <typename DistFunc>
-const typename std::vector<double>& SOM<DistFunc>::operator()(std::size_t x, std::size_t y) const {
+auto SOM<DistFunc>::operator()(std::size_t x, std::size_t y) const -> const reference_type {
   return m_cells(x, y);
 }
 
@@ -93,8 +94,9 @@ typename SOM<DistFunc>::const_iterator SOM<DistFunc>::cend() {
 namespace SOM_impl {
 
 template <typename DistFunc>
-std::tuple<std::size_t, std::size_t, double> findBMU_impl(const SOM<DistFunc>&                              som,
-                                                          std::function<double(const std::vector<double>&)> dist_func) {
+std::tuple<std::size_t, std::size_t, double>
+findBMU_impl(const SOM<DistFunc>&                                                  som,
+             std::function<double(const GridContainer::VectorValueProxy<double>&)> dist_func) {
   auto   result_iter      = som.begin();
   double closest_distance = std::numeric_limits<double>::max();
   for (auto iter = som.begin(); iter != som.end(); ++iter) {
@@ -113,9 +115,10 @@ template <typename DistFunc>
 std::tuple<std::size_t, std::size_t, double> SOM<DistFunc>::findBMU(const std::vector<double>& input) const {
   assert(input.size() == m_dimensions);
   DistFunc dist_func{};
-  return SOM_impl::findBMU_impl<DistFunc>(*this, [&dist_func, &input](const std::vector<double>& cell) -> double {
-    return dist_func.distance(cell, input);
-  });
+  return SOM_impl::findBMU_impl<DistFunc>(
+      *this, [&dist_func, &input](const GridContainer::VectorValueProxy<double>& cell) -> double {
+        return dist_func.distance(cell.begin(), cell.end(), input.begin());
+      });
 }
 
 template <typename DistFunc>
@@ -124,8 +127,8 @@ std::tuple<std::size_t, std::size_t, double> SOM<DistFunc>::findBMU(const std::v
   assert(input.size() == uncertainties.size() && input.size() == m_dimensions);
   DistFunc dist_func{};
   return SOM_impl::findBMU_impl<DistFunc>(
-      *this, [&dist_func, &input, &uncertainties](const std::vector<double>& cell) -> double {
-        return dist_func.distance(cell, input, uncertainties);
+      *this, [&dist_func, &input, &uncertainties](const GridContainer::VectorValueProxy<double>& cell) -> double {
+        return dist_func.distance(cell.begin(), cell.end(), input.begin(), uncertainties.begin());
       });
 }
 

--- a/SOM/SOM/_impl/SOM.icpp
+++ b/SOM/SOM/_impl/SOM.icpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -26,12 +26,13 @@
 namespace Euclid {
 namespace SOM {
 
-template <std::size_t ND, typename DistFunc>
-SOM<ND, DistFunc>::SOM(std::size_t x, std::size_t y, InitFunc::Signature init_func)
-    : m_cells(ImplTools::indexAxis("X", x), ImplTools::indexAxis("Y", y)), m_size(x, y) {
+template <typename DistFunc>
+SOM<DistFunc>::SOM(std::size_t dimensions, std::size_t x, std::size_t y, InitFunc::Signature init_func)
+    : m_dimensions(dimensions), m_cells(ImplTools::indexAxis("X", x), ImplTools::indexAxis("Y", y)), m_size(x, y) {
 
   // Initialize all the grid cells using the given function
   for (auto& array : m_cells) {
+    array.resize(m_dimensions);
     for (auto& w : array) {
       w = init_func();
     }
@@ -39,56 +40,61 @@ SOM<ND, DistFunc>::SOM(std::size_t x, std::size_t y, InitFunc::Signature init_fu
 
 }  // end of namespace SOM_impl
 
-template <std::size_t ND, typename DistFunc>
-const std::pair<std::size_t, std::size_t>& SOM<ND, DistFunc>::getSize() const {
+template <typename DistFunc>
+const std::pair<std::size_t, std::size_t>& SOM<DistFunc>::getSize() const {
   return m_size;
 }
 
-template <std::size_t ND, typename DistFunc>
-typename std::array<double, ND>& SOM<ND, DistFunc>::operator()(std::size_t x, std::size_t y) {
+template <typename DistFunc>
+std::size_t SOM<DistFunc>::getDimensions() const {
+  return m_dimensions;
+}
+
+template <typename DistFunc>
+typename std::vector<double>& SOM<DistFunc>::operator()(std::size_t x, std::size_t y) {
   return m_cells(x, y);
 }
 
-template <std::size_t ND, typename DistFunc>
-const typename std::array<double, ND>& SOM<ND, DistFunc>::operator()(std::size_t x, std::size_t y) const {
+template <typename DistFunc>
+const typename std::vector<double>& SOM<DistFunc>::operator()(std::size_t x, std::size_t y) const {
   return m_cells(x, y);
 }
 
-template <std::size_t ND, typename DistFunc>
-typename SOM<ND, DistFunc>::iterator SOM<ND, DistFunc>::begin() {
+template <typename DistFunc>
+typename SOM<DistFunc>::iterator SOM<DistFunc>::begin() {
   return m_cells.begin();
 }
 
-template <std::size_t ND, typename DistFunc>
-typename SOM<ND, DistFunc>::iterator SOM<ND, DistFunc>::end() {
+template <typename DistFunc>
+typename SOM<DistFunc>::iterator SOM<DistFunc>::end() {
   return m_cells.end();
 }
 
-template <std::size_t ND, typename DistFunc>
-typename SOM<ND, DistFunc>::const_iterator SOM<ND, DistFunc>::begin() const {
+template <typename DistFunc>
+typename SOM<DistFunc>::const_iterator SOM<DistFunc>::begin() const {
   return m_cells.begin();
 }
 
-template <std::size_t ND, typename DistFunc>
-typename SOM<ND, DistFunc>::const_iterator SOM<ND, DistFunc>::end() const {
+template <typename DistFunc>
+typename SOM<DistFunc>::const_iterator SOM<DistFunc>::end() const {
   return m_cells.end();
 }
 
-template <std::size_t ND, typename DistFunc>
-typename SOM<ND, DistFunc>::const_iterator SOM<ND, DistFunc>::cbegin() {
+template <typename DistFunc>
+typename SOM<DistFunc>::const_iterator SOM<DistFunc>::cbegin() {
   return m_cells.cbegin();
 }
 
-template <std::size_t ND, typename DistFunc>
-typename SOM<ND, DistFunc>::const_iterator SOM<ND, DistFunc>::cend() {
+template <typename DistFunc>
+typename SOM<DistFunc>::const_iterator SOM<DistFunc>::cend() {
   return m_cells.cend();
 }
 
 namespace SOM_impl {
 
-template <std::size_t ND, typename DistFunc>
-std::tuple<std::size_t, std::size_t, double> findBMU_impl(const SOM<ND, DistFunc>&                             som,
-                                                          std::function<double(const std::array<double, ND>&)> dist_func) {
+template <typename DistFunc>
+std::tuple<std::size_t, std::size_t, double> findBMU_impl(const SOM<DistFunc>&                              som,
+                                                          std::function<double(const std::vector<double>&)> dist_func) {
   auto   result_iter      = som.begin();
   double closest_distance = std::numeric_limits<double>::max();
   for (auto iter = som.begin(); iter != som.end(); ++iter) {
@@ -103,42 +109,46 @@ std::tuple<std::size_t, std::size_t, double> findBMU_impl(const SOM<ND, DistFunc
 
 }  // end of namespace SOM_impl
 
-template <std::size_t ND, typename DistFunc>
-std::tuple<std::size_t, std::size_t, double> SOM<ND, DistFunc>::findBMU(const std::array<double, ND>& input) const {
+template <typename DistFunc>
+std::tuple<std::size_t, std::size_t, double> SOM<DistFunc>::findBMU(const std::vector<double>& input) const {
+  assert(input.size() == m_dimensions);
   DistFunc dist_func{};
-  return SOM_impl::findBMU_impl<ND, DistFunc>(
-      *this, [&dist_func, &input](const std::array<double, ND>& cell) -> double { return dist_func.distance(cell, input); });
+  return SOM_impl::findBMU_impl<DistFunc>(*this, [&dist_func, &input](const std::vector<double>& cell) -> double {
+    return dist_func.distance(cell, input);
+  });
 }
 
-template <std::size_t ND, typename DistFunc>
-std::tuple<std::size_t, std::size_t, double> SOM<ND, DistFunc>::findBMU(const std::array<double, ND>& input,
-                                                                        const std::array<double, ND>& uncertainties) const {
+template <typename DistFunc>
+std::tuple<std::size_t, std::size_t, double> SOM<DistFunc>::findBMU(const std::vector<double>& input,
+                                                                    const std::vector<double>& uncertainties) const {
+  assert(input.size() == uncertainties.size() && input.size() == m_dimensions);
   DistFunc dist_func{};
-  return SOM_impl::findBMU_impl<ND, DistFunc>(*this,
-                                              [&dist_func, &input, &uncertainties](const std::array<double, ND>& cell) -> double {
-                                                return dist_func.distance(cell, input, uncertainties);
-                                              });
+  return SOM_impl::findBMU_impl<DistFunc>(
+      *this, [&dist_func, &input, &uncertainties](const std::vector<double>& cell) -> double {
+        return dist_func.distance(cell, input, uncertainties);
+      });
 }
 
-template <std::size_t ND, typename DistFunc>
+template <typename DistFunc>
 template <typename InputType, typename WeightFunc>
-std::tuple<std::size_t, std::size_t, double> SOM<ND, DistFunc>::findBMU(const InputType& input, WeightFunc weight_func) const {
+std::tuple<std::size_t, std::size_t, double> SOM<DistFunc>::findBMU(const InputType& input,
+                                                                    WeightFunc       weight_func) const {
 
-  static_assert(std::is_same<decltype(std::declval<WeightFunc>()(input)), std::array<double, ND>>::value,
-                "WeightFunc must be callable with input as parameter, returning an std::array<double, ND>");
+  static_assert(std::is_same<decltype(std::declval<WeightFunc>()(input)), std::vector<double>>::value,
+                "WeightFunc must be callable with input as parameter, returning an std::vector<double>");
 
   return findBMU(weight_func(input));
 }
 
-template <std::size_t ND, typename DistFunc>
+template <typename DistFunc>
 template <typename InputType, typename WeightFunc, typename UncertaintyFunc>
-std::tuple<std::size_t, std::size_t, double> SOM<ND, DistFunc>::findBMU(const InputType& input, WeightFunc weight_func,
-                                                                        UncertaintyFunc uncertainty_func) const {
+std::tuple<std::size_t, std::size_t, double> SOM<DistFunc>::findBMU(const InputType& input, WeightFunc weight_func,
+                                                                    UncertaintyFunc uncertainty_func) const {
 
-  static_assert(std::is_same<decltype(std::declval<WeightFunc>()(input)), std::array<double, ND>>::value,
-                "WeightFunc must be callable with input as parameter, returning an std::array<double, ND>");
-  static_assert(std::is_same<decltype(std::declval<UncertaintyFunc>()(input)), std::array<double, ND>>::value,
-                "UncertaintyFunc must be callable with input as parameter, returning an std::array<double, ND>");
+  static_assert(std::is_same<decltype(std::declval<WeightFunc>()(input)), std::vector<double>>::value,
+                "WeightFunc must be callable with input as parameter, returning an std::vector<double>");
+  static_assert(std::is_same<decltype(std::declval<UncertaintyFunc>()(input)), std::vector<double>>::value,
+                "UncertaintyFunc must be callable with input as parameter, returning an std::vector<double>");
 
   return findBMU(weight_func(input), uncertainty_func(input));
 }

--- a/SOM/SOM/_impl/SOM.icpp
+++ b/SOM/SOM/_impl/SOM.icpp
@@ -29,7 +29,7 @@ namespace SOM {
 template <typename DistFunc>
 SOM<DistFunc>::SOM(std::size_t dimensions, std::size_t x, std::size_t y, InitFunc::Signature init_func)
     : m_dimensions(dimensions)
-    , m_cells({ImplTools::indexAxis("X", x), ImplTools::indexAxis("Y", y)}, m_dimensions)
+    , m_cells(std::make_tuple(ImplTools::indexAxis("X", x), ImplTools::indexAxis("Y", y)), m_dimensions)
     , m_size(x, y) {
 
   // Initialize all the grid cells using the given function

--- a/SOM/SOM/_impl/SOMProjector.icpp
+++ b/SOM/SOM/_impl/SOMProjector.icpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -29,9 +29,9 @@ namespace SOM {
 
 namespace SOMProjector_impl {
 
-template <typename T, std::size_t ND, typename DistFunc, typename InputIter, typename AdderFunc, typename BmuFunc>
-SOMProjector::ProjectGrid<T> project_impl(const SOM<ND, DistFunc>& som, InputIter begin, InputIter end, AdderFunc adder_func,
-                                          BmuFunc bmu_func, const T& init_cell) {
+template <typename T, typename DistFunc, typename InputIter, typename AdderFunc, typename BmuFunc>
+SOMProjector::ProjectGrid<T> project_impl(const SOM<DistFunc>& som, InputIter begin, InputIter end,
+                                          AdderFunc adder_func, BmuFunc bmu_func, const T& init_cell) {
 
   // Create the grid to return
   auto                         size = som.getSize();
@@ -61,8 +61,8 @@ SOMProjector::ProjectGrid<T> project_impl(const SOM<ND, DistFunc>& som, InputIte
 
 }  // namespace SOMProjector_impl
 
-template <typename T, std::size_t ND, typename DistFunc, typename InputIter, typename WeightFunc, typename AdderFunc>
-SOMProjector::ProjectGrid<T> SOMProjector::project(const SOM<ND, DistFunc>& som, InputIter begin, InputIter end,
+template <typename T, typename DistFunc, typename InputIter, typename WeightFunc, typename AdderFunc>
+SOMProjector::ProjectGrid<T> SOMProjector::project(const SOM<DistFunc>& som, InputIter begin, InputIter end,
                                                    WeightFunc weight_func, AdderFunc adder_func, const T& init_cell) {
 
   auto bmu_func = [&som, &weight_func](const typename std::iterator_traits<InputIter>::value_type& input) {
@@ -72,13 +72,14 @@ SOMProjector::ProjectGrid<T> SOMProjector::project(const SOM<ND, DistFunc>& som,
   return SOMProjector_impl::project_impl(som, begin, end, adder_func, bmu_func, init_cell);
 }
 
-template <typename T, std::size_t ND, typename DistFunc, typename InputIter, typename WeightFunc, typename UncertaintyFunc,
+template <typename T, typename DistFunc, typename InputIter, typename WeightFunc, typename UncertaintyFunc,
           typename AdderFunc>
-SOMProjector::ProjectGrid<T> SOMProjector::project(const SOM<ND, DistFunc>& som, InputIter begin, InputIter end,
-                                                   WeightFunc weight_func, UncertaintyFunc uncertainty_func, AdderFunc adder_func,
-                                                   const T& init_cell) {
+SOMProjector::ProjectGrid<T> SOMProjector::project(const SOM<DistFunc>& som, InputIter begin, InputIter end,
+                                                   WeightFunc weight_func, UncertaintyFunc uncertainty_func,
+                                                   AdderFunc adder_func, const T& init_cell) {
 
-  auto bmu_func = [&som, &weight_func, &uncertainty_func](const typename std::iterator_traits<InputIter>::value_type& input) {
+  auto bmu_func = [&som, &weight_func,
+                   &uncertainty_func](const typename std::iterator_traits<InputIter>::value_type& input) {
     return som.findBMU(input, weight_func, uncertainty_func);
   };
 

--- a/SOM/SOM/_impl/UMatrix.icpp
+++ b/SOM/SOM/_impl/UMatrix.icpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -40,8 +40,8 @@ std::map<UMatrixType, std::function<double(const std::vector<double>&)>> type_fu
 
 }
 
-template <std::size_t ND, typename DistFunc>
-UMatrix computeUMatrix(const SOM<ND, DistFunc>& som, UMatrixType type) {
+template <typename DistFunc>
+UMatrix computeUMatrix(const SOM<DistFunc>& som, UMatrixType type) {
 
   DistFunc dist_func{};
 

--- a/SOM/SOM/_impl/UMatrix.icpp
+++ b/SOM/SOM/_impl/UMatrix.icpp
@@ -32,8 +32,10 @@ namespace SOM {
 namespace UMatrix_impl {
 
 std::map<UMatrixType, std::function<double(const std::vector<double>&)>> type_func_map{
-    {UMatrixType::MIN, [](const std::vector<double>& dist_list) { return *std::min_element(dist_list.begin(), dist_list.end()); }},
-    {UMatrixType::MAX, [](const std::vector<double>& dist_list) { return *std::max_element(dist_list.begin(), dist_list.end()); }},
+    {UMatrixType::MIN,
+     [](const std::vector<double>& dist_list) { return *std::min_element(dist_list.begin(), dist_list.end()); }},
+    {UMatrixType::MAX,
+     [](const std::vector<double>& dist_list) { return *std::max_element(dist_list.begin(), dist_list.end()); }},
     {UMatrixType::MEAN, [](const std::vector<double>& dist_list) {
        return std::accumulate(dist_list.begin(), dist_list.end(), 0.) / dist_list.size();
      }}};
@@ -69,7 +71,9 @@ UMatrix computeUMatrix(const SOM<DistFunc>& som, UMatrixType type) {
             continue;
           }
 
-          dist_list.push_back(dist_func.distance(som(x, y), som(i, j)));
+          auto sxy = som(x, y);
+          auto sij = som(i, j);
+          dist_list.push_back(dist_func.distance(sxy.begin(), sxy.end(), sij.begin()));
         }
       }
 

--- a/SOM/SOM/serialization/SOM.h
+++ b/SOM/SOM/serialization/SOM.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -24,57 +24,60 @@
 #ifndef SOM_SERIALIZATION_SOM_H
 #define SOM_SERIALIZATION_SOM_H
 
-#include "AlexandriaKernel/serialization/array.h"
 #include "ElementsKernel/Exception.h"
 #include "SOM/SOM.h"
 #include <boost/serialization/split_free.hpp>
 #include <boost/serialization/string.hpp>
+#include <boost/serialization/vector.hpp>
 #include <typeinfo>
 
 namespace boost {
 namespace serialization {
 
-template <class Archive, std::size_t ND, typename DistFunc>
-void save(Archive& ar, const Euclid::SOM::SOM<ND, DistFunc>& som, const unsigned int) {
+template <class Archive, typename DistFunc>
+void save(Archive& ar, const Euclid::SOM::SOM<DistFunc>& som, const unsigned int) {
   for (auto& cell : som) {
     ar << cell;
   }
 }
 
-template <class Archive, std::size_t ND, typename DistFunc>
-void load(Archive& ar, Euclid::SOM::SOM<ND, DistFunc>& som, const unsigned int) {
+template <class Archive, typename DistFunc>
+void load(Archive& ar, Euclid::SOM::SOM<DistFunc>& som, const unsigned int) {
   for (auto& cell : som) {
     ar >> cell;
   }
 }
 
-template <class Archive, std::size_t ND, typename DistFunc>
-void serialize(Archive& ar, Euclid::SOM::SOM<ND, DistFunc>& som, const unsigned int version) {
+template <class Archive, typename DistFunc>
+void serialize(Archive& ar, Euclid::SOM::SOM<DistFunc>& som, const unsigned int version) {
   split_free(ar, som, version);
 }
 
-template <class Archive, std::size_t ND, typename DistFunc>
-void save_construct_data(Archive& ar, const Euclid::SOM::SOM<ND, DistFunc>* t, const unsigned int) {
+template <class Archive, typename DistFunc>
+void save_construct_data(Archive& ar, const Euclid::SOM::SOM<DistFunc>* t, const unsigned int) {
   std::string dist_func_type = typeid(DistFunc).name();
   ar << dist_func_type;
+  ar << t->getDimensions();
   auto size = t->getSize();
   ar << size.first;
   ar << size.second;
 }
 
-template <class Archive, std::size_t ND, typename DistFunc>
-void load_construct_data(Archive& ar, Euclid::SOM::SOM<ND, DistFunc>* t, const unsigned int) {
+template <class Archive, typename DistFunc>
+void load_construct_data(Archive& ar, Euclid::SOM::SOM<DistFunc>* t, const unsigned int) {
   std::string dist_func_type;
   ar >> dist_func_type;
   if (dist_func_type != typeid(DistFunc).name()) {
     throw Elements::Exception() << "Incompatible DistFunc parameter. File contains SOM with " << dist_func_type
                                 << " and is read as " << typeid(DistFunc).name();
   }
+  std::size_t dim;
+  ar >> dim;
   std::size_t x;
   ar >> x;
   std::size_t y;
   ar >> y;
-  ::new (t) Euclid::SOM::SOM<ND, DistFunc>(x, y);
+  ::new (t) Euclid::SOM::SOM<DistFunc>(dim, x, y);
 }
 
 }  // namespace serialization

--- a/SOM/SOM/serialization/SOM.h
+++ b/SOM/SOM/serialization/SOM.h
@@ -57,7 +57,8 @@ template <class Archive, typename DistFunc>
 void save_construct_data(Archive& ar, const Euclid::SOM::SOM<DistFunc>* t, const unsigned int) {
   std::string dist_func_type = typeid(DistFunc).name();
   ar << dist_func_type;
-  ar << t->getDimensions();
+  auto dim = t->getDimensions();
+  ar << dim;
   auto size = t->getSize();
   ar << size.first;
   ar << size.second;

--- a/SOM/SOM/serialization/SOM.h
+++ b/SOM/SOM/serialization/SOM.h
@@ -43,7 +43,7 @@ void save(Archive& ar, const Euclid::SOM::SOM<DistFunc>& som, const unsigned int
 
 template <class Archive, typename DistFunc>
 void load(Archive& ar, Euclid::SOM::SOM<DistFunc>& som, const unsigned int) {
-  for (auto& cell : som) {
+  for (auto cell : som) {
     ar >> cell;
   }
 }

--- a/SOM/SOM/serialize.h
+++ b/SOM/SOM/serialize.h
@@ -25,6 +25,7 @@
 #define SOM_SERIALIZE_H
 
 #include "ElementsKernel/Exception.h"
+#include "GridContainer/serialization/GridCellManagerVectorOfVectors.h"
 #include "SOM/Distance.h"
 #include "SOM/serialization/SOM.h"
 #include <CCfits/CCfits>
@@ -39,7 +40,7 @@ template <typename OArchive, typename DistFunc>
 void somExport(std::ostream& out, const SOM<DistFunc>& som) {
   // Do NOT delete this pointer!!! It  points to the actual som
   const SOM<DistFunc>* ptr = &som;
-  OArchive                 boa{out};
+  OArchive             boa{out};
   boa << ptr;
 }
 
@@ -110,8 +111,8 @@ SOM<DistFunc> somFitsImport(const std::string& filename) {
     throw Elements::Exception() << "Data array in file " << filename << " does not have 3 dimensions";
   }
   std::size_t dim = fits.pHDU().axis(2);
-  std::size_t x = fits.pHDU().axis(0);
-  std::size_t y = fits.pHDU().axis(1);
+  std::size_t x   = fits.pHDU().axis(0);
+  std::size_t y   = fits.pHDU().axis(1);
 
   // Read the data from the file
   std::valarray<double> data;
@@ -119,9 +120,9 @@ SOM<DistFunc> somFitsImport(const std::string& filename) {
 
   // Copy the data in a SOM object
   SOM<DistFunc> result{dim, x, y};
-  int               i = 0;
+  int           i = 0;
   for (std::size_t w_i = 0; w_i < dim; ++w_i) {
-    for (auto& w_arr : result) {
+    for (auto w_arr : result) {
       w_arr[w_i] = data[i];
       ++i;
     }

--- a/SOM/SOM/serialize.h
+++ b/SOM/SOM/serialize.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -35,55 +35,55 @@
 namespace Euclid {
 namespace SOM {
 
-template <typename OArchive, std::size_t ND, typename DistFunc>
-void somExport(std::ostream& out, const SOM<ND, DistFunc>& som) {
+template <typename OArchive, typename DistFunc>
+void somExport(std::ostream& out, const SOM<DistFunc>& som) {
   // Do NOT delete this pointer!!! It  points to the actual som
-  const SOM<ND, DistFunc>* ptr = &som;
+  const SOM<DistFunc>* ptr = &som;
   OArchive                 boa{out};
   boa << ptr;
 }
 
-template <std::size_t ND, typename DistFunc>
-void somBinaryExport(std::ostream& out, const SOM<ND, DistFunc>& som) {
+template <typename DistFunc>
+void somBinaryExport(std::ostream& out, const SOM<DistFunc>& som) {
   somExport<boost::archive::binary_oarchive>(out, som);
 }
 
-template <typename IArchive, std::size_t ND, typename DistFunc = Distance::L2<ND>>
-SOM<ND, DistFunc> somImport(std::istream& in) {
+template <typename IArchive, typename DistFunc = Distance::L2>
+SOM<DistFunc> somImport(std::istream& in) {
   IArchive bia{in};
   // Do NOT delete manually this pointer. It is wrapped with a unique_ptr later.
-  SOM<ND, DistFunc>* ptr;
+  SOM<DistFunc>* ptr;
   bia >> ptr;
-  std::unique_ptr<SOM<ND, DistFunc>> smart_ptr{ptr};
+  std::unique_ptr<SOM<DistFunc>> smart_ptr{ptr};
   // We move out to the result the som pointed by the pointer. The unique_ptr
   // will delete the (now empty) pointed object
   return std::move(*smart_ptr);
 }
 
-template <std::size_t ND, typename DistFunc = Distance::L2<ND>>
-SOM<ND, DistFunc> somBinaryImport(std::istream& in) {
-  return somImport<boost::archive::binary_iarchive, ND, DistFunc>(in);
+template <typename DistFunc = Distance::L2>
+SOM<DistFunc> somBinaryImport(std::istream& in) {
+  return somImport<boost::archive::binary_iarchive, DistFunc>(in);
 }
 
-template <std::size_t ND, typename DistFunc>
-void somFitsExport(const std::string& filename, const SOM<ND, DistFunc>& som) {
+template <typename DistFunc>
+void somFitsExport(const std::string& filename, const SOM<DistFunc>& som) {
 
   // Create the output file and the array HDU
   int         n_axes = 3;
   std::size_t x;
   std::size_t y;
   std::tie(x, y)           = som.getSize();
-  long         ax_sizes[3] = {long(x), long(y), long(ND)};
+  long         ax_sizes[3] = {long(x), long(y), long(som.getDimensions())};
   CCfits::FITS fits(filename, DOUBLE_IMG, n_axes, ax_sizes);
 
   // Write in the header the DistFunc type
   fits.pHDU().addKey("DISTFUNC", typeid(DistFunc).name(), "");
 
   // Create a valarray with the SOM data
-  std::size_t           total_size = x * y * ND;
+  std::size_t           total_size = x * y * som.getDimensions();
   std::valarray<double> data(total_size);
   int                   i = 0;
-  for (std::size_t w_i = 0; w_i < ND; ++w_i) {
+  for (std::size_t w_i = 0; w_i < som.getDimensions(); ++w_i) {
     for (auto& w_arr : som) {
       data[i] = w_arr[w_i];
       ++i;
@@ -92,8 +92,8 @@ void somFitsExport(const std::string& filename, const SOM<ND, DistFunc>& som) {
   fits.pHDU().write(1, total_size, data);
 }
 
-template <std::size_t ND, typename DistFunc = Distance::L2<ND>>
-SOM<ND, DistFunc> somFitsImport(const std::string& filename) {
+template <typename DistFunc = Distance::L2>
+SOM<DistFunc> somFitsImport(const std::string& filename) {
 
   CCfits::FITS fits(filename, CCfits::Read);
 
@@ -109,10 +109,7 @@ SOM<ND, DistFunc> somFitsImport(const std::string& filename) {
   if (fits.pHDU().axes() != 3) {
     throw Elements::Exception() << "Data array in file " << filename << " does not have 3 dimensions";
   }
-  if (fits.pHDU().axis(2) != ND) {
-    throw Elements::Exception() << "Weights dimension of array in file " << filename << " should have size " << ND
-                                << " but was " << fits.pHDU().axis(2);
-  }
+  std::size_t dim = fits.pHDU().axis(2);
   std::size_t x = fits.pHDU().axis(0);
   std::size_t y = fits.pHDU().axis(1);
 
@@ -121,9 +118,9 @@ SOM<ND, DistFunc> somFitsImport(const std::string& filename) {
   fits.pHDU().read(data);
 
   // Copy the data in a SOM object
-  SOM<ND, DistFunc> result{x, y};
+  SOM<DistFunc> result{dim, x, y};
   int               i = 0;
-  for (std::size_t w_i = 0; w_i < ND; ++w_i) {
+  for (std::size_t w_i = 0; w_i < dim; ++w_i) {
     for (auto& w_arr : result) {
       w_arr[w_i] = data[i];
       ++i;

--- a/SOM/tests/src/SOM_test.cpp
+++ b/SOM/tests/src/SOM_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_SUITE(SOM_test)
 
 BOOST_AUTO_TEST_CASE(example_test) {
 
-  SOM<2> som{5, 5, InitFunc::uniformRandom(0, 1)};
+  SOM<> som{2, 5, 5, InitFunc::uniformRandom(0, 1)};
   som.findBMU({1, 2});
   som.findBMU({1, 2}, {0.1, 0.4});
 
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(example_test) {
 
   SOMTrainer trainer{NeighborhoodFunc::linearUnitDisk(3), LearningRestraintFunc::linear()};
   auto       weight_func = [](const std::pair<double, double>& p) {
-    std::array<double, 2> res;
+    std::vector<double> res(2);
     res[0] = p.first;
     res[1] = p.second;
     return res;


### PR DESCRIPTION
Use a parameter at construction time.
The performance is a bit worse (I guess the distance methods can not be as heavily optimized by the compiler as an array of fixed size can), but with this SOM correction compiles with around 2GiB (4 threads). This should fix the problem in Codeen.