### PR TITLE
Use boost 1.69 when building on centos7

### DIFF
--- a/.github/workflows/dependencies.txt
+++ b/.github/workflows/dependencies.txt
@@ -4,8 +4,8 @@ $PYTHON-numpy
 $PYTHON-pytest
 $PYTHON-sphinx
 CCfits-devel
-boost-$PYTHON-devel
-boost-devel
+$BOOST-$PYTHON-devel
+$BOOST-devel
 doxygen
 graphviz
 log4cpp-devel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,19 +38,19 @@ jobs:
     container: ${{ matrix.os-type }}:${{ matrix.os-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
       - name: Get package name and version
         id: package-version
-        uses: astrorama/actions/elements-project@master
+        uses: astrorama/actions/elements-project@v3.1
       - name: Install dependencies
-        uses: astrorama/actions/setup-dependencies@master
+        uses: astrorama/actions/setup-dependencies@v3.1
         with:
           dependency-list: .github/workflows/dependencies.txt
       - name: Build
         id: build
-        uses: astrorama/actions/elements-build-rpm@master
+        uses: astrorama/actions/elements-build-rpm@v3.1
       - name: Upload RPM to repository
-        uses: astrorama/actions/upload-rpm@master
+        uses: astrorama/actions/upload-rpm@v3.1
         if: ${{ github.repository_owner == 'astrorama' }}
         env:
           REPOSITORY_USER: ${{ secrets.REPOSITORY_USER }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,19 +38,19 @@ jobs:
     container: ${{ matrix.os-type }}:${{ matrix.os-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@master
       - name: Get package name and version
         id: package-version
-        uses: astrorama/actions/elements-project@v3
+        uses: astrorama/actions/elements-project@master
       - name: Install dependencies
-        uses: astrorama/actions/setup-dependencies@v3
+        uses: astrorama/actions/setup-dependencies@master
         with:
           dependency-list: .github/workflows/dependencies.txt
       - name: Build
         id: build
-        uses: astrorama/actions/elements-build-rpm@v3
+        uses: astrorama/actions/elements-build-rpm@master
       - name: Upload RPM to repository
-        uses: astrorama/actions/upload-rpm@v3
+        uses: astrorama/actions/upload-rpm@master
         if: ${{ github.repository_owner == 'astrorama' }}
         env:
           REPOSITORY_USER: ${{ secrets.REPOSITORY_USER }}

--- a/NdArray/NdArray/NdArray.h
+++ b/NdArray/NdArray/NdArray.h
@@ -541,7 +541,7 @@ private:
 
     ContainerWrapper(const ContainerWrapper&) = delete;
 
-    ContainerWrapper(ContainerWrapper&&) noexcept = default;
+    ContainerWrapper(ContainerWrapper&&) = default;
 
     template <typename... Args>
     explicit ContainerWrapper(Args&&... args) : m_container(std::forward<Args>(args)...) {
@@ -552,12 +552,12 @@ private:
       return m_container.size();
     }
 
-    template<typename T2>
+    template <typename T2>
     auto nbytesImpl(int) const -> decltype(std::declval<Container<T2>>().nbytes()) {
       return m_container.nbytes();
     }
 
-    template<typename T2>
+    template <typename T2>
     size_t nbytesImpl(...) const {
       return m_container.size() * sizeof(T2);
     }

--- a/NdArray/tests/src/Npy_test.cpp
+++ b/NdArray/tests/src/Npy_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -99,7 +99,7 @@ print(a.sum())
   auto                  output = runPython(PYCODE, file.path());
 
   T sum;
-  output >> sum;
+  (*output) >> sum;
   BOOST_CHECK_EQUAL(std::accumulate(ndarray.begin(), ndarray.end(), static_cast<T>(0)), sum);
 }
 
@@ -130,7 +130,7 @@ print((a[:,0] * a[:,1]).sum())
   }
 
   T weighted_sum;
-  output >> weighted_sum;
+  (*output) >> weighted_sum;
   BOOST_CHECK_EQUAL(expected, weighted_sum);
 }
 

--- a/NdArray/tests/src/TestHelper.h
+++ b/NdArray/tests/src/TestHelper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -28,7 +28,7 @@
 /**
  * Run embedded Python code
  */
-static std::stringstream runPython(const char* code, const boost::filesystem::path& npy) {
+static std::unique_ptr<std::stringstream> runPython(const char* code, const boost::filesystem::path& npy) {
   namespace bp = boost::process;
   Elements::TempFile code_file("npy_%%%%.py");
   std::ofstream      out(code_file.path().native());
@@ -44,8 +44,8 @@ static std::stringstream runPython(const char* code, const boost::filesystem::pa
   int          r = bp::system(python_exec, code_file.path().native(), npy.native(), bp::std_out > py_output);
   BOOST_CHECK_EQUAL(r, 0);
 
-  std::stringstream stream;
-  stream << py_output.rdbuf();
+  auto stream = Euclid::make_unique<std::stringstream>();
+  (*stream) << py_output.rdbuf();
   return stream;
 }
 

--- a/Pyston/CMakeLists.txt
+++ b/Pyston/CMakeLists.txt
@@ -24,10 +24,6 @@ elements_depends_on_subdirs(ElementsKernel)
 find_package(PythonInterp ${PYTHON_EXPLICIT_VERSION} REQUIRED)
 find_package(PythonLibs ${PYTHON_EXPLICIT_VERSION} REQUIRED)
 find_package(BoostPython ${PYTHON_EXPLICIT_VERSION})
-find_package(Boost 1.53 REQUIRED COMPONENTS filesystem timer)
-find_package(PythonInterp ${PYTHON_EXPLICIT_VERSION} REQUIRED)
-find_package(PythonLibs ${PYTHON_EXPLICIT_VERSION} REQUIRED)
-find_package(BoostPython ${PYTHON_EXPLICIT_VERSION})
 
 #===============================================================================
 # Declare the library dependencies here
@@ -39,11 +35,11 @@ find_package(BoostPython ${PYTHON_EXPLICIT_VERSION})
 #===============================================================================
 elements_add_library(Pyston src/lib/*.cpp
         INCLUDE_DIRS
-          Boost BoostPython
+          BoostPython
           PythonLibs PythonInterp
           ElementsKernel SEImplementation
         LINK_LIBRARIES
-          Boost BoostPython
+          BoostPython
           PythonLibs PythonInterp
           ElementsKernel
         PUBLIC_HEADERS Pyston)

--- a/cmake/modules/FindBoostPython.cmake
+++ b/cmake/modules/FindBoostPython.cmake
@@ -14,16 +14,16 @@ if (NOT BoostPython_FOUND)
     find_package(PythonInterp ${PYTHON_EXPLICIT_VERSION} REQUIRED)
 
     # Explicit versions
-    set (_BOOST_PYTHON_LIST "python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}" "python${PYTHON_VERSION_MAJOR}")
+    set (_BOOST_PYTHON_LIST "${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}" "${PYTHON_VERSION_MAJOR}")
 
     # Only for python2, without suffix
     if (BoostPython_FIND_VERSION VERSION_LESS 3)
-        list (APPEND _BOOST_PYTHON_LIST "python")
+        list (APPEND _BOOST_PYTHON_LIST "")
     endif ()
 
     # Pick the most restrictive
     foreach (_BOOST_PYTHON IN LISTS _BOOST_PYTHON_LIST)
-        find_package(Boost COMPONENTS "${_BOOST_PYTHON}")
+        find_package(Boost 1.63 REQUIRED COMPONENTS "python${_BOOST_PYTHON}" "numpy${_BOOST_PYTHON}")
         if (Boost_FOUND)
             set (BoostPython_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
             set (BoostPython_LIBRARIES ${Boost_LIBRARIES})


### PR DESCRIPTION
The system version is 1.53, which is more than 9 years old and has nice things missing (i.e. the endian library, and boost::python::numpy)