### PR TITLE
Update Elements to 6.3.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,4 +12,4 @@ set(CXX_SUGGEST_OVERRIDE ON
     FORCE)
 
 # Declare project name and version
-elements_project(Alexandria 2.31.4 USE Elements 6.3.3 DESCRIPTION "SDC-CH common library for the Euclid project")
+elements_project(Alexandria 2.31.4 USE Elements 6.3.4 DESCRIPTION "SDC-CH common library for the Euclid project")


### PR DESCRIPTION
Update Elements to 6.3.4 to compile on Fedora 42