### PR TITLE
Set of small changes required by sourcextractor python wrapper

### DIFF
--- a/Configuration/Configuration/ConfigManager.h
+++ b/Configuration/Configuration/ConfigManager.h
@@ -1,16 +1,19 @@
 /*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
- * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General
- * Public License as published by the Free Software Foundation; either version 3.0 of the License, or (at your option)
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
  * any later version.
  *
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  *
- * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to
- * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 /**
@@ -84,6 +87,21 @@ class ConfigManager {
 public:
   /// Returns a reference to the ConfigManager with the given ID
   static ConfigManager& getInstance(long id);
+
+  /**
+   * Destroy a ConfigManager instance
+   * @warning This is a dangerous thing to do, since something somewhere may be holding a reference
+   *          to the given instance. However, since the ConfigManager instances are kept on a static
+   *          map, it is *undefined* when they will be destroyed at the end of the process.
+   *          In those situations, it may be necessary to destroy them by hand before some other global
+   *          dependency is torn down (I am looking at sourcextractor++ and the Python interpreter, which is
+   *          required by the ModelFittingConfig)
+   */
+  static void deregisterInstance(long id);
+
+  long getId() const {
+    return m_id;
+  }
 
   /**
    * @brief Destructor

--- a/Configuration/src/lib/ConfigManager.cpp
+++ b/Configuration/src/lib/ConfigManager.cpp
@@ -32,15 +32,19 @@ namespace po = boost::program_options;
 namespace Euclid {
 namespace Configuration {
 
-static Elements::Logging logger = Elements::Logging::getLogger("ConfigManager");
+static Elements::Logging                              logger = Elements::Logging::getLogger("ConfigManager");
+static std::map<long, std::unique_ptr<ConfigManager>> manager_map{};
 
 ConfigManager& ConfigManager::getInstance(long id) {
-  static std::map<long, std::unique_ptr<ConfigManager>> manager_map{};
-  auto&                                                 manager_ptr = manager_map[id];
+  auto& manager_ptr = manager_map[id];
   if (manager_ptr == nullptr) {
     manager_ptr.reset(new ConfigManager{id});
   }
   return *manager_ptr;
+}
+
+void ConfigManager::deregisterInstance(long id) {
+  manager_map.erase(id);
 }
 
 ConfigManager::ConfigManager(long id) : m_id{id} {}

--- a/NdArray/NdArray/Borrowed.h
+++ b/NdArray/NdArray/Borrowed.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 Euclid Science Ground Segment
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef ALEXANDRIA_BORROWED_H
+#define ALEXANDRIA_BORROWED_H
+
+#include <new>
+
+namespace Euclid {
+namespace NdArray {
+
+template <typename T>
+struct BorrowedRange {
+  T* const          m_begin;
+  std::size_t const m_size;
+
+  T* data() const {
+    return m_begin;
+  }
+
+  std::size_t size() const {
+    return m_size;
+  }
+
+  void resize(std::size_t) const {
+    throw std::bad_alloc();
+  }
+};
+
+}  // namespace NdArray
+}  // namespace Euclid
+
+#endif  // ALEXANDRIA_BORROWED_H

--- a/NdArray/NdArray/NdArray.h
+++ b/NdArray/NdArray/NdArray.h
@@ -51,7 +51,7 @@ private:
   struct ContainerWrapper;
 
 public:
-  typedef NdArray<T> self_type;
+  using self_type = NdArray<T>;
 
   /**
    * Iterator type
@@ -63,7 +63,9 @@ public:
       : public std::iterator<std::random_access_iterator_tag, typename std::conditional<Const, const T, T>::type> {
   private:
     ContainerInterface* m_container_ptr;
-    size_t              m_offset, m_row_size, m_stride;
+    size_t              m_offset;
+    size_t              m_row_size;
+    size_t              m_stride;
     size_t              m_i;
 
     Iterator(ContainerInterface* container_ptr, size_t offset, const std::vector<size_t>& shape,
@@ -180,8 +182,8 @@ public:
     bool operator>(const Iterator& other);
   };
 
-  typedef Iterator<true>  const_iterator;
-  typedef Iterator<false> iterator;
+  using const_iterator = Iterator<true>;
+  using iterator       = Iterator<false>;
 
   /**
    * Destructor.
@@ -601,8 +603,11 @@ private:
   // plus a marker for the valid type, plus any alignment requirement.
   // This indirection makes NdArray only 8 bytes in size!
   struct Details {
-    size_t                              m_offset, m_size, m_total_stride;
-    std::vector<size_t>                 m_shape, m_stride_size;
+    size_t                              m_offset;
+    size_t                              m_size;
+    size_t                              m_total_stride;
+    std::vector<size_t>                 m_shape;
+    std::vector<size_t>                 m_stride_size;
     std::vector<std::string>            m_attr_names;
     std::shared_ptr<ContainerInterface> m_container;
   };

--- a/NdArray/tests/src/NdArray_test.cpp
+++ b/NdArray/tests/src/NdArray_test.cpp
@@ -22,6 +22,7 @@
  * @author Alejandro Alvarez Ayllon
  */
 
