### PR TITLE
Revert "Work around the re-parsing of the FITS header"

### DIFF
--- a/Table/src/lib/FitsReader.cpp
+++ b/Table/src/lib/FitsReader.cpp
@@ -131,7 +131,6 @@ Table FitsReader::readImpl(long rows) {
   // create all the rows
   std::vector<std::vector<Row::cell_type>> data;
   data.reserve(table_hdu.numCols());
-  table_hdu.makeThisCurrent();
   for (int i = 1; i <= table_hdu.numCols(); ++i) {
     // The i-1 is because CCfits starts from 1 and ColumnInfo from 0
     // We use a clone of the column because CCfits will cache in memory the read data, so multiple calls
@@ -139,11 +138,6 @@ Table FitsReader::readImpl(long rows) {
     // the FitsReader is destroyed (~FitsReader() => ~Table() => ~Column())
     // For scalars this is not a big deal, but when the column has an array (i.e. a bunch of PDZs), the
     // pile up can be significant after a while.
-    // CCfits will call makeThisCurrent *for each column*
-    // This can be very inefficient, since each call will trigger the parsing of the HDU headers (!!)
-    // Each convertColumn *can* assume makeThisCurrent() has been called here and
-    // *should* do a cast to CCfits::ColumnData to avoid this overhead. This is what CCfits::Column does anyway
-    // when reading ¯\_(ツ)_/¯
     std::unique_ptr<CCfits::Column> column(table_hdu.column(i).clone());
     data.emplace_back(
         translateColumn(*column, m_column_info->getDescription(i - 1).type, m_current_row, m_current_row + rows - 1));

--- a/Table/src/lib/FitsReaderHelper.cpp
+++ b/Table/src/lib/FitsReaderHelper.cpp
@@ -164,117 +164,38 @@ std::vector<std::string> autoDetectColumnDescriptions(const CCfits::Table& table
 }
 
 template <typename T>
-T dynamicCastWrapper(CCfits::Column* column) {
-  auto column_data = dynamic_cast<T>(column);
-  if (column_data == nullptr) {
-    throw Elements::Exception() << "Could not convert the CCfits::Column into " << typeid(T).name();
-  }
-  return column_data;
-}
-
-template <typename T>
 std::vector<Row::cell_type> convertScalarColumn(CCfits::Column& column, long first, long last) {
+  std::vector<T> data;
+  column.read(data, first, last);
   std::vector<Row::cell_type> result;
-  auto                        column_data = dynamicCastWrapper<CCfits::ColumnData<T>*>(&column);
-
-  column_data->readData(first, last - first + 1);
-
-  const auto& data = column_data->data();
-  result.reserve(data.size());
-  std::copy(data.begin(), data.end(), std::back_inserter(result));
-  return result;
-}
-
-// The handling of 32 and 64 bits integer is complicated by the fact
-// that the specification says J is 32 and K is 64, but cfitsio maps them to "long" and "long long" instead
-// This template allows fall-back between long => int32_t and long long => int64_t
-template <typename T, typename FallbackT>
-std::vector<Row::cell_type> convertScalarColumnFallback(CCfits::Column& column, long first, long last) {
-  std::vector<Row::cell_type> result;
-  auto                        column_data = dynamic_cast<CCfits::ColumnData<T>*>(&column);
-  if (column_data != nullptr) {
-    column_data->readData(first, last - first + 1);
-    const auto& data = column_data->data();
-    result.reserve(data.size());
-    std::copy(data.begin(), data.end(), std::back_inserter(result));
-  } else {
-    auto fallback_column_data = dynamicCastWrapper<CCfits::ColumnData<FallbackT>*>(&column);
-    fallback_column_data->readData(first, last - first + 1);
-    const auto& data = fallback_column_data->data();
-    result.reserve(data.size());
-    std::transform(data.begin(), data.end(), std::back_inserter(result), [](FallbackT v) { return static_cast<T>(v); });
+  for (auto value : data) {
+    result.push_back(value);
   }
-  return result;
-}
-
-template <>
-std::vector<Row::cell_type> convertScalarColumn<int32_t>(CCfits::Column& column, long first, long last) {
-  return convertScalarColumnFallback<int32_t, long>(column, first, last);
-}
-
-template <>
-std::vector<Row::cell_type> convertScalarColumn<int64_t>(CCfits::Column& column, long first, long last) {
-  return convertScalarColumnFallback<int64_t, long long>(column, first, last);
-}
-
-template <typename T>
-std::vector<std::vector<T>> getVectorData(CCfits::Column& column, long first, long last) {
-  auto column_data = dynamicCastWrapper<CCfits::ColumnVectorData<T>*>(&column);
-  column_data->readData(first, last - first + 1);
-  const auto&                 data = column_data->data();
-  std::vector<std::vector<T>> result(data.size());
-  std::transform(data.begin(), data.end(), result.begin(),
-                 [](const std::valarray<T>& array) { return std::vector<T>(std::begin(array), std::end(array)); });
   return result;
 }
 
 template <typename T>
 std::vector<Row::cell_type> convertVectorColumn(CCfits::Column& column, long first, long last) {
-  auto                        data = getVectorData<T>(column, first, last);
+  std::vector<std::valarray<T>> data;
+  column.readArrays(data, first, last);
   std::vector<Row::cell_type> result;
-  result.reserve(data.size());
-  for (auto& v : data) {
-    result.emplace_back(std::move(v));
+  for (auto& valar : data) {
+    result.push_back(std::vector<T>(std::begin(valar), std::end(valar)));
   }
   return result;
-}
-
-// Specializations for int32_t and int64_t with fallback
-template <typename T, typename FallbackT>
-std::vector<Row::cell_type> convertVectorWithFallback(CCfits::Column& column, long first, long last) {
-  std::vector<Row::cell_type> result;
-  if (dynamic_cast<CCfits::ColumnVectorData<T>*>(&column)) {
-    auto data = getVectorData<T>(column, first, last);
-    result.reserve(data.size());
-    for (auto& v : data) {
-      result.emplace_back(std::move(v));
-    }
-  } else {
-    auto data = getVectorData<FallbackT>(column, first, last);
-    result.reserve(data.size());
-    std::transform(data.begin(), data.end(), std::back_inserter(result),
-                   [](const std::vector<FallbackT>& v) { return std::vector<T>(v.begin(), v.end()); });
-  }
-  return result;
-}
-
-template <>
-std::vector<Row::cell_type> convertVectorColumn<int32_t>(CCfits::Column& column, long first, long last) {
-  return convertVectorWithFallback<int32_t, long>(column, first, last);
-}
-
-template <>
-std::vector<Row::cell_type> convertVectorColumn<int64_t>(CCfits::Column& column, long first, long last) {
-  return convertVectorWithFallback<int64_t, long long>(column, first, last);
 }
 
 template <typename T>
 std::vector<Row::cell_type> convertNdArrayColumn(CCfits::Column& column, long first, long last) {
+  std::vector<std::valarray<T>> data;
+  column.readArrays(data, first, last);
   std::vector<size_t> shape = parseTDIM(column.dimen());
-  auto                data  = convertVectorColumn<T>(column, first, last);
-  std::transform(std::make_move_iterator(data.begin()), std::make_move_iterator(data.end()), data.begin(),
-                 [shape](Row::cell_type&& v) { return NdArray<T>(shape, std::move(boost::get<std::vector<T>>(v))); });
-  return data;
+
+  std::vector<Row::cell_type> result;
+  for (auto& valar : data) {
+    result.push_back(NdArray<T>(shape, std::move(std::vector<T>(std::begin(valar), std::end(valar)))));
+  }
+  return result;
 }
 
 std::vector<Row::cell_type> translateColumn(CCfits::Column& column, std::type_index type) {


### PR DESCRIPTION
This reverts commit 68e21d127393c34738e717b482c59650f73d6492.

I tried to be too clever to my own good. It turns out that even when we ask for N elements, CCfits allocates an array as big as the input catalog and leaves everything with a default value except for the N we asked for, and gives back that array. So you need to take into account you are getting an array bigger than what you asked for and with only some entries filled in.

Too tricky. Going back to the old behavior but what at least works.