### PR TITLE
Add front() method to NdArray

### DIFF
--- a/NdArray/NdArray/NdArray.h
+++ b/NdArray/NdArray/NdArray.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
@@ -362,6 +362,11 @@ public:
    */
   template <typename... D>
   self_type& reshape(size_t i, D... rest);
+
+  /**
+   * @return A reference to the front element
+   */
+  const T& front() const;
 
   /**
    * Gets a reference to the value stored at the given coordinates.

--- a/NdArray/NdArray/_impl/NdArray.icpp
+++ b/NdArray/NdArray/_impl/NdArray.icpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
@@ -265,6 +265,11 @@ template <typename... D>
 auto NdArray<T>::reshape(size_t i, D... rest) -> self_type& {
   std::vector<size_t> acc{i};
   return reshape_helper(acc, rest...);
+}
+
+template <typename T>
+const T& NdArray<T>::front() const {
+  return m_details_ptr->m_container->get(m_details_ptr->m_offset);
 }
 
 template <typename T>

--- a/NdArray/tests/src/NdArray_test.cpp
+++ b/NdArray/tests/src/NdArray_test.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
@@ -44,6 +44,7 @@ BOOST_AUTO_TEST_CASE(OneDimension_test) {
   BOOST_CHECK_EQUAL(m.shape().size(), 1);
   BOOST_CHECK_EQUAL(m.shape()[0], 5);
   BOOST_CHECK_EQUAL(m.at(0), 10);
+  BOOST_CHECK_EQUAL(m.front(), 10);
 }
 
 //-----------------------------------------------------------------------------
@@ -61,6 +62,7 @@ BOOST_AUTO_TEST_CASE(TwoDimension_test) {
   BOOST_CHECK_EQUAL((m.at(0, 0)), 10);
   BOOST_CHECK_EQUAL((m.at(std::vector<size_t>{0, 0})), 10);
   BOOST_CHECK_EQUAL((m.at(1, 1)), 20);
+  BOOST_CHECK_EQUAL(m.front(), 10);
 
   const NdArray<int>& cm = m;
   BOOST_CHECK_EQUAL((cm.at(1, 1)), 20);
@@ -304,6 +306,7 @@ BOOST_AUTO_TEST_CASE(Slice_test) {
   BOOST_CHECK_EQUAL(first.at(0, 0), 1);
   BOOST_CHECK_EQUAL(first.at(1, 0), 2);
   BOOST_CHECK_EQUAL(first.at(2, 1), 3);
+  BOOST_CHECK_EQUAL(first.front(), 1);
 
   std::vector<int> expected_first{1, 1, 1, 2, 2, 2, 3, 3, 3};
   BOOST_CHECK_EQUAL_COLLECTIONS(first.begin(), first.end(), expected_first.begin(), expected_first.end());
@@ -319,6 +322,7 @@ BOOST_AUTO_TEST_CASE(Slice_test) {
   BOOST_CHECK_EQUAL(second.at(1, 0), 22);
   BOOST_CHECK_EQUAL(second.at({2, 1}), 33);
   BOOST_CHECK_EQUAL(second.at(2, 1), 33);
+  BOOST_CHECK_EQUAL(second.front(), 11);
 
   std::vector<int> expected_second{11, 11, 11, 22, 22, 22, 33, 33, 33};
   BOOST_CHECK_EQUAL_COLLECTIONS(second.begin(), second.end(), expected_second.begin(), expected_second.end());
@@ -333,10 +337,12 @@ BOOST_AUTO_TEST_CASE(NextSlice_test) {
   auto             first = m.slice(0);
   std::vector<int> expected_first{1, 1, 1, 2, 2, 2, 3, 3, 3};
   BOOST_CHECK_EQUAL_COLLECTIONS(first.begin(), first.end(), expected_first.begin(), expected_first.end());
+  BOOST_CHECK_EQUAL(first.front(), 1);
 
   first.next_slice();
   std::vector<int> expected_second{11, 11, 11, 22, 22, 22, 33, 33, 33};
   BOOST_CHECK_EQUAL_COLLECTIONS(first.begin(), first.end(), expected_second.begin(), expected_second.end());
+  BOOST_CHECK_EQUAL(first.front(), 11);
 }
 
 //-----------------------------------------------------------------------------
@@ -355,6 +361,7 @@ BOOST_AUTO_TEST_CASE(SliceTwice_test) {
   BOOST_CHECK_EQUAL(second.at(0), 3);
   BOOST_CHECK_EQUAL(second.at(1), 3);
   BOOST_CHECK_EQUAL(second.at(2), 3);
+  BOOST_CHECK_EQUAL(second.front(), 3);
 
   std::vector<int> expected_second{3, 3, 3};
   BOOST_CHECK_EQUAL_COLLECTIONS(second.begin(), second.end(), expected_second.begin(), expected_second.end());
@@ -395,6 +402,7 @@ BOOST_AUTO_TEST_CASE(RSlice_test) {
   BOOST_CHECK_EQUAL(first.at(1, 1), 22);
   BOOST_CHECK_EQUAL(first.at(0, 2), 3);
   BOOST_CHECK_EQUAL(first.at(1, 2), 33);
+  BOOST_CHECK_EQUAL(first.front(), 1);
 
   std::vector<int> expected_first{1, 2, 3, 11, 22, 33};
   BOOST_CHECK_EQUAL_COLLECTIONS(first.begin(), first.end(), expected_first.begin(), expected_first.end());
@@ -429,6 +437,7 @@ BOOST_AUTO_TEST_CASE(RSliceTwice_test) {
 
   BOOST_CHECK_EQUAL(second.at(0), 3);
   BOOST_CHECK_EQUAL(second.at(1), 33);
+  BOOST_CHECK_EQUAL(second.front(), 3);
 
   std::vector<int> expected_second{3, 33};
   BOOST_CHECK_EQUAL_COLLECTIONS(second.begin(), second.end(), expected_second.begin(), expected_second.end());

--- a/NdArray/tests/src/NpyMmap_test.cpp
+++ b/NdArray/tests/src/NpyMmap_test.cpp
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2012-2021 Euclid Science Ground Segment
+/**
+ * Copyright (C) 2012-2022 Euclid Science Ground Segment
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -68,6 +68,7 @@ BOOST_FIXTURE_TEST_CASE(MmapOpen_test, RandomGeneratorFixture) {
   auto read = readNpy<int32_t>(file.path());
   BOOST_CHECK_EQUAL(read.at(0, 1, 2), 1024 + 42);
   BOOST_CHECK_EQUAL(read.at(42, 5, 33), 1024 + 108);
+  BOOST_CHECK_EQUAL(read.front(), ndarray.front());
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
It is quite silly, but using in nnpz

```c++
&reference.front()
```

instead of

```c++
&reference.at(0, 0)
```

Is almost 2x faster. Maybe there is a better way for making `at` better for these cases?