### PR TITLE
Work around the re-parsing of the FITS header

### DIFF
--- a/Table/src/lib/FitsReader.cpp
+++ b/Table/src/lib/FitsReader.cpp
@@ -131,6 +131,7 @@ Table FitsReader::readImpl(long rows) {
   // create all the rows
   std::vector<std::vector<Row::cell_type>> data;
   data.reserve(table_hdu.numCols());
+  table_hdu.makeThisCurrent();
   for (int i = 1; i <= table_hdu.numCols(); ++i) {
     // The i-1 is because CCfits starts from 1 and ColumnInfo from 0
     // We use a clone of the column because CCfits will cache in memory the read data, so multiple calls
@@ -138,6 +139,11 @@ Table FitsReader::readImpl(long rows) {
     // the FitsReader is destroyed (~FitsReader() => ~Table() => ~Column())
     // For scalars this is not a big deal, but when the column has an array (i.e. a bunch of PDZs), the
     // pile up can be significant after a while.
+    // CCfits will call makeThisCurrent *for each column*
+    // This can be very inefficient, since each call will trigger the parsing of the HDU headers (!!)
+    // Each convertColumn *can* assume makeThisCurrent() has been called here and
+    // *should* do a cast to CCfits::ColumnData to avoid this overhead. This is what CCfits::Column does anyway
+    // when reading ¯\_(ツ)_/¯
     std::unique_ptr<CCfits::Column> column(table_hdu.column(i).clone());
     data.emplace_back(
         translateColumn(*column, m_column_info->getDescription(i - 1).type, m_current_row, m_current_row + rows - 1));


### PR DESCRIPTION
CCfits will call  `parent()->makeThisCurrent` when reading *each column*

For some reason that trigger a re-parsing of the HDU header just to get its name. On the particular case of
the reference sample, this seems to be heavy.

This patch basically moves the logic of `Column::read` into Alexandria, so we can skip those re-parsing of the header.
For `TrainSOM` this reduces almost 2 minutes of reading to around 5 seconds.