### PR TITLE
Add the Python exception type to the error message

### DIFF
--- a/Pyston/src/lib/Exceptions.cpp
+++ b/Pyston/src/lib/Exceptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/Pyston/src/lib/Exceptions.cpp
+++ b/Pyston/src/lib/Exceptions.cpp
@@ -1,5 +1,5 @@
-/**
- * @copyright (C) 2012-2020 Euclid Science Ground Segment
+/*
+ * Copyright (C) 2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -38,13 +38,15 @@ Exception::Exception() {
   py::handle<> handle_value(pvalue);
   py::handle<> handle_traceback(py::allow_null(ptraceback));
 
-  // Get only the error message
+  // Get the error message and exception type
   py::object err_msg_obj(py::handle<>(PyObject_Str(pvalue)));
   m_error_msg = py::extract<std::string>(err_msg_obj);
   if (m_error_msg.empty()) {
     py::object err_repr_obj(py::handle<>(PyObject_Repr(pvalue)));
     m_error_msg = py::extract<std::string>(err_repr_obj);
   }
+  py::object err_msg_type(py::handle<>(PyObject_GetAttrString(ptype, "__name__")));
+  m_error_msg = std::string(py::extract<std::string>(err_msg_type)) + ": " + m_error_msg;
 
   // Generate traceback
   if (ptraceback) {

--- a/Pyston/tests/src/ExpressionTreeBuilder_test.cpp
+++ b/Pyston/tests/src/ExpressionTreeBuilder_test.cpp
@@ -1,5 +1,5 @@
-/**
- * @copyright (C) 2012-2020 Euclid Science Ground Segment
+/*
+ * Copyright (C) 2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -101,7 +101,7 @@ def raises_exception(x, y, z):
     transparent(1, 2, 0.4);
     BOOST_FAIL("Call should have raised an exception");
   } catch (const Exception& ex) {
-    BOOST_CHECK_EQUAL(std::string(ex.what()), "Invalid Z value");
+    BOOST_CHECK_EQUAL(std::string(ex.what()), "ValueError: Invalid Z value");
     BOOST_CHECK_GT(ex.getTraceback().size(), 0);
     bool func_in_trace = false;
     for (auto& trace : ex.getTraceback()) {

--- a/Pyston/tests/src/ExpressionTreeBuilder_test.cpp
+++ b/Pyston/tests/src/ExpressionTreeBuilder_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Euclid Science Ground Segment
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free


### PR DESCRIPTION
i.e., `"Invalid Z value"` => `"ValueError: Invalid Z value"`