+#include "NdArray/Borrowed.h"
 #include "NdArray/NdArray.h"
 #include <boost/test/unit_test.hpp>
 #include <sstream>
@@ -499,6 +500,15 @@ BOOST_AUTO_TEST_CASE(FillWithIteratorNamed_test) {
     BOOST_CHECK_EQUAL(named.at(i, "SED"), -1);
     BOOST_CHECK_EQUAL(named.at(i, "PDZ"), -1);
   }
+}
+
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(Borrowed_test) {
+  std::vector<int> v{1, 2, 3, 4};
+  NdArray<int>     not_owning({2, 2}, BorrowedRange<int>{v.data(), v.size()});
+  BOOST_CHECK_EQUAL(not_owning.size(), v.size());
+  BOOST_CHECK_EQUAL(&(*not_owning.begin()), v.data());
 }
 
 //-----------------------------------------------------------------------------

--- a/Pyston/Pyston/GIL.h
+++ b/Pyston/Pyston/GIL.h
@@ -1,5 +1,5 @@
-/**
- * @copyright (C) 2012-2020 Euclid Science Ground Segment
+/*
+ * Copyright (C) 2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -52,6 +52,16 @@ public:
 
 protected:
   PyGILState_STATE& m_state;
+};
+
+class SaveThread {
+public:
+  SaveThread();
+
+  ~SaveThread();
+
+protected:
+  PyThreadState* m_state;
 };
 
 }  // end of namespace Pyston

--- a/Pyston/src/lib/GIL.cpp
+++ b/Pyston/src/lib/GIL.cpp
@@ -52,4 +52,12 @@ GILReleaser::~GILReleaser() {
   ++s_lock_count;
 }
 
+SaveThread::SaveThread() {
+  m_state = PyEval_SaveThread();
+}
+
+SaveThread::~SaveThread() {
+  PyEval_RestoreThread(m_state);
+}
+
 }  // end of namespace Pyston

--- a/Pyston/src/lib/GIL.cpp
+++ b/Pyston/src/lib/GIL.cpp
@@ -1,5 +1,5 @@
-/**
- * @copyright (C) 2012-2020 Euclid Science Ground Segment
+/*
+ * Copyright (C) 2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -23,12 +23,16 @@ namespace Pyston {
 static size_t s_lock_count = 0;
 
 GILLocker::GILLocker() {
-  m_state = PyGILState_Ensure();
-  ++s_lock_count;
+  if (Py_IsInitialized()) {
+    m_state = PyGILState_Ensure();
+    ++s_lock_count;
+  }
 }
 
 GILLocker::~GILLocker() {
-  PyGILState_Release(m_state);
+  if (Py_IsInitialized()) {
+    PyGILState_Release(m_state);
+  }
 }
 
 size_t GILLocker::getLockCount() {


### PR DESCRIPTION
* 87f1cdc7971612fd8c3979ada42188bde774ca5d When the interpreter shuts down, it will destruct its internal state before the globals used by the configuration / sourcextractor are destroyed. These globals *will* call some Python stuff, crashing.
* 8245da0a882cfab4bd6db80121ac7e035570dd3e Ugly hack to allow destroying configuration instances without having to wait for the termination of the program. Not ideal, but the only alternative I can think of that doesn't involve a considerable refactoring of Phosphoros & SourceXtractor
* 901db39db4f54bb92cefd6371803527f93cf7cfe This is needed so sourcextractor can release the GIL when doing its thing, so if there is multithreading in Python things can keep going
* 338e5c6217917494f2766997469e847e3970c1b4 Create easily `NdArray`s that do not own the memory (avoid copying stamps)
