### PR TITLE
Add setHeader API to Table::FitsWriter

### DIFF
--- a/Table/Table/FitsWriter.h
+++ b/Table/Table/FitsWriter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -179,6 +179,22 @@ public:
    */
   void addComment(const std::string& message) override;
 
+  /**
+   * @brief Sets a header key/value pair
+   * @tparam T
+   *    Value type
+   * @param key
+   *    Header name
+   * @param value
+   *    Header value
+   * @param comment
+   *    Header comment
+   */
+  template <typename T>
+  void setHeader(const std::string& key, T&& value, const std::string& comment = "") {
+    m_headers.emplace_back(Header{key, comment, value});
+  }
+
 protected:
   /// Creates the FITS file if it needs to be created, the table HDU if the
   /// name already exist and writes the comments.
@@ -189,13 +205,19 @@ protected:
   void append(const Table& table) override;
 
 private:
-  std::string                   m_filename      = "";
+  struct Header {
+    std::string    m_key, m_comment;
+    Row::cell_type m_value;
+  };
+
+  std::string                   m_filename;
   std::shared_ptr<CCfits::FITS> m_fits          = nullptr;
   bool                          m_initialized   = false;
   bool                          m_override_file = true;
   Format                        m_format        = Format::BINARY;
-  std::string                   m_hdu_name      = "";
-  std::vector<std::string>      m_comments{};
+  std::string                   m_hdu_name;
+  std::vector<std::string>      m_comments;
+  std::vector<Header>           m_headers;
   int                           m_hdu_index    = -1;
   long                          m_current_line = 0;
 

--- a/Table/src/lib/FitsWriter.cpp
+++ b/Table/src/lib/FitsWriter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -29,6 +29,20 @@
 
 namespace Euclid {
 namespace Table {
+
+struct HeaderVisitor : public boost::static_visitor<void> {
+
+  HeaderVisitor(CCfits::HDU* hdu, const std::string& key, const std::string& comment)
+      : m_hdu(hdu), m_key(key), m_comment(comment) {}
+
+  template <typename T>
+  void operator()(T&& val) const {
+    m_hdu->addKey(m_key, val, m_comment);
+  }
+
+  CCfits::HDU*       m_hdu;
+  const std::string &m_key, &m_comment;
+};
 
 FitsWriter::FitsWriter(const std::string& filename, bool override_flag)
     : m_filename(filename), m_override_file(override_flag) {}
@@ -105,6 +119,11 @@ void FitsWriter::init(const Table& table) {
       if (!shape_str.empty()) {
         table_hdu->addKey(CCfits::Column::TDIM() + std::to_string(column_index + 1), shape_str, "");
       }
+    }
+
+    for (auto& h : m_headers) {
+      HeaderVisitor visitor{table_hdu, h.m_key, h.m_comment};
+      boost::apply_visitor(visitor, h.m_value);
     }
 
     for (auto& c : m_comments) {

--- a/Table/tests/src/FitsWriter_test.cpp
+++ b/Table/tests/src/FitsWriter_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -104,6 +104,8 @@ BOOST_FIXTURE_TEST_CASE(writeBinary, BinaryFitsWriter_Fixture) {
   FitsWriter writer{fits_file_path};
   writer.setFormat(FitsWriter::Format::BINARY);
   writer.setHduName("BinaryTable");
+  writer.setHeader("MYSTR", std::string("MyValue"), "This is a comment");
+  writer.setHeader("MYINT", 1234, "Another comment");
 
   // When
   writer.addData(table);
@@ -233,6 +235,22 @@ BOOST_FIXTURE_TEST_CASE(writeBinary, BinaryFitsWriter_Fixture) {
   std::valarray<float> expectedv{1.5, 2.6, 3.7};
   result.column(9).read(vector, 1);
   BOOST_CHECK_EQUAL_COLLECTIONS(std::begin(vector), std::end(vector), std::begin(expectedv), std::end(expectedv));
+
+  // When
+  std::string my_string_val;
+  int my_int_val;
+
+  auto& my_string = result.keyWord("MYSTR");
+  auto& my_int = result.keyWord("MYINT");
+
+  my_string.value(my_string_val);
+  my_int.value(my_int_val);
+
+  // Then
+  BOOST_CHECK_EQUAL(my_string_val, "MyValue");
+  BOOST_CHECK_EQUAL(my_int_val, 1234);
+  BOOST_CHECK_EQUAL(my_string.comment(), "This is a comment");
+  BOOST_CHECK_EQUAL(my_int.comment(), "Another comment");
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Required so the reference sample photometry file can be build in C++.