### PR TITLE
Allow to override nbytes() for NdArray containers

### DIFF
--- a/NdArray/NdArray/NdArray.h
+++ b/NdArray/NdArray/NdArray.h
@@ -522,9 +522,7 @@ private:
     virtual size_t size() const = 0;
 
     /// Get the size in bytes
-    size_t nbytes() const {
-      return size() * sizeof(T);
-    }
+    virtual size_t nbytes() const = 0;
 
     /// Resize container
     virtual void resize(const std::vector<size_t>& shape) = 0;
@@ -552,6 +550,20 @@ private:
 
     size_t size() const final {
       return m_container.size();
+    }
+
+    template<typename T2>
+    auto nbytesImpl(int) const -> decltype(std::declval<Container<T2>>().nbytes()) {
+      return m_container.nbytes();
+    }
+
+    template<typename T2>
+    size_t nbytesImpl(...) const {
+      return m_container.size() * sizeof(T2);
+    }
+
+    size_t nbytes() const final {
+      return nbytesImpl<T>(0);
     }
 
     template <typename T2>

--- a/NdArray/NdArray/io/_impl/NpyCommon.h
+++ b/NdArray/NdArray/io/_impl/NpyCommon.h
@@ -252,6 +252,10 @@ public:
     return m_n_elements;
   }
 
+  size_t nbytes() const {
+    return m_max_size;
+  }
+
   T* data() {
     return m_data;
   }


### PR DESCRIPTION
i.e. it may belong to a numpy array of mixed types