### PR TITLE
Fix an OOB access in interpolation

### DIFF
--- a/MathUtils/src/lib/interpolation/linear.cpp
+++ b/MathUtils/src/lib/interpolation/linear.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -60,9 +60,12 @@ public:
 
     // To avoid if within the loop, treat values exactly equal to the first knot here
     auto x = xs.begin() + n_less;
-    while (*x == m_knots.front()) {
+    while (x < xs.end() && *x == m_knots.front()) {
       *o = m_coef1.front() * *x + m_coef0.front();
       ++o, ++x;
+    }
+    if (x == xs.end()) {
+      return;
     }
 
     // Interpolate values within range

--- a/MathUtils/src/lib/interpolation/spline.cpp
+++ b/MathUtils/src/lib/interpolation/spline.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -66,10 +66,13 @@ public:
 
     // To avoid if within the loop, treat values exactly equal to the first knot here
     auto x = xs.begin() + n_less;
-    while (*x == m_knots.front()) {
+    while (x < xs.end() && *x == m_knots.front()) {
       auto x2 = *x * *x;
       *o      = m_coef3.front() * x2 * *x + m_coef2.front() * x2 + m_coef1.front() * *x + m_coef0.front();
       ++o, ++x;
+    }
+    if (x == xs.end()) {
+      return;
     }
 
     // Interpolate values within range

--- a/MathUtils/tests/src/interpolation/Linear_test.cpp
+++ b/MathUtils/tests/src/interpolation/Linear_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -229,6 +229,34 @@ BOOST_FIXTURE_TEST_CASE(LinearExtrapolate_Vector, Linear_Fixture) {
   BOOST_REQUIRE_EQUAL(output.size(), x2.size());
   for (size_t i = 0; i < output.size(); ++i) {
     BOOST_CHECK_CLOSE(output[i], expected[i], close_tolerance);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(LinearInterpolateAllOutside, Linear_Fixture) {
+  // Given
+  std::vector<double> x{-1., 0., 1., 2., 8., 10.};
+  std::vector<double> y{4., 3., 1., 2., 2., 20.};
+  std::vector<double> x2{-20., -10., -5};
+  std::vector<double> x3{40., 50., 60, 70., 80.};
+
+  // When
+  auto linear = Euclid::MathUtils::interpolate(x, y, Euclid::MathUtils::InterpolationType::LINEAR, false);
+
+  // Then
+  std::vector<double> output;
+  (*linear)(x2, output);
+  BOOST_CHECK_EQUAL(output.size(), x2.size());
+
+  for (auto& v : output) {
+    BOOST_CHECK_EQUAL(v, 0.);
+  }
+
+  (*linear)(x3, output);
+  BOOST_CHECK_EQUAL(output.size(), x3.size());
+  for (auto& v : output) {
+    BOOST_CHECK_EQUAL(v, 0.);
   }
 }
 

--- a/MathUtils/tests/src/interpolation/Spline_test.cpp
+++ b/MathUtils/tests/src/interpolation/Spline_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -241,6 +241,32 @@ BOOST_FIXTURE_TEST_CASE(Spline_Vector, Spline_Fixture) {
   BOOST_REQUIRE_EQUAL(output.size(), xs.size());
   for (size_t i = 0; i < xs.size(); ++i) {
     BOOST_CHECK_CLOSE(output[i], expected[i], close_tolerance);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(InterpolateAllOutside, Spline_Fixture) {
+  // Given
+  std::vector<double> x2{-30., -20., -15.};
+  std::vector<double> x3{40., 50., 60., 80.};
+
+  // When
+  auto cubic = Euclid::MathUtils::interpolate(x, y, Euclid::MathUtils::InterpolationType::CUBIC_SPLINE, false);
+
+  // Then
+  std::vector<double> output;
+  (*cubic)(x2, output);
+  BOOST_CHECK_EQUAL(output.size(), x2.size());
+
+  for (auto& v : output) {
+    BOOST_CHECK_EQUAL(v, 0.);
+  }
+
+  (*cubic)(x3, output);
+  BOOST_CHECK_EQUAL(output.size(), x3.size());
+  for (auto& v : output) {
+    BOOST_CHECK_EQUAL(v, 0.);
   }
 }
 


### PR DESCRIPTION
Some values cause out-of-bounds access, which can crash depending on the platform.
In one of the PhosphorosCore tests, the crash is intercepted by the boost unit test framework, which deadlocks when trying to handle it.

I will port back to 2.23.