### PR TITLE
fix dependencies for fedora 42

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         id: package-version
         uses: astrorama/actions/elements-project@v3.4
       - name: Install dependencies
-        uses: astrorama/actions/setup-dependencies@v3.4
+        uses: astrorama/actions/setup-dependencies@v3.7
         with:
           dependency-list: .github/workflows/dependencies.txt
       - name: Build


### PR DESCRIPTION
Update setup-dependencies action to 3.7 to compile for fedora 42