### PR TITLE
Pyston: Clear error indicator before each test

### DIFF
--- a/Pyston/tests/src/PythonFixture.h
+++ b/Pyston/tests/src/PythonFixture.h
@@ -58,6 +58,7 @@ struct PythonFixture {
   PythonFixture() {
     static Singleton singleton;
     gil_state                = PyGILState_Ensure();
+    PyErr_Clear();
     auto main_module         = boost::python::import("__main__");
     main_namespace           = main_module.attr("__dict__");
     main_namespace["pyston"] = boost::python::import("pyston");


### PR DESCRIPTION
Fedora 41 will move to [Python 3.13](https://fedoraproject.org/wiki/Changes/Python3.13). With this version, the error status is not cleared when importing a module. It has to be manually cleared before each test. Otherwise, a test that triggers a Python exception on purpose will cause the following test to fail again with the same error.

See [Bugzilla #2259553](https://bugzilla.redhat.com/show_bug.cgi?id=2259553).