### PR TITLE
Override max_size if the npy file exists

### DIFF
--- a/NdArray/NdArray/io/NpyMmap.h
+++ b/NdArray/NdArray/io/NpyMmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -44,6 +44,8 @@ namespace NdArray {
  *  The underlying numpy format is expected to match the template type T
  * @note
  *  If you open in read-only mode, assign to a const NdArray to avoid accidental writes
+ * @note
+ *  max_size will be overridden by the actual file size if it is greater
  */
 template <typename T>
 NdArray<T> mmapNpy(const boost::filesystem::path&              path,

--- a/NdArray/NdArray/io/_impl/NpyMmap.icpp
+++ b/NdArray/NdArray/io/_impl/NpyMmap.icpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -39,10 +39,8 @@ NdArray<T> mmapNpy(const boost::filesystem::path& path, boost::iostreams::mapped
   boost::iostreams::mapped_file_params map_params;
   map_params.path  = path.native();
   map_params.flags = mode;
-  if (max_size)
-    map_params.length = max_size;
-  else
-    max_size = boost::filesystem::file_size(path);
+  max_size = std::max(max_size, boost::filesystem::file_size(path));
+  map_params.length = max_size;
 
   boost::iostreams::mapped_file input(map_params);
   MappedStream                  stream(input.operator boost::iostreams::mapped_file_source&());


### PR DESCRIPTION
Otherwise we can get in trouble if `mmap`ing a file already created that is bigger than the limit.